### PR TITLE
Added OAS resource folder to bundleStructure

### DIFF
--- a/lib/package/plugins/BN001-checkBundleStructure.js
+++ b/lib/package/plugins/BN001-checkBundleStructure.js
@@ -251,6 +251,17 @@ const bundleStructure = function (bundleType) {
             files: {
               extensions: ["wsdl"]
             }
+          },
+          {
+            name: "oas",
+            required: false,
+            files: {
+              extensions: [
+                "json",
+                "yaml",
+                "yml"
+              ]
+            }
           }
         ]
       }


### PR DESCRIPTION
Added optional resources/oas folder to bundleStructure as describe in #246 

Allows accepted folder structure described in https://cloud.google.com/apigee/docs/api-platform/reference/policies/oas-validation-policy