### PR TITLE
add check for {Proxy,Target}Endpoint on name

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ The list of rules is a work in progress and expected to increase over time. As p
 | &nbsp; |:white_medium_square:| PD001 | RouteRules to Targets | RouteRules should map to defined Targets |
 | &nbsp; |:white_check_mark:| PD002 | Unreachable Route Rules - defaults |  Only one RouteRule should be present without a condition |
 | &nbsp; |:white_check_mark:| PD003 | Unreachable Route Rules |  RouteRule without a condition should be last. |
+| &nbsp; |:white_check_mark:| PD004 | ProxyEndpoint name | ProxyEndpoint name should match basename of filename. |
 | Target Definition | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| TD001 | Mgmt Server as Target |  Discourage calls to the Management Server from a Proxy via target. |
 | &nbsp; |:white_check_mark:| TD002 | Use Target Servers |  Encourage the use of target servers |
+| &nbsp; |:white_check_mark:| TD003 | TargetEndpoint name | TargetEndpoint name should match basename of filename. |
 | Flow | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| FL001 | Unconditional Flows |  Only one unconditional flow will get executed. Error if more than one was detected. |
 | Step | &nbsp; | &nbsp; | &nbsp; | &nbsp; |

--- a/lib/package/Endpoint.js
+++ b/lib/package/Endpoint.js
@@ -56,6 +56,10 @@ Endpoint.prototype.getFileName = function() {
   return this.fileName;
 };
 
+Endpoint.prototype.select = function(xs) {
+  return xpath.select(xs, this.getElement());
+};
+
 Endpoint.prototype.getLines = function(start, stop) {
   //actually parse the source into lines if we haven't already and return the requested subset
   var result = "";

--- a/lib/package/plugins/proxyNameAttr.js
+++ b/lib/package/plugins/proxyNameAttr.js
@@ -1,0 +1,58 @@
+/*
+  Copyright 2019-2020 Google LLC
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const plugin = {
+  ruleId: "PD004",
+  name: "ProxyEndpoint Name",
+  message: "Check ProxyEndpoint name attribute against file name.",
+  fatal: false,
+  severity: 1, // 1 = warn, 2 = error
+  nodeType: "Endpoint",
+  enabled: true
+};
+
+const path = require('path'),
+      debug = require("debug")("bundlelinter:" + plugin.ruleId);
+
+const onProxyEndpoint = function(endpoint, cb) {
+        let shortFilename = path.basename(endpoint.getFileName()),
+            basename = shortFilename.split(".xml")[0],
+            nameFromAttribute = endpoint.getName(),
+            flagged = false;
+
+        try {
+          debug(`onProxyEndpoint shortfile(${shortFilename}) nameFromAttr(${nameFromAttribute})`);
+          if (basename !== nameFromAttribute) {
+            let nameAttr = endpoint.select('//@name');
+            endpoint.addMessage({
+              plugin,
+              line: nameAttr[0].lineNumber,
+              column: nameAttr[0].columnNumber,
+              message: `File basename (${basename}) does not match endpoint name (${nameFromAttribute}).`
+            });
+            flagged = true;
+          }
+          if (typeof(cb) == 'function') {
+            cb(null, flagged);
+          }
+        }
+        catch (exc1) {
+          console.error('exception: ' + exc1);
+          debug(`onProxyEndpoint exc(${exc1})`);
+        }
+      };
+
+module.exports = {
+  plugin,
+  onProxyEndpoint
+};

--- a/lib/package/plugins/targetNameAttr.js
+++ b/lib/package/plugins/targetNameAttr.js
@@ -1,0 +1,58 @@
+/*
+  Copyright 2019-2020 Google LLC
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const plugin = {
+  ruleId: "TD003",
+  name: "TargetEndpoint Name",
+  message: "Check TargetEndpoint name attribute against file name.",
+  fatal: false,
+  severity: 1,  // 1 = warn, 2 = error
+  nodeType: "Endpoint",
+  enabled: true
+};
+
+const path = require('path'),
+      debug = require("debug")("bundlelinter:" + plugin.ruleId);
+
+const onTargetEndpoint = function(endpoint, cb) {
+        let shortFilename = path.basename(endpoint.getFileName()),
+            basename = shortFilename.split(".xml")[0],
+            nameFromAttribute = endpoint.getName(),
+            flagged = false;
+
+        try {
+          debug(`onTargetEndpoint shortfile(${shortFilename}) nameFromAttr(${nameFromAttribute})`);
+          if (basename !== nameFromAttribute) {
+            let nameAttr = endpoint.select('//@name');
+            endpoint.addMessage({
+              plugin,
+              line: nameAttr[0].lineNumber,
+              column: nameAttr[0].columnNumber,
+              message: `File basename (${basename}) does not match endpoint name (${nameFromAttribute}).`
+            });
+            flagged = true;
+          }
+          if (typeof(cb) == 'function') {
+            cb(null, flagged);
+          }
+        }
+        catch (exc1) {
+          console.error('exception: ' + exc1);
+          debug(`onTargetEndpoint exc(${exc1})`);
+        }
+      };
+
+module.exports = {
+  plugin,
+  onTargetEndpoint
+};


### PR DESCRIPTION
name attribute should match the filename for the ProxyEndpoint or TargetEndpoint. This is now enforced during upload by ngsaas.