### PR TITLE
add support for oas and properties in bundle (BN001) plugin

### DIFF
--- a/lib/package/plugins/BN001-checkBundleStructure.js
+++ b/lib/package/plugins/BN001-checkBundleStructure.js
@@ -251,6 +251,26 @@ const bundleStructure = function (bundleType) {
             files: {
               extensions: ["wsdl"]
             }
+          },
+          {
+            name: "oas",
+            required: false,
+            files: {
+              extensions: [
+                "json",
+                "yaml",
+                "yml"
+              ]
+            }
+          },
+          {
+            name: "properties",
+            required: false,
+            files: {
+              extensions: [
+                "properties"
+              ]
+            }
           }
         ]
       }


### PR DESCRIPTION
this is to support new archetypes supported in apigee x/hybrid including oas and properties resource files