### PR TITLE
Make sample extra policy work with unknown policies

### DIFF
--- a/externalPlugins/EX-PO007-NamingConventions.js
+++ b/externalPlugins/EX-PO007-NamingConventions.js
@@ -66,9 +66,17 @@ var plugin = {
 var onPolicy = function(policy, cb) {
   var displayName = policy.getDisplayName(),
     policyType = policy.getType(),
-    prefixes = policyMetaData[policyType].indications,
     found = false,
-    hadWarn = false;
+    hadWarn = false,
+    policyMeta = policyMetaData[policyType];
+    
+  if (!policyMeta) {
+      // No prefix defined for this policy
+      found=false;
+      hadWarn=false;
+      return;
+  }
+  var prefixes = policyMeta.indications;
 
   prefixes.some(function(prefix) {
     if (displayName.startsWith(prefix)) {


### PR DESCRIPTION
The sample extra check plugin fails if the checked apiproxy has an unknown policyType in it, like "DecodeJWT". This change makes the plugin ignore those policies.