### PR TITLE
CC005 coerce param to string before testing

### DIFF
--- a/lib/package/plugins/CC005-unterminatedStrings.js
+++ b/lib/package/plugins/CC005-unterminatedStrings.js
@@ -60,6 +60,7 @@ const onCondition = function(condition, cb) {
 
         let constants = tokens.filter( t => t.type == 'constant');
         constants.forEach( t => {
+          t.value = String(t.value);
           if (t.value &&
               ((t.value.endsWith('"') && !t.value.startsWith('"')) ||
                ( !t.value.endsWith('"') && t.value.startsWith('"')) )


### PR DESCRIPTION
This fixes an exception that occurs with a condition like:
 `<Condition>(message.status.code &gt;= 500)</Condition>`