### PR TITLE
use the correct value for debug in assignvar plugin

### DIFF
--- a/lib/package/plugins/assignVariableUsage.js
+++ b/lib/package/plugins/assignVariableUsage.js
@@ -24,7 +24,7 @@ const plugin = {
         nodeType: "AssignMessage",
         enabled: true
       },
-      debug = require("debug")("apigeelint:" + plugin.name),
+      debug = require("debug")("apigeelint:" + plugin.ruleId),
       xpath = require("xpath"),
       util = require('util');
 


### PR DESCRIPTION
This is a change interesting only to developers and maintainers of the assignvariable plugin. 