### PR TITLE
deprecation warnings for ConcurrentRateLimit, OAuthV1 policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ The list of rules is a work in progress and expected to increase over time. As p
 | &nbsp; |:white_check_mark:| CC004 | Overly complex condition |  Condition complexity should be limited to fix number of variables and conjunctions. |
 | &nbsp; |:white_check_mark:| CC005 | unterminated strings in Condition |  Strings within a Condition element must be properly wrapped by double quotes. |
 | &nbsp; |:white_check_mark:| CC006 | Detect logical absurdities |  Conditions should not have internal logic conflicts - warn when these are detected. |
+| Deprecation | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
+| &nbsp; |:white_check_mark:| DC001 | ConcurrentRateLimit Policy Deprecation |  Check usage of deprecated policy ConcurrentRateLimit. |
+| &nbsp; |:white_check_mark:| DC002 | OAuth V1 Policies Deprecation |  Check usage of deprecated OAuth V1 policies. |
 
 From an implementation perspective the focus is on plugin support and flexibility over performance. Compute is cheap.
 

--- a/lib/package/plugins/DC001-deprecationConcurrentRateLimit.js
+++ b/lib/package/plugins/DC001-deprecationConcurrentRateLimit.js
@@ -1,0 +1,49 @@
+/*
+  Copyright 2019-2020 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const ruleId = require("../myUtil.js").getRuleId(),
+      debug = require("debug")("apigeelint:" + ruleId);
+
+const plugin = {
+        ruleId,
+        name: "ConcurrentRateLimit Policy Deprecation",
+        message: "Check usage of deprecated policy ConcurrentRateLimit.",
+        fatal: false,
+        severity: 1, //warning
+        nodeType: "Policy",
+        enabled: true
+      };
+    
+const onPolicy = function(policy, cb) {
+        let hadWarning = false;
+        if (policy.getType() === "ConcurrentRatelimit") {
+          hadWarning = true;
+          policy.addMessage({
+            plugin,
+            message:
+            'ConcurrentRateLimit Policy is deprecated. Refer to online deprecation notice for details.'
+          });          
+        }
+
+        if (typeof(cb) == 'function') {
+          cb(null, hadWarning);
+        }
+      };
+
+module.exports = {
+  plugin,
+  onPolicy
+};

--- a/lib/package/plugins/DC002-deprecationOAuthV1.js
+++ b/lib/package/plugins/DC002-deprecationOAuthV1.js
@@ -1,0 +1,51 @@
+/*
+  Copyright 2019-2020 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const ruleId = require("../myUtil.js").getRuleId(),
+      debug = require("debug")("apigeelint:" + ruleId);
+
+const plugin = {
+        ruleId,
+        name: "OAuth V1 Policies Deprecation",
+        message: "Check usage of deprecated OAuth V1 policies.",
+        fatal: false,
+        severity: 1, //warning
+        nodeType: "Policy",
+        enabled: true
+      };
+    
+const onPolicy = function(policy, cb) {
+        let hadWarning = false;
+        if (policy.getType() === "OAuthV1" ||
+            policy.getType() === "GetOAuthV1Info" ||
+            policy.getType() === "DeleteOAuthV1Info") {
+          hadWarning = true;
+          policy.addMessage({
+            plugin,
+            message:
+            'OAuth V1 policies are deprecated. Refer to online deprecation notice for details.'
+          });          
+        }
+
+        if (typeof(cb) == 'function') {
+          cb(null, hadWarning);
+        }
+      };
+
+module.exports = {
+  plugin,
+  onPolicy
+};

--- a/test/fixtures/resources/DC001-concurrentratelimit-deprecation/apiproxy/Products-API.xml
+++ b/test/fixtures/resources/DC001-concurrentratelimit-deprecation/apiproxy/Products-API.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<APIProxy revision="1" name="Products-API">
+    <Description>Products API</Description>
+</APIProxy>

--- a/test/fixtures/resources/DC001-concurrentratelimit-deprecation/apiproxy/policies/ConnectionThrottler.xml
+++ b/test/fixtures/resources/DC001-concurrentratelimit-deprecation/apiproxy/policies/ConnectionThrottler.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ConcurrentRatelimit name="ConnectionThrottler">
+    <AllowConnections count="200" ttl="5"/>
+    <Distributed>true</Distributed>
+    <StrictOnTtl>false</StrictOnTtl>
+    <TargetIdentifier name="default" ref="header/qparam/flow variables"/>
+</ConcurrentRatelimit>

--- a/test/fixtures/resources/DC001-concurrentratelimit-deprecation/apiproxy/proxies/default.xml
+++ b/test/fixtures/resources/DC001-concurrentratelimit-deprecation/apiproxy/proxies/default.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ProxyEndpoint name="default">
+  <PreFlow name="PreFlow">
+    <Request/>
+    <Response/>
+  </PreFlow>
+  <Flows>
+    <Flow name="GetProducts">
+      <Description/>
+      <Request/>
+      <Response/>
+      <Condition>(proxy.pathsuffix MatchesPath "/products") and (request.verb = "GET")</Condition>
+    </Flow>
+    <Flow name="GetProductDetails">
+      <Description/>
+      <Request/>
+      <Response/>
+      <Condition>(proxy.pathsuffix MatchesPath "/products/*") and (request.verb = "GET")</Condition>
+    </Flow>
+  </Flows>
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response/>
+  </PostFlow>
+  <HTTPProxyConnection>
+    <BasePath>/products-api</BasePath>
+    <VirtualHost>secure</VirtualHost>
+  </HTTPProxyConnection>
+  <RouteRule name="default">
+    <TargetEndpoint>default</TargetEndpoint>
+  </RouteRule>
+</ProxyEndpoint>

--- a/test/fixtures/resources/DC001-concurrentratelimit-deprecation/apiproxy/targets/default.xml
+++ b/test/fixtures/resources/DC001-concurrentratelimit-deprecation/apiproxy/targets/default.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<TargetEndpoint name="default">
+    <DefaultFaultRule name="DefaultFaultRule">
+        <Step>
+            <Name>ConnectionThrottler</Name>
+        </Step>
+        <AlwaysEnforce>true</AlwaysEnforce>
+    </DefaultFaultRule>
+    <PreFlow name="PreFlow">
+        <Request>
+            <Step>
+                <Name>ConnectionThrottler</Name>
+            </Step>
+        </Request>
+    </PreFlow>
+    <PostFlow name="PostFlow">
+        <Response>
+            <Step>
+                <Name>ConnectionThrottler</Name>
+            </Step>
+        </Response>
+    </PostFlow>
+    <Flows/>
+    <HTTPTargetConnection>
+        <LoadBalancer>
+            <Server name="pingstatus-v1"/>
+        </LoadBalancer>
+        <Path>{private.flow.target.basepath}/{flow.target.pathsuffix}</Path>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/DC002-deprecation-oauthv1/apiproxy/Products-API.xml
+++ b/test/fixtures/resources/DC002-deprecation-oauthv1/apiproxy/Products-API.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<APIProxy revision="1" name="Products-API">
+    <Description>Products API</Description>
+</APIProxy>

--- a/test/fixtures/resources/DC002-deprecation-oauthv1/apiproxy/policies/Delete-OAuth-v10-Info-1.xml
+++ b/test/fixtures/resources/DC002-deprecation-oauthv1/apiproxy/policies/Delete-OAuth-v10-Info-1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<DeleteOAuthV1Info async="false" continueOnError="false" enabled="true" name="Delete-OAuth-v10-Info-1">
+    <Properties/>
+    <AccessToken ref="request.header.token"></AccessToken>
+    <!--<RequestToken ref="request.header.token"></RequestToken>-->
+    <!--<Verifier ref="request.header.verifier"></Verifier>-->
+</DeleteOAuthV1Info>

--- a/test/fixtures/resources/DC002-deprecation-oauthv1/apiproxy/policies/Get-OAuth-v10a-Info-1.xml
+++ b/test/fixtures/resources/DC002-deprecation-oauthv1/apiproxy/policies/Get-OAuth-v10a-Info-1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GetOAuthV1Info async="false" continueOnError="false" enabled="true" name="Get-OAuth-v10a-Info-1">
+    <ConsumerKey ref="{flow.variable}">{value}</ConsumerKey>
+    <RequestToken ref="{flow.variable}">{request token}</RequestToken>
+    <AccessToken ref="{flow.variable}">{access token}</AccessToken>
+</GetOAuthV1Info>

--- a/test/fixtures/resources/DC002-deprecation-oauthv1/apiproxy/policies/OAuth-v10a-1.xml
+++ b/test/fixtures/resources/DC002-deprecation-oauthv1/apiproxy/policies/OAuth-v10a-1.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<OAuthV1 async="false" continueOnError="false" enabled="true" name="OAuth-v10a-1">
+    <Properties/>
+    <Operation>VerifyAccessToken</Operation>
+    <GenerateResponse enabled="true">
+        <Format>FORM_PARAM</Format>
+    </GenerateResponse>
+    <GenerateErrorResponse enabled="true">
+        <Format>FORM_PARAM</Format>
+        <Realm></Realm>
+    </GenerateErrorResponse>
+</OAuthV1>

--- a/test/fixtures/resources/DC002-deprecation-oauthv1/apiproxy/proxies/default.xml
+++ b/test/fixtures/resources/DC002-deprecation-oauthv1/apiproxy/proxies/default.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ProxyEndpoint name="default">
+    <PreFlow name="PreFlow">
+        <Request>
+            <Step>
+                <Name>OAuth-v10a-1</Name>
+            </Step>
+            <Step>
+                <Name>Get-OAuth-v10a-Info-1</Name>
+            </Step>
+            <Step>
+                <Name>Delete-OAuth-v10-Info-1</Name>
+            </Step>
+        </Request>
+        <Response/>
+    </PreFlow>
+    <Flows>
+        <Flow name="GetProducts">
+            <Description/>
+            <Request/>
+            <Response/>
+            <Condition>(proxy.pathsuffix MatchesPath "/products") and (request.verb = "GET")</Condition>
+        </Flow>
+        <Flow name="GetProductDetails">
+            <Description/>
+            <Request/>
+            <Response/>
+            <Condition>(proxy.pathsuffix MatchesPath "/products/*") and (request.verb = "GET")</Condition>
+        </Flow>
+    </Flows>
+    <PostFlow name="PostFlow">
+        <Request/>
+        <Response/>
+    </PostFlow>
+    <HTTPProxyConnection>
+        <BasePath>/products-api</BasePath>
+        <VirtualHost>secure</VirtualHost>
+    </HTTPProxyConnection>
+    <RouteRule name="default">
+        <TargetEndpoint>default</TargetEndpoint>
+    </RouteRule>
+</ProxyEndpoint>

--- a/test/fixtures/resources/DC002-deprecation-oauthv1/apiproxy/targets/default.xml
+++ b/test/fixtures/resources/DC002-deprecation-oauthv1/apiproxy/targets/default.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<TargetEndpoint name="default">
+    <PreFlow name="PreFlow">
+    </PreFlow>
+    <PostFlow name="PostFlow">
+    </PostFlow>
+    <Flows/>
+    <HTTPTargetConnection>
+        <LoadBalancer>
+            <Server name="pingstatus-v1"/>
+        </LoadBalancer>
+        <Path>{private.flow.target.basepath}/{flow.target.pathsuffix}</Path>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/specs/testDeprecationConcurretRatePolicy.js
+++ b/test/specs/testDeprecationConcurretRatePolicy.js
@@ -1,0 +1,49 @@
+/*
+  Copyright 2019-2020 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const assert = require("assert"),
+      path = require("path"),
+      bl = require("../../lib/package/bundleLinter.js");
+
+describe(`DC002 - ConcurrentRateLimit Policy is deprecated`, () => {
+  it('should generate the expected errors', () => {
+    let configuration = {
+          debug: true,
+          source: {
+            type: "filesystem",
+            path: path.resolve(__dirname, '../fixtures/resources/DC001-concurrentratelimit-deprecation/apiproxy'),
+            bundleType: "apiproxy"
+          },
+          excluded: {},
+          setExitCode: false,
+          output: () => {} // suppress output
+        };
+
+    bl.lint(configuration, (bundle) => {
+      let items = bundle.getReport();
+      assert.ok(items);
+      assert.ok(items.length);
+      let actualErrors = items.filter(item => item.messages && item.messages.length);
+      assert.equal(actualErrors.length, 1);
+      assert.ok(actualErrors[0].messages.length);
+      assert.equal(actualErrors[0].messages.length, 1);
+      assert.ok(actualErrors[0].messages[0].message);
+      assert.ok(actualErrors[0].messages[0].message.startsWith('ConcurrentRateLimit Policy is'),
+               actualErrors[0].messages[0].message);
+    });
+  });
+
+});

--- a/test/specs/testDeprecationOAuthv1.js
+++ b/test/specs/testDeprecationOAuthv1.js
@@ -1,0 +1,49 @@
+/*
+  Copyright 2019-2020 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const assert = require("assert"),
+      path = require("path"),
+      bl = require("../../lib/package/bundleLinter.js");
+
+describe(`DC001 - OAuth V1 policies are deprecated`, () => {
+  it('should generate the expected errors', () => {
+    let configuration = {
+          debug: true,
+          source: {
+            type: "filesystem",
+            path: path.resolve(__dirname, '../fixtures/resources/DC002-deprecation-oauthv1/apiproxy'),
+            bundleType: "apiproxy"
+          },
+          excluded: {},
+          setExitCode: false,
+          output: () => {} // suppress output
+        };
+
+    bl.lint(configuration, (bundle) => {
+      let items = bundle.getReport();
+      assert.ok(items);
+      assert.ok(items.length);
+      let actualErrors = items.filter(item => item.messages && item.messages.length);
+      assert.equal(actualErrors.length, 3);
+      assert.ok(actualErrors[0].messages.length);
+      assert.equal(actualErrors[0].messages.length, 1);
+      assert.ok(actualErrors[0].messages[0].message);
+      assert.ok(actualErrors[0].messages[0].message.startsWith('OAuth V1 policies are deprecated'),
+               actualErrors[0].messages[0].message);
+    });
+  });
+
+});


### PR DESCRIPTION
Add a new category of warnings to cover deprecated features 
- DC001 - ConcurrentRateLimit policy
- DC002 - 3 - OAuthV1 policies