### PR TITLE
allow config setExitCode to disable process.exit()

### DIFF
--- a/lib/package/bundleLinter.js
+++ b/lib/package/bundleLinter.js
@@ -168,20 +168,22 @@ var lint = function(config, done) {
       }
 
       // Exit code should return 1 when there are errors
-      bundle.getReport().some(function(value){
+      if (typeof config.setExitCode == 'undefined' || config.setExitCode) {
+        bundle.getReport().some(function(value){
           if (value.errorCount > 0) {
-             process.exitCode = 1;
-             return;
-          }
-      });
-
-      // Exit code should return 1 when more than maximum number of warnings allowed
-      if(config.maxWarnings >=0){
-        let warningCount = 0;
-        bundle.getReport().forEach(report => warningCount += report.warningCount);
-        if(warningCount > config.maxWarnings){
-          process.exitCode = 1;
+            process.exitCode = 1;
             return;
+          }
+        });
+
+        // Exit code should return 1 when more than maximum number of warnings allowed
+        if(config.maxWarnings >=0){
+          let warningCount = 0;
+          bundle.getReport().forEach(report => warningCount += report.warningCount);
+          if(warningCount > config.maxWarnings){
+            process.exitCode = 1;
+            return;
+          }
         }
       }
     }

--- a/test/specs/stepHygiene.js
+++ b/test/specs/stepHygiene.js
@@ -1,0 +1,60 @@
+// stepHygiene.js
+// ------------------------------------------------------------------
+//
+/* jshint esversion:9, node:true, strict:implied */
+/* global process, console, Buffer, describe, it */
+
+const assert = require("assert"),
+      path = require("path"),
+      bl = require("../../lib/package/bundleLinter.js");
+
+describe(`ST002 - StepHygiene`, () => {
+  it('should generate the expected errors', () => {
+  let configuration = {
+        debug: true,
+        source: {
+          type: "filesystem",
+          path: path.resolve(__dirname, '../fixtures/resources/ST002-step-hygiene/apiproxy'),
+          bundleType: "apiproxy"
+        },
+        excluded: {},
+        setExitCode: false,
+        output: () => {} // suppress output
+      };
+
+    bl.lint(configuration, (bundle) => {
+      let items = bundle.getReport();
+      assert.ok(items);
+      assert.ok(items.length);
+      let proxyEndpointItems = items.filter( m => m.filePath.endsWith('endpoint1.xml'));
+      assert.equal(proxyEndpointItems.length, 1);
+      let st002Messages = proxyEndpointItems[0].messages.filter( m => m.ruleId == 'ST002');
+      assert.equal(st002Messages.length, 3);
+
+      let expected = [
+            {
+              line: 13,
+              column: 5,
+              message: "Multiple Name elements for Step"
+            },
+            {
+              line: 34,
+              column: 7,
+              message: "Multiple Condition elements for Step"
+            },
+            {
+              line: 57,
+              column: 7,
+              message: "Stray element (Step) under Step"
+            }
+          ];
+      expected.forEach( (item, ix) => {
+        Object.keys(item).forEach( key => {
+          assert.equal(st002Messages[ix][key], item[key], `case(${ix}) key(${key})`);
+        });
+      });
+
+    });
+  });
+
+});


### PR DESCRIPTION
- this change adds a config option, setExitCode which when present and false, disables process.exit() in the case where there are errors or the number of warnings exceeds the configured maximum. 
 
- also add tests for step hygiene (ST002), which exercises this option.