### PR TITLE
debug for all plugins now uses the plugin ruleId

### DIFF
--- a/lib/package/plugins/bundleSizeResourceCount.js
+++ b/lib/package/plugins/bundleSizeResourceCount.js
@@ -28,7 +28,7 @@ var plugin = {
     nodeType: "Bundle",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name);
+  debug = require("debug")("bundlelinter:" + plugin.ruleId);
 
 var onBundle = function(bundle, cb) {
   var limit = 20,

--- a/lib/package/plugins/checkForMultipleStatsCollectorPolicies.js
+++ b/lib/package/plugins/checkForMultipleStatsCollectorPolicies.js
@@ -24,7 +24,7 @@ var plugin = {
     nodeType: "Bundle",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   statsPolicies = [], hadWarnErr=false;
 
 var onBundle = function(bundle, cb) {

--- a/lib/package/plugins/distributedQuotaCheck.js
+++ b/lib/package/plugins/distributedQuotaCheck.js
@@ -26,7 +26,7 @@ var plugin = {
     nodeType: "Quota",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   xpath = require("xpath");
 
 var onPolicy = function(policy, cb) {

--- a/lib/package/plugins/emptyRouteRuleLast.js
+++ b/lib/package/plugins/emptyRouteRuleLast.js
@@ -24,7 +24,7 @@ var plugin = {
     nodeType: "RouteRule",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name);
+  debug = require("debug")("bundlelinter:" + plugin.ruleId);
 
 var onProxyEndpoint = function(ep, cb) {
   var routeRules = ep.getRouteRules() || [],

--- a/lib/package/plugins/emptyRouteRules.js
+++ b/lib/package/plugins/emptyRouteRules.js
@@ -24,7 +24,7 @@ var plugin = {
     nodeType: "RouteRule",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name);
+  debug = require("debug")("bundlelinter:" + plugin.ruleId);
 
 var onProxyEndpoint = function(ep, cb) {
   var warnMessage =

--- a/lib/package/plugins/eslint.js
+++ b/lib/package/plugins/eslint.js
@@ -7,7 +7,7 @@ var plugin = {
     nodeType: "Resource",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name), hadWarnErr=false;
+  debug = require("debug")("bundlelinter:" + plugin.ruleId), hadWarnErr=false;
 
 var onResource = function(resource, cb) {
   try {

--- a/lib/package/plugins/extractFormParamConditionCheck.js
+++ b/lib/package/plugins/extractFormParamConditionCheck.js
@@ -27,7 +27,7 @@ var plugin = {
     nodeType: "ExtractVariables",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   xpath = require("xpath");
 
 var onPolicy = function(policy, cb) {
@@ -47,7 +47,7 @@ var onPolicy = function(policy, cb) {
     );
 
     if (sourceElement.length) {
-      source = sourceElement[0].data;
+      let source = sourceElement[0].data;
 
       condRegExp = !source.match(condRegExp) ? source : condRegExp;
     }

--- a/lib/package/plugins/extractJSONConditionCheck.js
+++ b/lib/package/plugins/extractJSONConditionCheck.js
@@ -27,7 +27,7 @@ var plugin = {
     nodeType: "ExtractVariables",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   xpath = require("xpath");
 
 var onPolicy = function(policy, cb) {
@@ -47,7 +47,7 @@ var onPolicy = function(policy, cb) {
     );
 
     if (sourceElement.length) {
-      source = sourceElement[0].data;
+      let source = sourceElement[0].data;
 
       condRegExp = !source.match(condRegExp) ? source : condRegExp;
     }

--- a/lib/package/plugins/extractXMLConditionCheck.js
+++ b/lib/package/plugins/extractXMLConditionCheck.js
@@ -27,7 +27,7 @@ var plugin = {
     nodeType: "ExtractVariables",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   xpath = require("xpath");
 
 var onPolicy = function(policy,cb) {
@@ -47,7 +47,7 @@ var onPolicy = function(policy,cb) {
     );
 
     if (sourceElement.length) {
-      source = sourceElement[0].data;
+      let source = sourceElement[0].data;
 
       condRegExp = !source.match(condRegExp) ? source : condRegExp;
     }
@@ -59,13 +59,13 @@ var onPolicy = function(policy,cb) {
       //get steps
       //check each step for a condition on body
       steps.forEach(function(step) {
-        var condition = step.getCondition();
+        let condition = step.getCondition();
         if (!condition || !condition.getExpression().match(condRegExp)) {
           missingBodyCheck = true;
 
           //is the parent a flow we might revert the decision if it has an appropriate condition
           if (step.parent && step.parent.getType() === "Flow") {
-            var condition = step.parent.getCondition();
+            condition = step.parent.getCondition();
             if (condition && condition.getExpression().match(condRegExp)) {
               missingBodyCheck = false;
             }

--- a/lib/package/plugins/jsHint.js
+++ b/lib/package/plugins/jsHint.js
@@ -23,7 +23,7 @@ var plugin = {
     nodeType: "Resource",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name), hadWarnErr=false;
+  debug = require("debug")("bundlelinter:" + plugin.ruleId), hadWarnErr=false;
 
 var onResource = function(resource, cb) {
   try {

--- a/lib/package/plugins/mgmtServerTargetEndpointCheck.js
+++ b/lib/package/plugins/mgmtServerTargetEndpointCheck.js
@@ -26,7 +26,7 @@ var plugin = {
     nodeType: "TargetEndpoint",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   xpath = require("xpath"),
   regexp = "(/v1/organizations/|enterprise.apigee.com)";
 

--- a/lib/package/plugins/policyCount.js
+++ b/lib/package/plugins/policyCount.js
@@ -28,7 +28,7 @@ var plugin = {
     nodeType: "Bundle",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name);
+  debug = require("debug")("bundlelinter:" + plugin.ruleId);
 
 var onBundle = function(bundle, cb) {
   var limit = 100,//for testing set to 100 on release

--- a/lib/package/plugins/quotaPolicyReuseCheck.js
+++ b/lib/package/plugins/quotaPolicyReuseCheck.js
@@ -26,7 +26,7 @@ var plugin = {
     nodeType: "Quota",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name);
+  debug = require("debug")("bundlelinter:" + plugin.ruleId);
 
 var onPolicy = function(policy,cb) {
   var hadWarning = false;

--- a/lib/package/plugins/responseCacheErrorResponseCheck.js
+++ b/lib/package/plugins/responseCacheErrorResponseCheck.js
@@ -24,7 +24,7 @@ var plugin = {
     nodeType: "ResponseCache",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   xpath = require("xpath");
 
 var onPolicy = function(policy, cb) {

--- a/lib/package/plugins/serviceCalloutRequestName.js
+++ b/lib/package/plugins/serviceCalloutRequestName.js
@@ -24,7 +24,7 @@ var plugin = {
     nodeType: "Policy",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   myUtil = require("../myUtil.js");
 
 var onPolicy = function(policy, cb) {

--- a/lib/package/plugins/serviceCalloutResponseName.js
+++ b/lib/package/plugins/serviceCalloutResponseName.js
@@ -24,7 +24,7 @@ var plugin = {
     nodeType: "Policy",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   myUtil = require("../myUtil.js");
 
 var onPolicy = function(policy,cb) {

--- a/lib/package/plugins/threatProtectionJSONConditionCheck.js
+++ b/lib/package/plugins/threatProtectionJSONConditionCheck.js
@@ -28,7 +28,7 @@ var plugin = {
     nodeType: "JSONThreatProtection",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   condRegExp =
     "(response.content|response.form|request.content|request.form|message.content|message.form|message.verb|request.verb)";
 

--- a/lib/package/plugins/threatProtectionXMLConditionCheck.js
+++ b/lib/package/plugins/threatProtectionXMLConditionCheck.js
@@ -27,7 +27,7 @@ var plugin = {
     nodeType: "XMLThreatProtection",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   condRegExp =
     "(response.content|response.form|request.content|request.form|message.content|message.form|message.verb|request.verb)";
 

--- a/lib/package/plugins/unusedVariables.js
+++ b/lib/package/plugins/unusedVariables.js
@@ -23,7 +23,7 @@ var plugin = {
     nodeType: "Bundle",
     enabled: false
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   hadWarnErr = false;
 
 // This plugin does **NOT** check for variables that are used incorrectly.

--- a/lib/package/plugins/useTargetServers.js
+++ b/lib/package/plugins/useTargetServers.js
@@ -26,7 +26,7 @@ var plugin = {
     nodeType: "TargetEndpoint",
     enabled: true
   },
-  debug = require("debug")("bundlelinter:" + plugin.name),
+  debug = require("debug")("bundlelinter:" + plugin.ruleId),
   xpath = require("xpath");
 
 var onTargetEndpoint = function(target, cb) {
@@ -36,7 +36,7 @@ var onTargetEndpoint = function(target, cb) {
       "/TargetEndpoint/HTTPTargetConnection/URL/text()",
       target.getElement()
     );
-  
+
   if (url && url[0] !== undefined ) {
     var attr = xpath.select("/TargetEndpoint/@name", target.getElement() );
     target.addMessage({


### PR DESCRIPTION
Eg, enable debugging for eslint plugin via
  `DEBUG=bundlelinter:PO025 node ./cli.js ...`

Previously the debug used the "name" property on the plugin which included whitespace, not the appropriate thing to use in a debug flag.