### PR TITLE
add PO026 to scan AssignVariable

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The list of rules is a work in progress and expected to increase over time. As p
 | &nbsp; |:white_check_mark:| PO023 | Quota Policy Reuse | When the same Quota policy is used more than once you must ensure that the conditions of execution are mutually exclusive or that you intend for a call to count more than once per message processed. |
 | &nbsp; |:white_check_mark:| PO024 | Cache Error Responses | By default the ResponseCache policy will cache non 200 responses. Either create a condition or use policy configuration options to exclude non 200 responses. |
 | &nbsp; |:white_check_mark:| PO025 | EsLint Errors | Runs EsLint on all policy resources. |
+| &nbsp; |:white_check_mark:| PO026 | AssignVariable Usage | With AssignMessage/AssignVariable, check various usage issues. Example: The Name element must be present. The Ref element, if any, should not be surrounded in curlies. And so on. |
 | FaultRules | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| FR001 | No Condition on FaultRule | It's not a best practice to have a FaultRule without an outer condition, which automatically makes the FaultRule true. |
 | Conditional | &nbsp; | &nbsp; | &nbsp; | &nbsp; |

--- a/lib/package/plugins/assignVariableUsage.js
+++ b/lib/package/plugins/assignVariableUsage.js
@@ -1,0 +1,108 @@
+/*
+  Copyright 2019-2020 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+//| &nbsp; |:white_medium_square:| PO026 | AssignVariable Usage | With AssignVariable, check various usage issues. The Name element must be present. The Ref element, if any, should not be surrounded in curlies. |
+
+const plugin = {
+        ruleId: "PO026",
+        name: "AssignVariableUsage",
+        fatal: false,
+        severity: 2, //error
+        nodeType: "AssignMessage",
+        enabled: true
+      },
+      debug = require("debug")("bundlelinter:" + plugin.name),
+      xpath = require("xpath"),
+      util = require('util');
+
+const onPolicy = function(policy, cb) {
+      let flagged = false;
+      const addMessage = (line, column, message) => {
+              policy.addMessage({plugin, message, line, column});
+              flagged = true;
+            };
+      if (policy.getType() === "AssignMessage") {
+        const avNodes = xpath.select("/AssignMessage/AssignVariable", policy.getElement());
+        if (avNodes && avNodes.length>0) {
+          debug(`${policy.fileName} found ${avNodes.length} AssignVariable elements`);
+          avNodes.forEach( (node, ix) => {
+            const addNodeMessage = (message) =>
+                    addMessage(node.lineNumber, node.columnNumber, message);
+
+            const childNodes = xpath.select("*", node);
+            if (childNodes.length == 0) {
+              addNodeMessage("empty AssignVariable. Should have a Name child, and at least one of {Ref, Template, Value}.");
+            }
+            else {
+              let found = { Name:0, Template:0, Value:0, Ref:0 };
+              childNodes.forEach( (child, ix) => {
+                debug(util.format(child));
+                if (found.hasOwnProperty(child.tagName)) {
+                  found[child.tagName]++;
+                }
+                else {
+                  addMessage(child.lineNumber, child.columnNumber, `There is a stray element (${child.tagName})`);
+                }
+              });
+
+              if (found.Name > 1) {
+                addNodeMessage("There is more than one Name element");
+              }
+              else if ( found.Name == 0) {
+                addNodeMessage("There is no Name element");
+              }
+
+              if (found.Ref > 1) {
+                addNodeMessage("There is more than one Ref element");
+              }
+              else if (found.Ref == 1) {
+                let textnode = xpath.select("Ref/text()", node),
+                    refText = textnode[0].data;
+                if (refText && refText.startsWith('{') && refText.endsWith('}')) {
+                  addMessage(textnode[0].lineNumber, textnode[0].columnNumber, "The text of the Ref element must be a variable name, should not be wrapped in curlies.");
+                }
+              }
+
+              if (found.Template > 1) {
+                addNodeMessage("There is more than one Template element");
+              }
+
+              if (found.Value > 1) {
+                addNodeMessage("There is more than one Value element");
+              }
+
+              // TODO: add ResourceURL to this list when the CL for b/155436526 is merged
+              if (found.Value == 0 && found.Template == 0 && found.Ref == 0) {
+                addNodeMessage("You should have at least one of: {Ref, Value, Template}");
+              }
+
+            }
+
+          });
+        }
+        else {
+          debug(`${policy.fileName} found no AssignVariable elements`);
+        }
+      }
+      if (typeof(cb) == 'function') {
+        cb(null, flagged);
+      }
+    };
+
+module.exports = {
+  plugin,
+  onPolicy
+};

--- a/test/fixtures/resources/PO0026-assignVariable/apiproxy/PO0026-assignVariable.xml
+++ b/test/fixtures/resources/PO0026-assignVariable/apiproxy/PO0026-assignVariable.xml
@@ -1,0 +1,10 @@
+<APIProxy revision="1" name="PO0026-assignVariable">
+  <ConfigurationVersion minorVersion="0" majorVersion="4"/>
+  <CreatedAt>1489339923158</CreatedAt>
+  <CreatedBy>dino</CreatedBy>
+  <Description/>
+  <DisplayName>PO0026-assignVariable</DisplayName>
+  <LastModifiedAt>1489340418969</LastModifiedAt>
+  <LastModifiedBy>orgAdmin</LastModifiedBy>
+  <TargetEndpoints/>
+</APIProxy>

--- a/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/AM-AssignVariable-MissingNameElement.xml
+++ b/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/AM-AssignVariable-MissingNameElement.xml
@@ -1,0 +1,8 @@
+<AssignMessage name='AM-AssignVariable-MissingNameElement'>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <AssignVariable>
+    <!-- the Name element is missing -->
+    <Ref>system.id</Ref>
+  </AssignVariable>
+
+</AssignMessage>

--- a/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/AM-AssignVariable-MultipleProblems.xml
+++ b/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/AM-AssignVariable-MultipleProblems.xml
@@ -1,0 +1,44 @@
+<AssignMessage name='AM-AssignVariable-MultipleProblems'>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <AssignVariable>
+    <Ref>system.id</Ref> <!-- missing name element -->
+  </AssignVariable>
+
+  <AssignVariable>
+    <Name>foobar</Name>
+    <!-- No Ref, Value, or Template -->
+  </AssignVariable>
+
+  <AssignVariable>
+    <Name>something</Name>
+    <Ref>{curlies_are_wrong_here}</Ref>
+  </AssignVariable>
+
+  <AssignVariable/>
+
+  <AssignVariable>
+    <Name>dummy</Name>
+    <Value>1234</Value>
+    <StrayElement/>
+  </AssignVariable>
+
+  <AssignVariable>
+    <Name>dummy1</Name>
+    <Name>dummy2</Name>
+    <Value>1234</Value>
+  </AssignVariable>
+
+  <AssignVariable>
+    <Name>dummy3</Name>
+    <Value>123</Value>
+    <Value>1234</Value>
+  </AssignVariable>
+
+  <AssignVariable>
+    <Name>dummy3</Name>
+    <Value>123</Value>
+    <Template>1234</Template>
+    <Template>56789</Template>
+  </AssignVariable>
+
+</AssignMessage>

--- a/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/AM-AssignVariable-RefWithCurlies.xml
+++ b/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/AM-AssignVariable-RefWithCurlies.xml
@@ -1,0 +1,10 @@
+<AssignMessage name='AM-AssignVariable-RefWithCurlies'>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <AssignVariable>
+    <!-- the Ref element should contain a variable name not
+         surrounded by curlies -->
+    <Name>my_variable</Name>
+    <Ref>{system.id}</Ref>
+  </AssignVariable>
+
+</AssignMessage>

--- a/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/AM-AssignVariable-TooManyNameElements.xml
+++ b/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/AM-AssignVariable-TooManyNameElements.xml
@@ -1,0 +1,10 @@
+<AssignMessage name='AM-AssignVariable-TooManyNameElements'>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <AssignVariable>
+    <!-- the Name element is duplicated -->
+    <Name>abba</Name>
+    <Name>dabba</Name>
+    <Ref>system.id</Ref>
+  </AssignVariable>
+
+</AssignMessage>

--- a/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/AM-CleanResponseHeaders.xml
+++ b/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/AM-CleanResponseHeaders.xml
@@ -1,0 +1,6 @@
+<AssignMessage name='AM-CleanResponseHeaders'>
+  <AssignTo createNew='false' transport='http' type='response'/>
+  <Remove>
+    <Headers/>
+  </Remove>
+</AssignMessage>

--- a/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/AM-Response.xml
+++ b/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/AM-Response.xml
@@ -1,0 +1,11 @@
+<AssignMessage name='AM-Response'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <Set>
+    <Payload contentType='application/json'>{
+    "status" : "ok"
+}</Payload>
+    <ReasonPhrase>OK</ReasonPhrase>
+    <StatusCode>200</StatusCode>
+  </Set>
+  <AssignTo>response</AssignTo>
+</AssignMessage>

--- a/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/RF-UnknownRequest.xml
+++ b/test/fixtures/resources/PO0026-assignVariable/apiproxy/policies/RF-UnknownRequest.xml
@@ -1,0 +1,16 @@
+<RaiseFault name='RF-UnknownRequest'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <FaultResponse>
+    <Set>
+      <Payload contentType='application/json'>{
+  "error" : {
+    "code" : 404.01,
+    "message" : "that request was unknown; try a different request."
+  }
+}
+</Payload>
+      <StatusCode>404</StatusCode>
+      <ReasonPhrase>Not Found</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+</RaiseFault>

--- a/test/fixtures/resources/PO0026-assignVariable/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/PO0026-assignVariable/apiproxy/proxies/endpoint1.xml
@@ -1,0 +1,72 @@
+<ProxyEndpoint name="endpoint1">
+  <Description>Proxy Endpoint 1</Description>
+  <HTTPProxyConnection>
+    <BasePath>/PO0026-assignVariable</BasePath>
+    <Properties/>
+    <VirtualHost>secure</VirtualHost>
+  </HTTPProxyConnection>
+
+  <FaultRules/>
+
+  <PreFlow name="PreFlow">
+    <Request>
+      <Step>
+        <Name>AM-AssignVariable-RefWithCurlies</Name>
+      </Step>
+      <Step>
+        <Name>AM-AssignVariable-MissingNameElement</Name>
+      </Step>
+      <Step>
+        <Name>AM-AssignVariable-TooManyNameElements</Name>
+      </Step>
+      <Step>
+        <Name>AM-AssignVariable-MultipleProblems</Name>
+      </Step>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-CleanResponseHeaders</Name>
+      </Step>
+    </Response>
+  </PreFlow>
+  <PostFlow name="PostFlow">
+    <Request>
+    </Request>
+    <Response>
+    </Response>
+  </PostFlow>
+  <PostClientFlow name="PostFlow">
+    <Request>
+    </Request>
+    <Response>
+    </Response>
+  </PostClientFlow>
+
+  <Flows>
+
+    <Flow name="flow1">
+      <Request>
+      </Request>
+      <Response>
+        <Step>
+          <Name>AM-Response</Name>
+        </Step>
+      </Response>
+      <Condition>(proxy.pathsuffix MatchesPath "/t1") and (request.verb = "GET")</Condition>
+    </Flow>
+
+    <Flow name="unknown request">
+      <Request>
+        <Step>
+          <Name>RF-UnknownRequest</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+    </Flow>
+
+  </Flows>
+
+  <RouteRule name="NoRouteRule"/>
+
+</ProxyEndpoint>


### PR DESCRIPTION
For issue #116  

This plugin checks for:
  - exactly one Name element
  - at most one Ref, at most one Template, at most one Value
  - at least one of {Ref, Template, Value}
  - if Ref, then the inner text should not be surrounded in curlies

  Also update README and add a test.