### PR TITLE
jshint plugin now finds and reads a .jshintrc file

### DIFF
--- a/lib/package/plugins/jsHint.js
+++ b/lib/package/plugins/jsHint.js
@@ -25,34 +25,49 @@ var plugin = {
   },
   debug = require("debug")("bundlelinter:" + plugin.name), hadWarnErr=false;
 
+const jshint = require("jshint"),
+      jsHintCli = require("jshint/src/cli.js");
+
+const getMessageClass = function(s) {
+        if (/E\d{3}/.test(s)) return "error";
+        if (/W\d{3}/.test(s)) return "warning";
+        if (/I\d{3}/.test(s)) return "info";
+        return "message";
+      };
+
 var onResource = function(resource, cb) {
   try {
     var fname = resource.getFileName();
+    debug("onResource(): " + resource.path);
     if (
       fname.endsWith(".jsc") ||
       fname.endsWith(".js") ||
       fname.endsWith(".json")
     ) {
-      var jshint = require("jshint");
+      let jsHintOptions = jsHintCli.getConfig(resource.path);
+      delete jsHintOptions.dirname;
+      if (Object.keys(jsHintOptions).length == 0) {
+        // default apigeelint options
+        debug('applying default options');
+        jsHintOptions = { maxerr: 50};
+      }
+
+      debug('options:' + JSON.stringify(jsHintOptions));
       //must be a jsc js or json resource
       if (
-        !jshint.JSHINT(`/*jshint maxerr: 50 */\n` + resource.getContents())
+        !jshint.JSHINT(resource.getContents(), jsHintOptions)
       ) {
         var errors = jshint.JSHINT.errors;
         //now walk through each error
         errors.forEach(function(error) {
           if (error.code !== "W087") {
-            if (error.id === "(error)") {
-              plugin.severity = 2;
-            } else {
-              plugin.severity = 1;
-            }
             var result = {
               plugin,
+              severity: (/E\d{3}/.test(error.code)) ? 2 : 1,
               source: error.evidence,
               line: error.line,
               column: error.character,
-              message: error.id + ": " + error.reason
+              message: getMessageClass(error.code) + ` ${error.code}: ${error.reason}`
             };
             resource.addMessage(result);
             hadWarnErr=true;


### PR DESCRIPTION
This uses the jshint cli function to find the rc file to apply, searching up the directory hierarchy.  If none is found, then the plugin uses the default options, { maxerr: 50 } .

It also reformats the error message slightly from previously; not all "errors" in the return from JSHINT are actually errors. Some are warnings. The new logic treats them as such.