### PR TITLE
add support for HTTPTargetConnection

### DIFF
--- a/lib/package/Endpoint.js
+++ b/lib/package/Endpoint.js
@@ -23,6 +23,7 @@ var Flow = require("./Flow.js"),
   debug = require("debug")("bundlelinter:Endpoint"),
   fs = require("fs"),
   HTTPProxyConnection = require("./HTTPProxyConnection.js"),
+  HTTPTargetConnection = require("./HTTPTargetConnection.js"),
   bundleTypes = require('./BundleTypes.js');
 
 function Endpoint(element, parent, fname, bundletype) {
@@ -184,6 +185,18 @@ Endpoint.prototype.getHTTPProxyConnection = function() {
     }
   }
   return this.httpProxyConnection;
+};
+
+Endpoint.prototype.getHTTPTargetConnection = function() {
+  if (!this.httpTargetConnection) {
+    var doc = xpath.select("./HTTPTargetConnection", this.element),
+      ep = this;
+    if (doc) {
+        ep.httpTargetConnection = new HTTPTargetConnection(doc[0], ep);
+      
+    }
+  }
+  return this.httpTargetConnection;
 };
 
 Endpoint.prototype.getFlows = function() {

--- a/lib/package/HTTPTargetConnection.js
+++ b/lib/package/HTTPTargetConnection.js
@@ -1,0 +1,99 @@
+/*
+  Copyright 2019 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+var xpath = require("xpath");
+
+function HTTPTargetConnection(element, parent) {
+  this.parent = parent;
+  this.element = element;
+}
+
+HTTPTargetConnection.prototype.getName = function() {
+  if (!this.name) {
+    var attr = xpath.select("//@name", this.element);
+    this.name = (attr[0] && attr[0].value) || "";
+  }
+  return this.name;
+};
+
+HTTPTargetConnection.prototype.getMessages = function() {
+  return this.parent.getMessages();
+};
+
+HTTPTargetConnection.prototype.getLines = function(start, stop) {
+  return this.parent.getLines(start, stop);
+};
+
+HTTPTargetConnection.prototype.getSource = function() {
+  if (!this.source) {
+    var start = this.element.lineNumber - 1,
+      stop = this.element.nextSibling.lineNumber - 1;
+    this.source = this.getLines(start, stop);
+  }
+  return this.source;
+};
+
+HTTPTargetConnection.prototype.getType = function() {
+  return this.element.tagName;
+};
+
+HTTPTargetConnection.prototype.getURL = function() {
+    if (!this.URL) {
+      var doc = xpath.select("./URL", this.element);
+      if (doc && doc[0]) {
+        this.URL = (doc[0].childNodes[0].nodeValue) || "";
+      }
+    }
+    return this.URL;
+  };
+
+HTTPTargetConnection.prototype.getProperties = function() {
+  var props = [];
+  if (!this.properties) {
+    var propsNodeList = xpath.select("./Properties", this.element)[0].childNodes;
+    Array.from(propsNodeList).forEach(function(prop) {
+        if (prop.childNodes){
+            props[prop.attributes[0].nodeValue]=prop.childNodes[0].nodeValue;
+        }
+    });
+  }
+  return props;
+};
+
+HTTPTargetConnection.prototype.getElement = function() {
+  return this.element;
+};
+
+HTTPTargetConnection.prototype.getParent = function() {
+  return this.parent;
+};
+
+HTTPTargetConnection.prototype.addMessage = function(msg) {
+  if (!msg.hasOwnProperty("entity")) {
+    msg.entity = this;
+  }
+  this.parent.addMessage(msg);
+};
+
+HTTPTargetConnection.prototype.summarize = function() {
+  var summary = {};
+  summary.name = this.getName();
+  summary.basePath = this.getBasePath();
+  return summary;
+};
+
+//Public
+module.exports = HTTPTargetConnection;


### PR DESCRIPTION
Adding support for parsing HTTPTargetConnection. This allows code analysis of the URL and properties within the HTTPTargetConnection configuration. 

An example external plugin to use these new functions:

```
var plugin = {
    ruleId: "CSTM001",
    name: "Check if the HttpTargetConnection timeout is set",
    message: "Timeout property should be set to 3 seconds or less in the HttpTargetConnection.",
    fatal: false,
    severity: 2, //error
    nodeType: "Bundle",
    enabled: true
  };

  var onTargetEndpoint = function(ep, cb) {
    var httpTargetConnection = ep.getHTTPTargetConnection(),
        hadError = false;

    if (httpTargetConnection) {
        var properties = httpTargetConnection.getProperties();
        if (properties["connect.timeout.millis"] > 3000 || properties["connect.timeout.millis"] == null) {
            ep.addMessage({
                plugin,
                message: plugin.message
            });
            hadError = true;
        }
    }
    if (typeof(cb) == 'function') {
        cb(null, hadError);
    }
};

module.exports = {
  plugin,
  onTargetEndpoint
};
```