### PR TITLE
Set chalk version to last compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@xmldom/xmldom": "^0.7.4",
     "babel-code-frame": "latest",
-    "chalk": "latest",
+    "chalk": "4.1.2",
     "commander": "^2.9.0",
     "debug": "latest",
     "decache": "latest",


### PR DESCRIPTION
Chalk latest is installed but is unsupported by this repo - advise setting to 4.1.2 until app can be modified to support Chalk latest.