### PR TITLE
remove unnecessary parallelism

### DIFF
--- a/lib/package/Bundle.js
+++ b/lib/package/Bundle.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Google LLC
+  Copyright 2019-2020 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,20 +14,20 @@
   limitations under the License.
 */
 
-var FindFolder = require("node-find-folder"),
-  decompress = require("decompress"),
-  fs = require("fs"),
-  async = require("async"),
-  path = require("path"),
-  Resource = require("./Resource.js"),
-  Policy = require("./Policy.js"),
-  Endpoint = require("./Endpoint.js"),
-  xpath = require("xpath"),
-  Dom = require("xmldom").DOMParser,
-  bundleType = require('./BundleTypes.js'),
-  debug = require("debug")("bundlelinter:Bundle");
-
-const util = require("util");
+const FindFolder = require("node-find-folder"),
+      decompress = require("decompress"),
+      fs = require("fs"),
+      path = require("path"),
+      Resource = require("./Resource.js"),
+      Policy = require("./Policy.js"),
+      Endpoint = require("./Endpoint.js"),
+      xpath = require("xpath"),
+      Dom = require("xmldom").DOMParser,
+      bundleType = require('./BundleTypes.js'),
+      util = require("util"),
+      debug = require("debug")("bundlelinter:Bundle"),
+      myUtil = require("./myUtil.js"),
+      getcb = myUtil.curry(myUtil.diagcb, debug);
 
 function _buildEndpoints(folder, tag, bundle, processFunction) {
   try {
@@ -243,7 +243,7 @@ function Bundle(config, cb) {
 
   if (config.source.type === "ManagementServer") {
     //shared flow not implemented for management server
-    if(config.source.bundleType === bundleTypes.BundleType.SHAREDFLOW){
+    if(config.source.bundleType === bundleType.BundleType.SHAREDFLOW){
       throw "SharedFlows for management server not supported";
     }
 
@@ -389,217 +389,109 @@ Bundle.prototype.onBundle = function(pluginFunction, cb) {
   pluginFunction(this, cb);
 };
 
-Bundle.prototype.onResources = function(pluginFunction, cb) {
-  async.each(
-    this.resources,
-    function(resource, cb) {
-      pluginFunction(resource, cb);
-    },
-    function(err) {
-      cb(err);
-    }
-  );
-};
-
 Bundle.prototype.onPolicies = function(pluginFunction, cb) {
-  async.each(
-    this.getPolicies(),
-    function(policy, cb) {
-      pluginFunction(policy, cb);
-    },
-    function(err) {
-      cb(err);
-    }
-  );
+  this.getPolicies().forEach(policy =>
+      pluginFunction(policy, getcb(`policy '${policy.getName()}'`)));
+  cb(null, {});
 };
 
 Bundle.prototype.onSteps = function(pluginFunction, callback) {
-  //will need to run these in parallel
-  var bundle = this;
-
-  async.parallel(
-    [
-      function(cb) {
-        if (bundle.getProxyEndpoints()) {
-          async.each(
-            bundle.getProxyEndpoints(),
-            function(ep, cb) {
-              ep.onSteps(pluginFunction, cb);
-            },
-            function(err) {
-              cb(err);
-            }
-          );
-        } else {
-          cb("Bundle no proxyEndpoints");
-        }
-      },
-      function(cb) {
-        if (bundle.getTargetEndpoints()) {
-          async.each(
-            bundle.getTargetEndpoints(),
-            function(ep, cb) {
-              ep.onSteps(pluginFunction, cb);
-            },
-            function(err) {
-              cb(err);
-            }
-          );
-        } else {
-          cb("Bundle no targetEndpoints");
-        }
-      }
-    ],
-    function(err, result) {
-      if (err) {
-        callback(err);
-      } else {
-        callback(null, result);
-      }
+  // there is no need to run the checks in parallel
+  const bundle = this,
+        proxies = bundle.getProxyEndpoints(),
+        targets = bundle.getTargetEndpoints();
+  debug(`onSteps: bundle name: '${bundle.getName()}'`);
+  try {
+    if (proxies && proxies.length>0) {
+      proxies.forEach(ep => ep.onSteps(pluginFunction, getcb(`proxyendpoint '${ep.getName()}'`)));
+    } else {
+      debug("no proxyEndpoints");
     }
-  );
+    if (targets && targets.length>0) {
+      targets.forEach(ep => ep.onSteps(pluginFunction, getcb(`targetendpoint '${ep.getName()}'`)));
+    } else {
+      debug("no targetEndpoints");
+    }
+  }
+  catch (exc1) {
+    debug('exception: ' + exc1);
+    debug(exc1.stack);
+  }
+  callback(null, {});
 };
 
 Bundle.prototype.onConditions = function(pluginFunction, callback) {
-  //will need to run these in parallel
-  var bundle = this;
-
-  async.parallel(
-    [
-      function(pcb) {
-        if (bundle.getProxyEndpoints()) {
-          async.each(
-            bundle.getProxyEndpoints(),
-            function(ep, ecb) {
-              ep.onConditions(pluginFunction, ecb);
-            },
-            function(err) {
-              pcb(err);
-            }
-          );
-        } else {
-          pcb("no proxyEndpoints");
-        }
-      },
-      function(pcb) {
-        if (bundle.getTargetEndpoints()) {
-          async.each(
-            bundle.getTargetEndpoints(),
-            function(ep, ecb) {
-              ep.onConditions(pluginFunction, ecb);
-            },
-            function(err) {
-              pcb(err);
-            }
-          );
-        } else {
-          pcb("no targetEndpoints");
-        }
-      }
-    ],
-    function(err, result) {
-      if (err) {
-        callback(err);
-      } else {
-        callback(null, result);
-      }
+  const bundle = this,
+        proxies = bundle.getProxyEndpoints(),
+        targets = bundle.getTargetEndpoints();
+  debug(`onConditions: bundle name: '${bundle.getName()}'`);
+  try {
+    if (proxies && proxies.length>0) {
+      proxies.forEach(ep =>
+                      ep.onConditions(pluginFunction, getcb(`proxyendpoint '${ep.getName()}'`)));
     }
-  );
+    if (targets && targets.length > 0) {
+      targets.forEach(ep =>
+                      ep.onConditions(pluginFunction, getcb(`targetendpoint '${ep.getName()}'`)));
+    }
+  }
+  catch (exc1) {
+    debug('exception: ' + exc1);
+    debug(exc1.stack);
+  }
+  callback(null, {});
 };
 
 Bundle.prototype.onResources = function(pluginFunction, cb) {
-  var bundle = this;
-
+  const bundle = this;
   if (bundle.getResources()) {
-    async.each(
-      bundle.getResources(),
-      function(re, cb) {
-        pluginFunction(re, cb);
-      },
-      function(err) {
-        cb(err);
-      }
-    );
-  } else {
-    cb("no resources");
+    bundle.getResources().forEach(re =>
+        pluginFunction(re, getcb(`resource '${re.getName()}'`)));
   }
+  cb(null, {});
 };
 
 Bundle.prototype.onFaultRules = function(pluginFunction, cb) {
-  var bundle = this;
-
+  const bundle = this;
   if (bundle.getFaultRules()) {
-    async.each(
-      bundle.getFaultRules(),
-      function(fr, cb) {
-        fr && pluginFunction(fr, cb);
-      },
-      function(err) {
-        cb(err);
-      }
-    );
-  } else {
-    cb("no faultRules");
+    bundle.getFaultRules().forEach(fr =>
+                                   fr && pluginFunction(fr, getcb(`faultrule '${fr.getName()}'`)));
   }
+  cb(null, {});
 };
 
 Bundle.prototype.onDefaultFaultRules = function(pluginFunction, cb) {
-  var bundle = this;
-
+  const bundle = this;
   if (bundle.getDefaultFaultRules()) {
-    async.each(
-      bundle.getDefaultFaultRules(),
-      function(dfr, cb) {
-        dfr && pluginFunction(dfr, cb);
-      },
-      function(err) {
-        cb(err);
-      }
-    );
-  } else {
-    cb("no defaultFaultRules");
+    bundle.getDefaultFaultRules().forEach(dfr =>
+                                          dfr && pluginFunction(dfr, getcb('defaultfaultrule')));
   }
+  cb(null, {});
 };
 
 Bundle.prototype.onProxyEndpoints = function(pluginFunction, cb) {
-  var eps = this.getProxyEndpoints();
-  if (eps) {
-    async.each(
-      eps,
-      function(ep, cb) {
-        pluginFunction(ep, cb);
-      },
-      function(err) {
-        cb(err);
-      }
-    );
-  } else {
-    cb("no proxyEndpoints");
+  let eps = this.getProxyEndpoints();
+  if (eps && eps.length > 0) {
+    eps.forEach( ep =>
+                 pluginFunction(ep, getcb(`proxyendpoint '${ep.getName()}'`)));
   }
+  cb(null, {});
 };
 
 Bundle.prototype.onTargetEndpoints = function(pluginFunction, cb) {
-  var eps = this.getTargetEndpoints();
-  if (eps) {
-    async.each(
-      eps,
-      function(ep, cb) {
-        pluginFunction(ep, cb);
-      },
-      function(err) {
-        cb(err);
-      }
-    );
-  } else {
-    cb("no targetEndpoints");
+  let eps = this.getTargetEndpoints();
+  if (eps && eps.length > 0) {
+    eps.forEach( ep =>
+                 pluginFunction(ep, getcb(`targetendpoint '${ep.getName()}'`)));
   }
+  cb(null, {});
 };
 
 Bundle.prototype.getProxyEndpoints = function() {
   if (!this.proxyEndpoints) {
     if(this.bundleTypeName === bundleType.BundleType.SHAREDFLOW){
       buildsharedflows(this);
-    }else {
+    } else {
       buildProxyEndpoints(this);
     }
 

--- a/lib/package/Endpoint.js
+++ b/lib/package/Endpoint.js
@@ -14,17 +14,18 @@
   limitations under the License.
 */
 
-var Flow = require("./Flow.js"),
-  RouteRule = require("./RouteRule.js"),
-  FaultRule = require("./FaultRule.js"),
-  xpath = require("xpath"),
-  myUtil = require("./myUtil.js"),
-  async = require("async"),
-  debug = require("debug")("bundlelinter:Endpoint"),
-  fs = require("fs"),
-  HTTPProxyConnection = require("./HTTPProxyConnection.js"),
-  HTTPTargetConnection = require("./HTTPTargetConnection.js"),
-  bundleTypes = require('./BundleTypes.js');
+const Flow = require("./Flow.js"),
+      RouteRule = require("./RouteRule.js"),
+      FaultRule = require("./FaultRule.js"),
+      xpath = require("xpath"),
+      myUtil = require("./myUtil.js"),
+      debug = require("debug")("bundlelinter:Endpoint"),
+      util = require("util"),
+      fs = require("fs"),
+      getcb = myUtil.curry(myUtil.diagcb, debug),
+      HTTPProxyConnection = require("./HTTPProxyConnection.js"),
+      HTTPTargetConnection = require("./HTTPTargetConnection.js"),
+      bundleTypes = require('./BundleTypes.js');
 
 function Endpoint(element, parent, fname, bundletype) {
   this.bundleType = bundletype ? bundletype : "apiproxy" //default to apiproxy if bundletype not passed
@@ -91,9 +92,11 @@ Endpoint.prototype.getSource = function() {
     var start = this.element.lineNumber - 1,
       stop = Number.MAX_SAFE_INTEGER;
     if (this.element.nextSibling && this.element.nextSibling.lineNumber) {
-      this.element.nextSibling.lineNumber - 1;
+      this.source = this.element.nextSibling.lineNumber - 1;
     }
-    this.source = this.getLines(start, stop);
+    else {
+      this.source = this.getLines(start, stop);
+    }
   }
   return this.source;
 };
@@ -240,7 +243,7 @@ Endpoint.prototype.getAllFlows = function() {
 Endpoint.prototype.getFaultRules = function() {
   if (!this.faultRules) {
     var doc = xpath.select("./FaultRules/FaultRule", this.element),
-      ep = this;
+        ep = this;
     ep.faultRules = [];
     if (doc) {
       doc.forEach(function(frElement) {
@@ -265,170 +268,102 @@ Endpoint.prototype.getDefaultFaultRule = function() {
 };
 
 Endpoint.prototype.onSteps = function(pluginFunction, callback) {
-  var endpoint = this;
+  const endpoint = this,
+        flows = endpoint.getFlows(),
+        faultrules = endpoint.getFaultRules();
+  debug(`onSteps: endpoint name: '${endpoint.getName()}'`);
+  try {
 
-  async.parallel(
-    [
-      function(cb) {
-        if (endpoint.getPreFlow()) {
-          endpoint.getPreFlow().onSteps(pluginFunction, cb);
-        } else {
-          cb("Endpoint no preFlow");
-        }
-      },
-      function(cb) {
-        if (endpoint.getFlows()) {
-          async.each(
-            endpoint.getFlows(),
-            function(fl, cb) {
-              fl.onSteps(pluginFunction, cb);
-            },
-            function(err) {
-              cb(err);
-            }
-          );
-        } else {
-          cb("Endpoint no flows");
-        }
-      },
-      function(cb) {
-        if (endpoint.getFlows() && endpoint.getPostFlow()) {
-          endpoint.getPostFlow().onSteps(pluginFunction, cb);
-        } else {
-          cb("Endpoint no postFlow");
-        }
-      },
-      function(cb) {
-        if (endpoint.getDefaultFaultRule()) {
-          endpoint.getDefaultFaultRule().onSteps(pluginFunction, cb);
-        } else {
-          cb("Endpoint no defaultFaultRule");
-        }
-      },
-      function(cb) {
-        if (endpoint.getFaultRules()) {
-          async.each(
-            endpoint.getFaultRules(),
-            function(fr, cb) {
-              fr.onSteps(pluginFunction, cb);
-            },
-            function(err) {
-              cb(err);
-            }
-          );
-        } else {
-          cb("Endpoint no faultRules");
-        }
-      }
-    ],
-    function(err, result) {
-      if (err) {
-        callback(err);
-      } else {
-        callback(null, result);
-      }
+    if (endpoint.getPreFlow()) {
+      endpoint.getPreFlow().onSteps(pluginFunction, getcb("onSteps preflow"));
     }
-  );
+    if (flows && flows.length >0) {
+      flows.forEach( fl =>
+                     fl.onSteps(pluginFunction, getcb(`onSteps flow '${fl.getName()}'`)));
+    }
+
+    if (endpoint.getPostFlow()) {
+      endpoint.getPostFlow().onSteps(pluginFunction, getcb('onSteps postflow'));
+    } else {
+      debug('onSteps: no postflow');
+    }
+    if (endpoint.getDefaultFaultRule()) {
+      debug('onSteps: defaultFaultRule');
+      endpoint.getDefaultFaultRule().onSteps(pluginFunction, getcb('onSteps dfr'));
+    } else {
+      debug('onSteps: no defaultFaultRule');
+    }
+
+    if (faultrules && faultrules.length>0) {
+      faultrules.forEach( fr =>
+                          fr.onSteps(pluginFunction, getcb('onSteps faultrules')) );
+
+    } else {
+      debug("onSteps: no faultRules");
+    }
+  }
+  catch (exc1) {
+    debug('exception: ' + exc1);
+    debug(exc1.stack);
+  }
+
+  if (callback)
+    callback(null, {});
 };
 
 Endpoint.prototype.onConditions = function(pluginFunction, callback) {
-  //parallelize this with async
-  var endpoint = this;
+  const endpoint = this,
+        flows = endpoint.getFlows(),
+        faultrules = endpoint.getFaultRules(),
+        routerules = endpoint.getRouteRules();
+  debug(`onConditions: endpoint name: ' + '${endpoint.getName()}'`);
 
-  async.parallel(
-    [
-      function(cb) {
-        if (endpoint.getPreFlow()) {
-          endpoint.getPreFlow().onConditions(pluginFunction, cb);
-        } else {
-          cb("Endpoint no preFlow");
-        }
-      },
-      function(cb) {
-        if (endpoint.getFlows()) {
-          async.each(
-            endpoint.getFlows(),
-            function(fl,ecb) {
-              fl.onConditions(pluginFunction, ecb);
-            },
-            function(err) {
-              cb(err);
-            }
-          );
-        } else {
-          cb("Endpoint no flows");
-        }
-      },
-      function(cb) {
-        if (endpoint.getPostFlow()) {
-          endpoint.getPostFlow().onConditions(pluginFunction, cb);
-        } else {
-          cb("Endpoint no postFlow");
-        }
-      },
-      function(cb) {
-        if (endpoint.getDefaultFaultRule()) {
-          async.each(
-            endpoint.getDefaultFaultRule().getSteps(),
-            function(step, cb) {
-              step.onConditions(pluginFunction, cb);
-            },
-            function(err) {
-              cb(err);
-            }
-          );
-        } else {
-          cb("Endpoint no defaultFautlRule");
-        }
-      },
-      function(cb) {
-        if (endpoint.getFaultRules()) {
-          async.each(
-            endpoint.getFaultRules(),
-            function(fr, cb) {
-              fr.onConditions(pluginFunction, cb);
-              async.each(
-                fr.getSteps(),
-                function(step, cb) {
-                  step.onConditions(pluginFunction, cb);
-                },
-                function(err) {
-                  //cb will already have been called. Handle any clean up here.
-                }
-              );
-            },
-            function(err) {
-              cb(err);
-            }
-          );
-        } else {
-          cb("Endpoint no faultRules");
-        }
-      },
-      function(cb) {
-        if (endpoint.getRouteRules()) {
-          async.each(
-            endpoint.getRouteRules(),
-            function(rr, cb) {
-              rr.onConditions(pluginFunction, cb);
-            },
-            function(err) {
-              cb(err);
-            }
-          );
-        } else {
-          cb("Endpoint no routeRules");
-        }
-      }
-    ],
-    function(err, result) {
-      if (err) {
-        callback(err);
-      } else {
-        callback(null, result);
-      }
+  try {
+    if (endpoint.getPreFlow()) {
+      endpoint.getPreFlow().onConditions(pluginFunction, getcb("onConditions preflow"));
+    } else {
+      debug('onConditions: no PreFlow');
     }
-  );
+    if (flows && flows.length >0) {
+      flows.forEach( fl =>
+                     fl.onConditions(pluginFunction, getcb(`onConditions flow '${fl.getName()}'`)));
+    } else {
+      debug('onConditions: no Flows');
+    }
+    if (endpoint.getPostFlow()) {
+      endpoint.getPostFlow().onConditions(pluginFunction, getcb('onConditions postflow'));
+    } else {
+      debug('onConditions: no PostFlow');
+    }
+    if (endpoint.getDefaultFaultRule()) {
+      endpoint.getDefaultFaultRule().getSteps().forEach( step =>
+                                                         step.onConditions(pluginFunction, getcb('onConditions dfr')));
+    } else {
+      debug('onConditions: no DefaultFaultRule');
+    }
+    if (faultrules && faultrules.length>0) {
+      faultrules.forEach( fr => {
+        fr.onConditions(pluginFunction, getcb(`faultrule '${fr.getName()}'`));
+        fr.getSteps().forEach( step =>
+                               step.onConditions(pluginFunction, getcb(`onConditions faultrule '${fr.getName()}'`)));
+      });
+    } else {
+      debug("onConditions: no FaultRules");
+    }
+    if (routerules && routerules.length>0) {
+      routerules.forEach( rr =>
+                          rr.onConditions(pluginFunction, getcb(`onConditions routerule '${rr.getName()}'`)));
+    } else {
+      debug("onConditions: no RouteRules");
+    }
+  }
+  catch (exc1) {
+    debug('exception: ' + exc1);
+    debug(exc1.stack);
+  }
+
+  if (callback)
+    callback(null, {});
 };
 
 Endpoint.prototype.getElement = function() {

--- a/lib/package/FaultRule.js
+++ b/lib/package/FaultRule.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Google LLC
+  Copyright 2019-2020 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,9 +14,11 @@
   limitations under the License.
 */
 
-var Condition = require("./Condition.js"),
-  xpath = require("xpath"),
-  async = require("async");
+const Condition = require("./Condition.js"),
+      xpath = require("xpath"),
+      debug = require("debug")("bundlelinter:FaultRule"),
+      myUtil = require("./myUtil.js"),
+      getcb = myUtil.curry(myUtil.diagcb, debug);
 
 function FaultRule(element, parent) {
   this.parent = parent;
@@ -91,61 +93,26 @@ FaultRule.prototype.addMessage = function(msg) {
 };
 
 FaultRule.prototype.onConditions = function(pluginFunction, callback) {
-  //async
-  var faultRule = this;
-
-  async.parallel(
-    [
-      function(cb) {
-        if (faultRule.getCondition()) {
-          pluginFunction(faultRule.getCondition(), cb);
-        } else {
-          cb("FaultRule no condition");
-        }
-      },
-      function(cb) {
-        if (faultRule.getSteps()) {
-          async.each(
-            faultRule.getSteps(),
-            function(step, cb) {
-              step.onConditions(pluginFunction, cb);
-            },
-            function(err) {
-              cb(err);
-            }
-          );
-        } else {
-          cb("FaultRule no steps");
-        }
-      }
-    ],
-    function(err, result) {
-      if (err) {
-        callback(err);
-      } else {
-        callback(null, result);
-      }
-    }
-  );
+  let faultRule = this,
+      steps = faultRule.getSteps();
+  if (faultRule.getCondition()) {
+    pluginFunction(faultRule.getCondition(), getcb(`onConditions '${faultRule.getName()}'`));
+  }
+  if (steps && steps.length > 0) {
+    steps.forEach((step, ix) =>
+                  step.onConditions(pluginFunction, getcb(`onConditions step ${ix}`)));
+  }
+  callback(null, {});
 };
 
 FaultRule.prototype.onSteps = function(pluginFunction, callback) {
-  //async
-  var faultRule = this;
-
-  if (faultRule.getSteps()) {
-    async.each(
-      faultRule.getSteps(),
-      function(step, cb) {
-        step.onSteps(pluginFunction, cb);
-      },
-      function(err) {
-        callback(err);
-      }
-    );
-  } else {
-    callback("FaultRule no steps");
+  let faultRule = this,
+      steps = faultRule.getSteps();
+  if (steps && steps.length > 0) {
+    steps.forEach((step, ix) =>
+        step.onSteps(pluginFunction, getcb(`onSteps step ${ix}`)));
   }
+  callback(null, {});
 };
 
 FaultRule.prototype.summarize = function() {

--- a/lib/package/Flow.js
+++ b/lib/package/Flow.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Google LLC
+  Copyright 2019-2020 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,16 +14,20 @@
   limitations under the License.
 */
 
-var xpath = require("xpath"),
-  FlowPhase = require("./FlowPhase.js"),
-  Condition = require("./Condition.js"),
-  async = require("async"),
-  myUtil = require("./myUtil.js"),
-  debug = require("debug")("bundlelinter:Flow");
+const xpath = require("xpath"),
+      FlowPhase = require("./FlowPhase.js"),
+      Condition = require("./Condition.js"),
+      myUtil = require("./myUtil.js"),
+      debug = require("debug")("bundlelinter:Flow"),
+      getcb = myUtil.curry(myUtil.diagcb, debug);
 
 function Flow(element, parent) {
   this.parent = parent;
   this.element = element;
+  this.condition = null;
+  this.flowResponse = null;
+  this.sharedflow = null;
+  this.description = null;
 }
 
 Flow.prototype.getName = function() {
@@ -58,8 +62,8 @@ Flow.prototype.getFlowName = function() {
 };
 
 Flow.prototype.getDescription = function() {
-  if (!this.description) {
-    var doc = xpath.select("./Description", this.element);
+  if (this.description == null) {
+    let doc = xpath.select("./Description", this.element);
     this.description =
       (doc &&
         doc[0] &&
@@ -71,8 +75,8 @@ Flow.prototype.getDescription = function() {
 };
 
 Flow.prototype.getCondition = function() {
-  if (!this.condition) {
-    var element = xpath.select("./Condition", this.element);
+  if (this.condition == null) {
+    let element = xpath.select("./Condition", this.element);
     this.condition = element && element[0] && new Condition(element[0], this);
   }
   return this.condition;
@@ -82,99 +86,51 @@ Flow.prototype.getFlowRequest = function() {
   if (!this.flowRequest) {
     //odd... in preflow I need the parentNode
     //in Flow I don't... what is wrong
-    var doc = xpath.select("./Request", this.element);
+    let doc = xpath.select("./Request", this.element);
     this.flowRequest = new FlowPhase(doc[0] || "", this);
   }
   return this.flowRequest;
 };
 
 Flow.prototype.getFlowResponse = function() {
-  if (!this.flowResponse) {
-    var doc = xpath.select("./Response", this.element);
-    if (doc && doc[0]) {
-      this.flowResponse = new FlowPhase(doc[0], this);
-    }
+  if (this.flowResponse == null) {
+    let doc = xpath.select("./Response", this.element);
+    this.flowResponse = (doc && doc[0]) ? new FlowPhase(doc[0], this) : false;
   }
   return this.flowResponse;
 };
 
 Flow.prototype.getSharedFlow = function() {
-  if (!this.sharedflow) {
-    var doc = xpath.select(".", this.element);
-    if (doc && doc[0]) {
-      this.sharedflow = new FlowPhase(doc[0], this);
-    }
+  if (this.sharedflow == null) {
+    let doc = xpath.select(".", this.element);
+    this.sharedflow = doc && doc[0] && new FlowPhase(doc[0], this);
   }
   return this.sharedflow;
 };
 
 Flow.prototype.onSteps = function(pluginFunction, callback) {
-  //parallel these
-  var flow = this;
-
-  async.parallel(
-    [
-      function(cb) {
-        if (flow.getFlowRequest()) {
-          flow.getFlowRequest().onSteps(pluginFunction, cb);
-        } else {
-          cb("Flow no flowRequest");
-        }
-      },
-      function(cb) {
-        if (flow.getFlowResponse()) {
-          flow.getFlowResponse().onSteps(pluginFunction, cb);
-        } else {
-          cb("Flow no flowResponse");
-        }
-      }
-    ],
-    function(err, result) {
-      if (err) {
-        callback(err);
-      } else {
-        callback(null, result);
-      }
-    }
-  );
+  let flow = this;
+  if (flow.getFlowRequest()) {
+    flow.getFlowRequest().onSteps(pluginFunction, getcb(`onSteps Request`));
+  }
+  if (flow.getFlowResponse()) {
+    flow.getFlowResponse().onSteps(pluginFunction, getcb(`onSteps Response`));
+  }
+  callback(null, {});
 };
 
 Flow.prototype.onConditions = function(pluginFunction, callback) {
-  //parallel these
-  var flow = this;
-
-  async.parallel(
-    [
-      function(acb) {
-        if (flow.getFlowRequest()) {
-          flow.getFlowRequest().onConditions(pluginFunction, acb);
-        } else {
-          acb("Flow no flowRequest");
-        }
-      },
-      function(acb) {
-        if (flow.getFlowResponse()) {
-          flow.getFlowResponse().onConditions(pluginFunction, acb);
-        } else {
-          acb("Flow no flowResponse");
-        }
-      },
-      function(acb) {
-        if (flow.getCondition()) {
-          pluginFunction(flow.getCondition(), acb);
-        } else {
-          acb("Flow no condition");
-        }
-      }
-    ],
-    function(err, result) {
-      if (err && !result) {
-        callback(err);
-      } else {
-        callback(err, result);
-      }
-    }
-  );
+  let flow = this;
+  if (flow.getFlowRequest()) {
+    flow.getFlowRequest().onConditions(pluginFunction, getcb(`onConditions Request`));
+  }
+  if (flow.getFlowResponse()) {
+    flow.getFlowResponse().onConditions(pluginFunction, getcb(`onConditions Response`));
+  }
+  if (flow.getCondition()) {
+    pluginFunction(flow.getCondition(), getcb(`onConditions Flow`));
+  }
+  callback(null, {});
 };
 
 Flow.prototype.getElement = function() {
@@ -188,7 +144,7 @@ Flow.prototype.getLines = function(start, stop) {
 Flow.prototype.getSource = function() {
   if (!this.source) {
     var start = this.element.lineNumber - 1,
-      stop = this.element.nextSibling.lineNumber - 1;
+        stop = this.element.nextSibling.lineNumber - 1;
     this.source = this.getLines(start, stop);
   }
   return this.source;
@@ -206,18 +162,15 @@ Flow.prototype.addMessage = function(msg) {
 };
 
 Flow.prototype.summarize = function() {
-  var summary = {};
-
-  summary.name = this.getName();
-  summary.description = this.getDescription();
-  summary.type = this.getType();
-  summary.flowName = this.getFlowName();
-  summary.condition =
-    (this.getCondition() && this.getCondition().summarize()) || {};
-  summary.requestPhase =
-    (this.getFlowRequest() && this.getFlowRequest().summarize()) || {};
-  summary.responsePhase =
-    (this.getFlowResponse() && this.getFlowResponse().summarize()) || {};
+  let summary = {
+        name : this.getName(),
+        description : this.getDescription(),
+        type : this.getType(),
+        flowName : this.getFlowName(),
+        condition : (this.getCondition() && this.getCondition().summarize()) || {},
+        requestPhase : (this.getFlowRequest() && this.getFlowRequest().summarize()) || {},
+        responsePhase : (this.getFlowResponse() && this.getFlowResponse().summarize()) || {}
+      };
   return summary;
 };
 

--- a/lib/package/FlowPhase.js
+++ b/lib/package/FlowPhase.js
@@ -14,9 +14,11 @@
   limitations under the License.
 */
 
-var xpath = require("xpath"),
-  Step = require("./Step.js"),
-  async = require("async");
+const xpath = require("xpath"),
+      Step = require("./Step.js"),
+      myUtil = require("./myUtil.js"),
+      debug = require("debug")("bundlelinter:FlowPhase"),
+      getcb = myUtil.curry(myUtil.diagcb, debug);
 
 function FlowPhase(element, parent) {
   this.parent = parent;
@@ -44,8 +46,8 @@ FlowPhase.prototype.getPhase = function() {
 
 FlowPhase.prototype.getSteps = function() {
   if (!this.steps) {
-    var doc = xpath.select("./Step", this.element),
-      fp = this;
+    let doc = xpath.select("./Step", this.element),
+        fp = this;
     fp.steps = [];
     if (doc) {
       doc.forEach(function(stepElement) {
@@ -57,33 +59,21 @@ FlowPhase.prototype.getSteps = function() {
 };
 
 FlowPhase.prototype.onSteps = function(pluginFunction, cb) {
-  //async
-  if (this.getSteps()) {
-    async.each(
-      this.getSteps(),
-      function(step, cb) {
-        pluginFunction(step, cb);
-      },
-      function(err) {
-        cb(err);
-      }
-    );
+  let steps = this.getSteps();
+  if (steps && steps.length > 0) {
+    steps.forEach( (step, ix) =>
+        pluginFunction(step, getcb(`step ${ix}}`)));
   }
+  cb(null, {});
 };
 
 FlowPhase.prototype.onConditions = function(pluginFunction, cb) {
-  //async
-  if (this.getSteps()) {
-    async.each(
-      this.getSteps(),
-      function(step, cb) {
-        step.onConditions(pluginFunction, cb);
-      },
-      function(err) {
-        cb(err);
-      }
-    );
+  let steps = this.getSteps();
+  if (steps && steps.length > 0) {
+    steps.forEach( (step, ix) =>
+        step.onConditions(pluginFunction, getcb(`step ${ix}}`)));
   }
+  cb(null, {});
 };
 
 FlowPhase.prototype.getElement = function() {

--- a/lib/package/Step.js
+++ b/lib/package/Step.js
@@ -14,11 +14,12 @@
   limitations under the License.
 */
 
-var Condition = require("./Condition.js"),
-  FaultRule = require("./FaultRule.js"),
-  async = require("async"),
-  xpath = require("xpath"),
-  myUtil = require("./myUtil.js");
+const Condition = require("./Condition.js"),
+      FaultRule = require("./FaultRule.js"),
+      xpath = require("xpath"),
+      myUtil = require("./myUtil.js"),
+      debug = require("debug")("bundlelinter:Bundle"),
+      getcb = myUtil.curry(myUtil.diagcb, debug);
 
 function Step(element, parent) {
   this.parent = parent;
@@ -76,7 +77,7 @@ Step.prototype.getFlowName = function() {
 };
 
 Step.prototype.getFaultRules = function() {
-  if (!this.routeRules) {
+  if (!this.faultRules) {
     var doc = xpath.select("./FaultRules/FaultRule", this.element),
       st = this;
     st.faultRules = [];
@@ -87,7 +88,7 @@ Step.prototype.getFaultRules = function() {
       });
     }
   }
-  return this.routeRules;
+  return this.faultRules;
 };
 
 Step.prototype.getCondition = function() {
@@ -118,87 +119,38 @@ Step.prototype.addMessage = function(msg) {
 };
 
 Step.prototype.onConditions = function(pluginFunction, callback) {
-  //async
-  var step=this;
-
-  async.parallel(
-    [
-      function(cb) {
-        if (step.getCondition()) {
-          pluginFunction(step.getCondition(), cb);
-        }
-      },
-      function(cb) {
-        if (step.getFaultRules()) {
-          async.each(
-            step.getFaultRules(),
-            function(fr) {
-              fr.onConditions(pluginFunction, cb);
-            },
-            function(err) {
-              cb(err);
-            }
-          );
-        }
-      }
-    ],
-    function(err, result) {
-      if (err) {
-        callback(err);
-      } else {
-        callback(null, result);
-      }
-    }
-  );
+  let step = this,
+      faultRules = step.getFaultRules();
+  if (step.getCondition()) {
+    pluginFunction(step.getCondition(), getcb(`onConditions ${this.getName()}`));
+  }
+  if (faultRules && faultRules.length > 0) {
+    faultRules.forEach(fr =>
+                       fr.onConditions(pluginFunction, getcb(`onConditions FaultRule '${fr.getName()}'`)));
+  }
+  callback(null, {});
 };
 
 Step.prototype.onSteps = function(pluginFunction, callback) {
-  //async
-  var step=this;
+  let step = this,
+      faultRules = step.getFaultRules();
+  pluginFunction(step, getcb(`onSteps ${this.getName()}`));
 
-  async.parallel(
-    [
-      function(cb) {
-        pluginFunction(step, cb);
-      },
-      function(cb) {
-        if (step.getFaultRules()) {
-          async.each(
-            step.getFaultRules(),
-            function(fr) {
-              fr.onSteps(pluginFunction, cb);
-            },
-            function(err) {
-              cb(err);
-            }
-          );
-        }
-      }
-    ],
-    function(err, result) {
-      if (err) {
-        callback(err);
-      } else {
-        callback(null, result);
-      }
-    }
-  );
+  if (faultRules && faultRules.length > 0) {
+    faultRules.forEach(fr =>
+              fr.onSteps(pluginFunction, getcb(`onSteps FaultRule '${this.getName()}'`)));
+  }
+  callback(null, {});
+
 };
 
 Step.prototype.summarize = function() {
-  var summary = {};
-  summary.name = this.getName();
-  summary.flowName = this.getFlowName();
-  var faultRules = this.getFaultRules();
-  if (faultRules) {
-    summary.faultRules = [];
-    faultRules.forEach(function(fr) {
-      summary.faultRules.push(fr.summarize());
-    });
-  }
-  summary.condition =
-    (this.getCondition() && this.getCondition().summarize()) || {};
-  return summary;
+  return {
+    name : this.getName(),
+    flowName : this.getFlowName(),
+    condition : (this.getCondition() && this.getCondition().summarize()) || {},
+    faultRules : this.getFaultRules() && this.faultRules.map( fr => fr.summarize())
+  };
 };
 
 //Public

--- a/lib/package/bundleLinter.js
+++ b/lib/package/bundleLinter.js
@@ -14,12 +14,14 @@
   limitations under the License.
 */
 
-var fs = require("fs"),
-  path = require("path"),
-  Bundle = require("./Bundle.js"),
-  request = require("request"),
-  async = require("async"),
-  debug = require("debug")("bundlelinter:");
+const fs = require("fs"),
+      path = require("path"),
+      Bundle = require("./Bundle.js"),
+      request = require("request"),
+      pluralize = require("pluralize"),
+      myUtil = require("./myUtil.js"),
+      debug = require("debug")("bundlelinter:"),
+      getcb = myUtil.curry(myUtil.diagcb, debug);
 
 function contains(a, obj, f) {
   if (!a || !a.length) {
@@ -204,89 +206,31 @@ var getFormatter = function(format) {
   }
 };
 
-var executePlugin = function(file, bundle, callback) {
-  if (file.endsWith(".js")) {
-    var plugin = require(file);
-    if (plugin.plugin.enabled && bundle.excluded[plugin.plugin.ruleId]!==true) {
-      async.parallel(
-        [
-          function(acb) {
-            if (plugin.onBundle) {
-              bundle.onBundle(plugin.onBundle, acb);
-            } else {
-              acb("bundleLinter no onBundle");
+const bfnName = (term) =>
+  (term == 'Bundle') ? 'onBundle' : pluralize('on' + term, 2);
+
+var executePlugin = function(file, bundle) {
+      if (file.endsWith(".js")) {
+        let plugin = require(file);
+        if (plugin.plugin.enabled && bundle.excluded[plugin.plugin.ruleId]!==true) {
+          debug(`execPlugin ${file}`);
+          let basename = path.basename(file).slice(0, -3),
+              entityTypes = ['Bundle', 'Step', 'Condition',
+                             'ProxyEndpoint', 'TargetEndpoint',
+                             'Resource', 'Policy', 'FaultRule',
+                             'DefaultFaultRule'];
+
+          entityTypes.forEach( etype => {
+            let pfn = plugin['on' + etype];
+            if (pfn) {
+              let label =`plugin ${basename} on${etype}`;
+              debug(label + ' start');
+              bundle[bfnName(etype)](pfn, getcb(label));
             }
-          },
-          function(acb) {
-            if (plugin.onStep) {
-              bundle.onSteps(plugin.onStep, acb);
-            } else {
-              acb("bundleLinter no onStep");
-            }
-          },
-          function(acb) {
-            if (plugin.onCondition) {
-              bundle.onConditions(plugin.onCondition, acb);
-            } else {
-              acb("bundleLinter no onCondition");
-            }
-          },
-          function(acb) {
-            if (plugin.onProxyEndpoint) {
-              bundle.onProxyEndpoints(plugin.onProxyEndpoint, acb);
-            } else {
-              acb("bundleLinter no onProxyEndpoint");
-            }
-          },
-          function(acb) {
-            if (plugin.onTargetEndpoint) {
-              bundle.onTargetEndpoints(plugin.onTargetEndpoint, acb);
-            } else {
-              acb("bundleLinter no onTargetEndpoint");
-            }
-          },
-          function(acb) {
-            if (plugin.onResource) {
-              bundle.onResources(plugin.onResource, acb);
-            } else {
-              acb("bundleLinter no onResource");
-            }
-          },
-          function(acb) {
-            if (plugin.onPolicy) {
-              bundle.onPolicies(plugin.onPolicy, acb);
-            } else {
-              acb("bundleLinter no onPolicy");
-            }
-          },
-          function(acb) {
-            if (plugin.onFaultRule) {
-              bundle.onFaultRules(plugin.onFaultRule, acb);
-            } else {
-              acb("bundleLinter no onFaultRule");
-            }
-          },
-          function(acb) {
-            if (plugin.onDefaultFaultRule) {
-              bundle.onDefaultFaultRules(plugin.onDefaultFaultRule, acb);
-            } else {
-              acb("bundleLinter no onDefaultFaultRules");
-            }
-          }
-        ],
-        function(err, result) {
-          if (typeof callback === "function") {
-            if (err) {
-              callback(err);
-            } else {
-              callback(null, result);
-            }
-          }
+          });
         }
-      );
-    }
-  }
-};
+      }
+    };
 
 module.exports = {
   lint,

--- a/lib/package/myUtil.js
+++ b/lib/package/myUtil.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Google LLC
+  Copyright 2019-2020 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 */
 
 var xpath = require("xpath"),
-  util = require("util");
+    util = require("util");
 
 function rBuildTagBreadCrumb(doc, bc) {
   if (doc && doc.parentNode) {
@@ -77,6 +77,21 @@ function selectTagValue(item, path) {
   return doc && doc[0] && doc[0].childNodes && doc[0].childNodes[0].nodeValue;
 }
 
+const diagcb = (dbg, label) =>
+    (e, d) => {
+      if (e) {
+        dbg(`${label} message(${e})`);
+        if (e.stack)
+          dbg(e.stack);
+      }
+      //debug(`${label} result: ` + util.format(d));
+      dbg(`${label} done (${d})`);
+    };
+
+// return a curried function with the left-most argument filled
+const curry = (fn, arg1) =>
+   (...arguments) => fn.apply(this,[arg1].concat(arguments));
+
 module.exports = {
   buildTagBreadCrumb,
   print,
@@ -84,5 +99,7 @@ module.exports = {
   selectAttributeValue,
   selectTagValue,
   inspect,
-  getFileName
+  getFileName,
+  curry,
+  diagcb
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "private": false,
   "dependencies": {
-    "async": "^2.5.0",
     "babel-code-frame": "latest",
     "chalk": "latest",
     "commander": "^2.9.0",
@@ -54,6 +53,7 @@
     "pdfmake": "latest"
   },
   "devDependencies": {
+    "async": "^2.5.0",
     "codacy-coverage": "^2.0.2",
     "mocha": "^6.0.2",
     "mocha-lcov-reporter": "^1.3.0",


### PR DESCRIPTION
Using async.parallel may provide small perf advantages, but because there is no I/O or waiting, it's probably negligible. But async.parallel has costs - for example any exception thrown by a plugin will get swallowed. Also the code that uses the async module is less readable, too.

Therefore, let's remove unnecessary parallelism.