### PR TITLE
add ResourceURL to PO026 plugin

### DIFF
--- a/lib/package/plugins/PO026-assignVariableUsage.js
+++ b/lib/package/plugins/PO026-assignVariableUsage.js
@@ -39,7 +39,6 @@ const onBundle = function(bundle, cb) {
 };
 
 const onPolicy = function(policy, cb) {
-      debug( "configuration profile is: " + profile );
       let flagged = false;
       let ptype = policy.getType();
       if (ptype === "AssignMessage" || ptype === "RaiseFault") {
@@ -55,19 +54,18 @@ const onPolicy = function(policy, cb) {
             const addNodeMessage = (message) =>
                     addMessage(node.lineNumber, node.columnNumber, message);
 
-            debug( "Configuration profile is: " + profile );
+            debug(`Configuration profile is: ${profile}`);
+            let found = { Name:0, Ref:0, Value:0, Template:0 };
             if( profile === "apigeex") {
-              var found = { Name:0, Ref:0, Value:0, Template:0, PropertySetRef:0 };
-            } else {
-              var found = { Name:0, Ref:0, Value:0, Template:0 };
+              found = { ...found, PropertySetRef:0, ResourceURL:0 };
             }
+
             // Get the keys after Name
-            var str = Object.keys(found).toString();
-            var foundKeysStr = str.substring(str.indexOf(",")+1);
+            var foundKeysStr = Object.keys(found).filter(k => k != 'Name').join(',');
 
             const childNodes = xpath.select("*", node);
             if (childNodes.length == 0) {
-              addNodeMessage( "empty AssignVariable. Should have a Name child, and at least one of {" + foundKeysStr + "}." );
+              addNodeMessage(`empty AssignVariable. Should have a Name child, and at least one of {${foundKeysStr}}.` );
             }
             else {
               childNodes.forEach( (child, ix) => {
@@ -124,7 +122,7 @@ const onPolicy = function(policy, cb) {
                 }
               }
               if( foundAny === 0) {
-                addNodeMessage( "You should have at least one of: {" + foundKeysStr + "}");
+                addNodeMessage( `You should have at least one of: {${foundKeysStr}}`);
               }
             }
           });

--- a/test/fixtures/resources/PO026-assignVariable-resourceUrl/AM-AssignVariable-1.xml
+++ b/test/fixtures/resources/PO026-assignVariable-resourceUrl/AM-AssignVariable-1.xml
@@ -1,0 +1,6 @@
+<AssignMessage name='AM-AssignVariable-1'>
+  <AssignVariable>
+    <Name>assigned</Name>
+    <ResourceURL>jsc://settings.json</ResourceURL>
+  </AssignVariable>
+</AssignMessage>

--- a/test/specs/profile.js
+++ b/test/specs/profile.js
@@ -2,7 +2,7 @@
 // ------------------------------------------------------------------
 
 /* jshint esversion:9, node:true, strict:implied */
-/* global process, console, Buffer, describe, it */
+/* global describe, it */
 
 const assert = require("assert"),
       path = require("path"),
@@ -32,7 +32,7 @@ describe(`PO026 - PropertySetRef with --profile 'apigeex' for PO026-apigeex-prox
         if( item.filePath === "/apiproxy/policies/AM-config-properties.xml") {
             assert.equal(item.errorCount,0);
         }
-      }); 
+      });
     });
   });
 });
@@ -61,7 +61,51 @@ describe(`PO026 - PropertySetRef with --profile 'apigee' for PO026-apigeex-proxy
         if( item.filePath === "/apiproxy/policies/AM-config-properties.xml") {
             assert.equal(item.errorCount,6);
         }
-      }); 
+      });
     });
   });
+});
+
+const testID = "PO026",
+      Policy = require("../../lib/package/Policy.js"),
+      Dom = require("xmldom").DOMParser,
+      fs = require("fs"),
+      plugin = require(bl.resolvePlugin(testID));
+
+const resourceUrlTest =
+  (suffix, profile, cb) => {
+    let filename = `AM-AssignVariable-${suffix}.xml`;
+    it(`should correctly process ${filename} for profile ${profile}`, () => {
+      let fqfname = path.resolve(__dirname, '../fixtures/resources/PO026-assignVariable-resourceUrl', filename),
+          policyXml = fs.readFileSync(fqfname, 'utf-8'),
+          doc = new Dom().parseFromString(policyXml),
+          p = new Policy(doc.documentElement, this);
+
+      p.getElement = () => doc.documentElement;
+
+      plugin.onBundle({profile});
+      plugin.onPolicy(p, (e, foundIssues) => {
+        assert.equal(e, undefined, "should be undefined");
+        cb(p, foundIssues);
+      });
+    });
+  };
+
+
+describe(`PO026 - AssignVariable with ResourceURL`, () => {
+
+  resourceUrlTest('1', 'apigeex', (p, foundIssues) => {
+    assert.equal(foundIssues, false);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
+  });
+
+  resourceUrlTest('1', 'apigee', (p, foundIssues) => {
+    assert.equal(foundIssues, true);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 2);
+    assert.ok(p.getReport().messages[0].message.indexOf("stray element")>0);
+    assert.ok(p.getReport().messages[1].message.indexOf("You should have at least one of")>=0);
+  });
+
 });


### PR DESCRIPTION
There is a new syntax for AssignVariable, allowing `ResourceURL` as a source for the value.  It looks like this:

```
<AssignMessage name='AM-Value-From-ResourceURL'>
    <AssignVariable> 
        <Name>variable-to-set</Name> 
        <ResourceURL>xsl://name-of-stylesheet.xsl</ResourceURL> 
    </AssignVariable> 
</AssignMessage>
```
 
This change introduces handling for that element in the PO026 plugin. 
Also adds a new test for same, for 2 profiles.