### PR TITLE
Allow apigeelint to fail, if maximum number of warnings is exceeded

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -31,6 +31,7 @@ program
     "Provide the host and path to upload linter results"
   )
   .option("-e, --excluded [value]", "The comma separated list of tests to be excluded")
+  .option("--maxWarnings [value]", "Number of warnings to trigger nonzero exit code - default: -1")
   .option("-u, --user [value]", "Apigee user account")
   .option("-p, --password [value]", "Apigee password")
   .option("-o, --organization [value]", "Apigee organization")
@@ -51,8 +52,13 @@ var configuration = {
     bundleType: program.path.includes(bundleType.BundleType.SHAREDFLOW) ? bundleType.BundleType.SHAREDFLOW : bundleType.BundleType.APIPROXY
   },
   externalPluginsDirectory: program.externalPluginsDirectory,
-  excluded: {}
+  excluded: {},
+  maxWarnings: -1
 };
+
+if(!isNaN(program.maxWarnings)){
+  configuration.maxWarnings = Number.parseInt(program.maxWarnings);
+}
 
 if (program.formatter) {
   configuration.formatter = program.formatter || "json.js";

--- a/lib/package/bundleLinter.js
+++ b/lib/package/bundleLinter.js
@@ -174,6 +174,16 @@ var lint = function(config, done) {
              return;
           }
       });
+
+      // Exit code should return 1 when more than maximum number of warnings allowed
+      if(config.maxWarnings >=0){
+        let warningCount = 0;
+        bundle.getReport().forEach(report => warningCount += report.warningCount);
+        if(warningCount > config.maxWarnings){
+          process.exitCode = 1;
+            return;
+        }
+      }
     }
   });
 };


### PR DESCRIPTION
A new parameter "--maxWarnings" (inspired by ESLint) has been added.
If more warnings are reported than allowed, the lint will exit with an error code - allowing CI/CD pipelines to fail on bad quality commits.

The default value for --maxWarnings is -1, which disables this new feature.

This solves issue #214 