### PR TITLE
PO031 new plugin to check Set/Payload in AssignMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ This is the current list:
 | &nbsp; |:white_check_mark:| PO028 | Policy Availability in profile | Check for policies available in particular profiles. |
 | &nbsp; |:white_check_mark:| PO029 | Known policy type | Check that all policies are of a known type. |
 | &nbsp; |:white_check_mark:| PO030 | ExpirySettings | ExpirySettings should use exactly one child element, no deprecated elements. |
+| &nbsp; |:white_check_mark:| PO031 | AssignMessage content-type | When assigning to Payload, you should also assign content-type, exactly once. |
 | FaultRules | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| FR001 | No Condition on FaultRule | It's not a best practice to have a FaultRule without an outer condition, which automatically makes the FaultRule true. |
 | &nbsp; |:white_check_mark:| FR002 | DefaultFaultRule Structure | DefaultFaultRule should have only supported child elements, at most one AlwaysEnforce element, and at most one Condition element. |

--- a/lib/package/plugins/PO031-assignMessage-ContentType.js
+++ b/lib/package/plugins/PO031-assignMessage-ContentType.js
@@ -1,0 +1,86 @@
+/*
+  Copyright 2019-2021 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const xpath = require("xpath"),
+      util = require('util'),
+      ruleId = require("../myUtil.js").getRuleId(),
+      debug = require("debug")("apigeelint:" + ruleId);
+
+const plugin = {
+        ruleId,
+        name: "AM/ContentType",
+        fatal: false,
+        severity: 1, // warning
+        nodeType: "Policy",
+        enabled: true
+      };
+
+const onPolicy = function(policy, cb) {
+        let flagged = false;
+        const addMessage = (line, column, message) => {
+                policy.addMessage({plugin, message, line, column});
+                flagged = true;
+              };
+        try {
+          if (policy.getType() === "AssignMessage") {
+            const nodeset = xpath.select("/AssignMessage/Set/Payload", policy.getElement());
+            if (nodeset.length>0) {
+              debug(`${policy.fileName} found ${nodeset.length} Set/Payload elements`);
+              if (nodeset.length>1) {
+                nodeset.slice(1).forEach( node =>
+                                          addMessage(node.lineNumber, node.columnNumber, "extraneous Set/Payload element"));
+              }
+              else {
+                const payloadElt = nodeset[0],
+                      ctypeAttr = xpath.select1('@contentType', payloadElt);
+
+                const headerSet = xpath.select("../Headers/Header[translate(@name, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz') = 'content-type']", payloadElt);
+                let headerElt;
+                if (headerSet.length>0) {
+                  if (headerSet.length>1) {
+                    debug(`${policy.fileName} found ${headerSet.length} Set/Headers/Header[@content-type] elements`);
+                    headerSet.slice(1).forEach( node =>
+                                                addMessage(node.lineNumber, node.columnNumber, "redundant Header element"));
+                  }
+                  else {
+                    headerElt = headerSet[0];
+                  }
+                }
+                if (ctypeAttr && headerElt) {
+                  addMessage(headerElt.lineNumber, headerElt.columnNumber, "redundant Header element. Set/Payload already specifies the content-type.");
+                }
+                if ( ! ctypeAttr && !headerElt) {
+                  addMessage(payloadElt.lineNumber, payloadElt.columnNumber, "Neither @contentType attribute nor a Header[@name='content-type'] has been defined.");
+                }
+              }
+            }
+            else {
+              debug(`${policy.fileName} found no Set/Payload elements`);
+            }
+          }
+          if (typeof(cb) == 'function') {
+            cb(null, flagged);
+          }
+        }
+        catch(e) {
+          debug(util.format(e));
+        }
+      };
+
+module.exports = {
+  plugin,
+  onPolicy
+};

--- a/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/fail/AM-Missing-ContentType.xml
+++ b/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/fail/AM-Missing-ContentType.xml
@@ -1,0 +1,15 @@
+<AssignMessage name='AM-1'>
+  <AssignTo createNew='true' transport='http' type='request'>contrivedMessage</AssignTo>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <Set>
+    <Headers>
+      <!-- wrong name value -->
+      <Header name='not-content-type'>text/plain</Header>
+    </Headers>
+    <!-- wrong attribute name -->
+    <Payload content-Type='text/plain'>
+payload-text-here
+</Payload>
+    <Verb>POST</Verb>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/fail/AM-RedundantHeader.xml
+++ b/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/fail/AM-RedundantHeader.xml
@@ -1,0 +1,13 @@
+<AssignMessage name='AM-1'>
+  <AssignTo createNew='true' transport='http' type='request'>contrivedMessage</AssignTo>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <Set>
+    <Headers>
+      <Header name='content-type'>text/plain</Header>
+    </Headers>
+    <Payload contentType='text/plain'>
+payload-text-here
+</Payload>
+    <Verb>POST</Verb>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/fail/AM-RedundantPayload.xml
+++ b/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/fail/AM-RedundantPayload.xml
@@ -1,0 +1,15 @@
+<AssignMessage name='AM-1'>
+  <AssignTo createNew='true' transport='http' type='request'>contrivedMessage</AssignTo>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <Set>
+    <Headers>
+      <Header name='foo'>does-not-matter</Header>
+    </Headers>
+    <Payload contentType='text/plain'>
+payload-text-here
+    </Payload>
+    <!-- this is redundant -->
+    <Payload/>
+    <Verb>POST</Verb>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/fail/messages.js
+++ b/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/fail/messages.js
@@ -1,0 +1,6 @@
+// These are the error messages only for the failed policies.
+module.exports = {
+  "AM-RedundantHeader.xml" : "redundant Header element. Set/Payload already specifies the content-type.",
+  "AM-Missing-ContentType.xml" : "Neither @contentType attribute nor a Header[@name='content-type'] has been defined.",
+  "AM-RedundantPayload.xml" : "extraneous Set/Payload element"
+};

--- a/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/pass/AM-ContentTypeAttribute.xml
+++ b/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/pass/AM-ContentTypeAttribute.xml
@@ -1,0 +1,13 @@
+<AssignMessage name='AM-1'>
+  <AssignTo createNew='true' transport='http' type='request'>contrivedMessage</AssignTo>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <Set>
+    <Headers>
+      <Header name='anything'>anything-else</Header>
+    </Headers>
+    <Payload contentType='text/plain'>
+payload-text-here
+</Payload>
+    <Verb>POST</Verb>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/pass/AM-NoPayload.xml
+++ b/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/pass/AM-NoPayload.xml
@@ -1,0 +1,10 @@
+<AssignMessage name='AM-1'>
+  <AssignTo createNew='true' transport='http' type='request'>contrivedMessage</AssignTo>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <Set>
+    <Headers>
+      <Header name='foo'>text/plain</Header>
+    </Headers>
+    <Verb>POST</Verb>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/pass/AM-SetHeader.xml
+++ b/test/fixtures/resources/PO031-AssignMessage-Payload-ContentType/pass/AM-SetHeader.xml
@@ -1,0 +1,13 @@
+<AssignMessage name='AM-1'>
+  <AssignTo createNew='true' transport='http' type='request'>contrivedMessage</AssignTo>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <Set>
+    <Headers>
+      <Header name='content-type'>text/plain</Header>
+    </Headers>
+    <Payload>
+payload-text-here
+</Payload>
+    <Verb>POST</Verb>
+  </Set>
+</AssignMessage>

--- a/test/specs/PO031-AssignMessage-Payload-ContentType.js
+++ b/test/specs/PO031-AssignMessage-Payload-ContentType.js
@@ -1,0 +1,111 @@
+/*
+  Copyright 2019-2021 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const testID = "PO031",
+      assert = require("assert"),
+      fs = require("fs"),
+      path = require("path"),
+      //util = require('util'),
+      bl = require("../../lib/package/bundleLinter.js"),
+      plugin = require(bl.resolvePlugin(testID)),
+      Policy = require("../../lib/package/Policy.js"),
+      Dom = require("@xmldom/xmldom").DOMParser,
+      rootDir = path.resolve(__dirname, '../fixtures/resources/PO031-AssignMessage-Payload-ContentType'),
+      debug = require("debug")("apigeelint:" + testID);
+
+const loadPolicy = function(sourceDir, shortFileName) {
+        let fqPath = path.join(sourceDir, shortFileName),
+            policyXml = fs.readFileSync(fqPath).toString('utf-8'),
+            doc = new Dom().parseFromString(policyXml),
+            p = new Policy(doc.documentElement, this);
+        p.fileName = shortFileName;
+        p.getElement = () => doc.documentElement;
+        return p;
+      };
+
+describe(`${testID} - Payload Content-Type looks good`, function() {
+  let sourceDir = path.join(rootDir, 'pass');
+  let testOne = (shortFileName) => {
+        it(`checks no error (${shortFileName})`, () => {
+          let policy = loadPolicy(sourceDir, shortFileName);
+          // I don't know why this it function must return a Promise, in order
+          // for the assertions to actually work.  It seems the similar tests
+          // for PO029 do not require this. Not clear why. But in any case, do
+          // not change this unless you're sure.
+          return new Promise(function(resolve, reject) {
+            plugin.onPolicy(policy, (e, foundIssues) => {
+              try {
+                assert.equal(e, undefined, "should be undefined");
+                assert.equal(foundIssues, false, "should be no issues");
+                let messages = policy.getReport().messages;
+                assert.ok(messages, "messages should exist");
+                assert.equal(messages.length, 0, "unexpected number of messages");
+              }
+              catch(ex) {
+                return reject(ex);
+              }
+              return resolve();
+            });
+          });
+        });
+      };
+
+  fs.readdirSync(sourceDir)
+    .filter( shortFileName => shortFileName.endsWith(".xml"))
+    .forEach( testOne );
+});
+
+describe(`${testID} - Payload content-type looks wrong`, () => {
+  let sourceDir = path.join(rootDir, 'fail');
+  const expectedErrorMessages = require(path.join(sourceDir, 'messages.js'));
+
+  let testOne = (shortFileName) => {
+        let policy = loadPolicy(sourceDir, shortFileName);
+        it(`checks expected error (${shortFileName})`, () => {
+          assert.ok(policy, "policy should exist");
+          // I don't know why this it function must return a Promise, in order
+          // for the assertions to actually work.  It seems the similar tests
+          // for PO029 do not require this. Not clear why. But in any case, do
+          // not change this unless you're sure.
+          return new Promise(function(resolve, reject) {
+            plugin.onPolicy(policy, (e, foundIssues) => {
+              try {
+                assert.equal(e, undefined, "should be undefined");
+                assert.equal(foundIssues, true, "should be issues");
+                let messages = policy.getReport().messages;
+                assert.ok(messages, "messages should exist");
+                assert.equal(messages.length, 1, "unexpected number of messages");
+                assert.ok(messages[0].message, 'did not find message member');
+                let expected = expectedErrorMessages[policy.fileName];
+                assert.ok(expected, 'test configuration failure: did not find an expected message');
+                assert.equal(messages[0].message, expected, 'did not find expected message');
+                debug(`message[0]: ${messages[0].message}`);
+              }
+              catch(ex) {
+                return reject(ex);
+              }
+              return resolve();
+            });
+          });
+        });
+      };
+
+  fs.readdirSync(sourceDir)
+    .filter( shortFileName => shortFileName.endsWith(".xml"))
+    .forEach( testOne );
+});


### PR DESCRIPTION
Assign a content-type if assigning a Payload.
Must not redundantly assign a content-type.

Also, an update to the README for this feature.