### PR TITLE
Fix typo in checkConditionLength

### DIFF
--- a/lib/package/plugins/checkConditionLength.js
+++ b/lib/package/plugins/checkConditionLength.js
@@ -20,7 +20,7 @@ var plugin = {
   ruleId: "CC003",
   name: "Condition Length",
   message:
-    "Overly long conditions on Stesp are difficult to debug and maintain.",
+    "Overly long conditions on Steps are difficult to debug and maintain.",
   fatal: false,
   severity: 1, //warning
   nodeType: "Condition",


### PR DESCRIPTION
Just a simple typo I discovered whilst linting during my pipeline. I kept the casing intact, even though I think it would be more appropriate to either capitalize `Conditions` to match `Steps`, or instead keep `conditions` lowercase and also make `steps` lowercase to match.