### PR TITLE
Endpoint.getName() now works correctly

### DIFF
--- a/lib/package/Endpoint.js
+++ b/lib/package/Endpoint.js
@@ -43,11 +43,7 @@ function Endpoint(element, parent, fname, bundletype) {
 
 Endpoint.prototype.getName = function() {
   if (!this.name) {
-    var doc = xpath.select("/", this.element);
-    this.name = myUtil.selectAttributeValue(
-      doc[0].documentElement.attributes,
-      "name"
-    );
+    this.name = xpath.select("string(./@name)", this.element);
   }
   return this.name;
 };

--- a/lib/package/plugins/mgmtServerTargetEndpointCheck.js
+++ b/lib/package/plugins/mgmtServerTargetEndpointCheck.js
@@ -39,9 +39,12 @@ var onTargetEndpoint = function(target, cb) {
     warnErr = false;
 
   if (url && url[0] && url[0].data.match(regexp)) {
+    let name = target.getName();
     target.addMessage({
       plugin,
-      message: "TargetEndpoint appears to be connecting to Management Server."
+      line: url[0].lineNumber,
+      column: url[0].columnNumber,
+      message: `TargetEndpoint (${name}) appears to be connecting to Management Server.`
     });
     warnErr = true;
   }

--- a/lib/package/plugins/useTargetServers.js
+++ b/lib/package/plugins/useTargetServers.js
@@ -36,12 +36,12 @@ var onTargetEndpoint = function(target, cb) {
       "/TargetEndpoint/HTTPTargetConnection/URL/text()",
       target.getElement()
     );
-  
+
   if (url && url[0] !== undefined ) {
-    var attr = xpath.select("/TargetEndpoint/@name", target.getElement() );
+    let name = target.getName();
     target.addMessage({
       plugin,
-      message: "TargetEndpoint (" + attr[0].value + ") is using URL (" + url + "), using a Target Server simplifies CI/CD."
+      message: `TargetEndpoint (${name}) is using URL (${url}), using a Target Server simplifies CI/CD.`
     });
     hadWarnErr=true;
   }


### PR DESCRIPTION
This addresses issue #167 

Also, the plugins now use this method rather than performing xpath themselves.