### PR TITLE
PO013 support .jshintignore files

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ The list of rules is a work in progress and expected to increase over time. As p
 | &nbsp; |:white_medium_square:| PO009 | Service Callout Target - Mgmt Server |  Targeting management server may result in higher than expected latency use with caution. |
 | &nbsp; |:white_medium_square:| PO010 | Service Callout Target - Target Server |  Encourage use of target servers. |
 | &nbsp; |:white_medium_square:| PO011 | Service Callout Target - Dynamic URLs |  Error on dynamic URLs in target server URL tag. |
-| &nbsp; |:white_medium_square:| PO012 | Service Callout Target - Script Target Node |  JSHint, ESLint. |
-| &nbsp; |:white_check_mark:| PO013 | Resource Call Out - Javascript |  JSHint, ESLint. |
+| &nbsp; |:white_medium_square:| PO012 | Service Callout Target - Script Target Node |  Not implemented. |
+| &nbsp; |:white_check_mark:| PO013 | Resource files - Javascript |  Run JSHint on .js, .jsc, or .json files in the resources directory. Supports .jshintrc and .jshintignore files. |
 | &nbsp; |:white_medium_square:| PO014 | Resource Call Out - Java |  PMD, Checkstyle. |
 | &nbsp; |:white_medium_square:| PO015 | Resource Call Out - Python |  Pylint. |
 | &nbsp; |:white_medium_square:| PO016 | Statistics Collector - duplicate variables |  Warn on duplicate variables. |

--- a/lib/package/plugins/PO013-jsHint.js
+++ b/lib/package/plugins/PO013-jsHint.js
@@ -13,8 +13,12 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+/* global process */
 
 const ruleId = require("../myUtil.js").getRuleId(),
+      path = require("path"),
+      fs = require("fs"),
+      minimatch = require("minimatch"),
       debug = require("debug")("apigeelint:" + ruleId);
 
 const plugin = {
@@ -39,6 +43,61 @@ const getMessageClass = function(s) {
         return "message";
       };
 
+const cat = (file) => fs.readFileSync(file).toString('utf-8');
+
+function findFile(name, cwd) {
+  cwd = cwd || process.cwd();
+  let filename = path.normalize(path.join(cwd, name));
+  if (fs.existsSync(filename)) {
+    return filename;
+  }
+  let parent = path.resolve(cwd, "../");
+  if (cwd === parent) {
+    return null;
+  }
+  return findFile(name, parent);
+}
+
+let ignores = [];
+
+function loadIgnores(cwd) {
+  let file = findFile(".jshintignore", cwd) || "";
+
+  if (!file) {
+    return [];
+  }
+  if (ignores[file]) {
+    return ignores[file];
+  }
+  let lines = (file ? cat(file) : "").split("\n");
+  debug("loadIgnores(): " + lines.join(', '));
+
+  ignores[file] = lines
+    .filter(line => !!line.trim() )
+    .map(line => {
+      if (line[0] === "!")
+        return "!" + path.resolve(path.dirname(file), line.substr(1).trim());
+      return path.join(path.dirname(file), line.trim());
+    });
+    return ignores[file];
+}
+
+const shouldIgnore = (filepath, patterns) => {
+        let result = patterns.some(pattern => {
+              let resolved = path.resolve(filepath);
+
+              return (filepath === pattern) ||
+            minimatch(resolved, pattern, { nocase: true, dot: true }) ||
+            (fs.statSync(resolved).isDirectory() &&
+             pattern.match(/^[^\/\\]*[\/\\]?$/) &&
+             filepath.match(new RegExp("^" + pattern + ".*")));
+            });
+
+        debug(`shouldIgnore(${filepath}) result:` + result);
+        return result;
+      };
+
+
 const onResource = function(resource, cb) {
   try {
     let fname = resource.getFileName();
@@ -48,35 +107,38 @@ const onResource = function(resource, cb) {
       fname.endsWith(".js") ||
       fname.endsWith(".json")
     ) {
-      let jsHintOptions = jsHintCli.getConfig(resource.path);
-      delete jsHintOptions.dirname;
-      if (Object.keys(jsHintOptions).length == 0) {
-        // default apigeelint options
-        debug('applying default options');
-        jsHintOptions = { maxerr: 50};
-      }
+      let ignores = loadIgnores(path.dirname(resource.path));
+      if ( ! shouldIgnore(resource.path, ignores)) {
+        let jsHintOptions = jsHintCli.getConfig(resource.path);
+        delete jsHintOptions.dirname;
+        if (Object.keys(jsHintOptions).length == 0) {
+          // default apigeelint options
+          debug('applying default options');
+          jsHintOptions = { maxerr: 50};
+        }
 
-      debug('options:' + JSON.stringify(jsHintOptions));
-      if ( !jshint.JSHINT(resource.getContents(), jsHintOptions) ) {
-        jshint.JSHINT.errors.forEach(function(error) {
-          if (error.code !== "W087") {
-            var result = {
-              plugin,
-              severity: (/E\d{3}/.test(error.code)) ? 2 : 1,
-              source: error.evidence,
-              line: error.line,
-              column: error.character,
-              message: getMessageClass(error.code) + ` ${error.code}: ${error.reason}`
-            };
-            resource.addMessage(result);
-            hadWarnErr=true;
-          }
-        });
+        debug('jshint options:' + JSON.stringify(jsHintOptions));
+        if ( !jshint.JSHINT(resource.getContents(), jsHintOptions) ) {
+          jshint.JSHINT.errors.forEach(function(error) {
+            if (error.code !== "W087") {
+              var result = {
+                    plugin,
+                    severity: (/E\d{3}/.test(error.code)) ? 2 : 1,
+                    source: error.evidence,
+                    line: error.line,
+                    column: error.character,
+                    message: getMessageClass(error.code) + ` ${error.code}: ${error.reason}`
+                  };
+              resource.addMessage(result);
+              hadWarnErr=true;
+            }
+          });
+        }
       }
     }
   } catch (e) {
     debugger;
-    debug("jshint error" + e);
+    debug("jshint error: " + e);
   }
   if (typeof cb == "function") {
     cb(null, hadWarnErr);


### PR DESCRIPTION
The plugin now searches "up" the directory tree for a .jshintignore file, and ignores files noted within it.