### PR TITLE
prefer message item severity to plugin severity

### DIFF
--- a/lib/package/Bundle.js
+++ b/lib/package/Bundle.js
@@ -240,7 +240,7 @@ function Bundle(config, cb) {
   this.xPathName = bundleType.getXPathName(config.source.bundleType);
   this.bundleTypeName = config.source.bundleType;
   this.excluded = config.excluded;
-  
+
   if (config.source.type === "ManagementServer") {
     //shared flow not implemented for management server
     if(config.source.bundleType === bundleTypes.BundleType.SHAREDFLOW){
@@ -331,7 +331,7 @@ Bundle.prototype.addMessage = function(msg) {
   //then process new style
   if (msg.hasOwnProperty("plugin")) {
     msg.ruleId = msg.plugin.ruleId;
-    msg.severity = msg.plugin.severity;
+    if (!msg.severity) msg.severity = msg.plugin.severity;
     msg.nodeType = msg.plugin.nodeType;
     delete msg.plugin;
   }

--- a/lib/package/Endpoint.js
+++ b/lib/package/Endpoint.js
@@ -181,7 +181,7 @@ Endpoint.prototype.getHTTPProxyConnection = function() {
       ep = this;
     if (doc) {
         ep.httpProxyConnection = new HTTPProxyConnection(doc[0], ep);
-      
+
     }
   }
   return this.httpProxyConnection;
@@ -193,7 +193,7 @@ Endpoint.prototype.getHTTPTargetConnection = function() {
       ep = this;
     if (doc) {
         ep.httpTargetConnection = new HTTPTargetConnection(doc[0], ep);
-      
+
     }
   }
   return this.httpTargetConnection;
@@ -447,7 +447,7 @@ Endpoint.prototype.addMessage = function(msg) {
   //Severity should be one of the following: 0 = off, 1 = warning, 2 = error
   if (msg.hasOwnProperty("plugin")) {
     msg.ruleId = msg.plugin.ruleId;
-    msg.severity = msg.plugin.severity;
+    if (!msg.severity) msg.severity = msg.plugin.severity;
     msg.nodeType = msg.plugin.nodeType;
     delete msg.plugin;
   }

--- a/lib/package/Policy.js
+++ b/lib/package/Policy.js
@@ -139,7 +139,7 @@ Policy.prototype.getType = function() {
 Policy.prototype.addMessage = function(msg) {
   if (msg.hasOwnProperty("plugin")) {
     msg.ruleId = msg.plugin.ruleId;
-    msg.severity = msg.plugin.severity;
+    if (!msg.severity) msg.severity = msg.plugin.severity;
     msg.nodeType = msg.plugin.nodeType;
     delete msg.plugin;
   }

--- a/lib/package/Resource.js
+++ b/lib/package/Resource.js
@@ -42,7 +42,7 @@ Resource.prototype.getParent = function() {
 Resource.prototype.addMessage = function(msg) {
   if (msg.hasOwnProperty("plugin")) {
     msg.ruleId = msg.plugin.ruleId;
-    msg.severity = msg.plugin.severity;
+    if (!msg.severity) msg.severity = msg.plugin.severity;
     msg.nodeType = msg.plugin.nodeType;
     delete msg.plugin;
   }


### PR DESCRIPTION
Currently, this change will make a difference only in the esLint plugin, which now allows people to configure severity for each of the various esLint rules. In the future, we can extend the jshint plugin to work the same way. Any future plugins can also benefit from this.
