### PR TITLE
Ignore files like RF-Unauthorized.xml~

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The list of rules is a work in progress and expected to increase over time. As p
 | Linter | Status | Code | Name | Description |
 | ------ | ------ | ---- | ---- | ----------- |
 | Bundle | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
-| &nbsp; |:white_check_mark:| BN001 | Bundle folder structure correctness. | Bundles have a clear structure. |
+| &nbsp; |:white_check_mark:| BN001 | Bundle folder structure correctness. This plugin ignores some files, like .DS\_store and any file ending in ~.  | Bundles have a clear structure. |
 | &nbsp; |:white_check_mark:| BN002 | Extraneous files. | Ensure each folder contains appropriate resources in the bundle. |
 | &nbsp; |:white_check_mark:| BN003 | Cache Coherence | A bundle that includes cache reads should include cache writes with the same keys. |
 | &nbsp; |:white_check_mark:| BN004 | Unused variables. |  Within a bundle variables created should be used in conditions, resource callouts, or policies. |

--- a/lib/package/plugins/checkBundleStructure.js
+++ b/lib/package/plugins/checkBundleStructure.js
@@ -128,7 +128,7 @@ function checkNode(node, curRoot) {
             "."
         );
       }
-    } else if (file !== ".DS_Store") {
+    } else if (file !== ".DS_Store" && !file.endsWith('~')) {
       //does the file extension match those valid for this node
       var extension = file.split(".");
       if (extension.length > 1) {


### PR DESCRIPTION
  - the files ending in twiddle are backup files.

  - also update README stating that ~ files are
    ignored, as well as .DS_store.