### PR TITLE
rework checks on Conditions for PO003 and PO004

### DIFF
--- a/lib/package/plugins/PO001-threatProtectionJSONConditionCheck.js
+++ b/lib/package/plugins/PO001-threatProtectionJSONConditionCheck.js
@@ -31,7 +31,7 @@ const plugin = {
     enabled: true
   },
   condRegExp =
-    "(response.content|response.form|request.content|request.form|message.content|message.form|request.verb|message.verb)";
+    "(response.content|response.formstring|request.content|request.formstring|message.content|message.formstring|request.verb|message.verb)";
 
 const checker = require('./_policyConditionCheck.js');
 

--- a/lib/package/plugins/PO003-extractJSONConditionCheck.js
+++ b/lib/package/plugins/PO003-extractJSONConditionCheck.js
@@ -18,8 +18,7 @@
 //| &nbsp; |:white_medium_square:| PO003 | Extract Variables with JSONPayload |  A check for a body element must be performed before policy execution. |
 
 const ruleId = require("../myUtil.js").getRuleId(),
-      debug = require("debug")("apigeelint:" + ruleId),
-      xpath = require("xpath");
+      debug = require("debug")("apigeelint:" + ruleId);
 
 const plugin = {
         ruleId,
@@ -32,90 +31,9 @@ const plugin = {
         enabled: true
       };
 
-const onPolicy = function(policy, cb) {
-        let condRegExp =
-        "(response\.content|response\.form|request\.content|request\.form|message\.content|message\.form|message\.verb|request\.verb)";
-
-  let flagged = false;
-  if (policy.getType() === "ExtractVariables") {
-    debug('found ExtractVariables policy');
-
-    if (policy.getSteps().length > 0) {
-      debug(`policy has ${policy.getSteps().length} steps`);
-      let jsonPayload = xpath.select(
-            "/ExtractVariables/JSONPayload/text()",
-            policy.getElement()
-          );
-
-      if (jsonPayload.length > 0) {
-        debug('is JSONPayload');
-
-        let sourceElement = xpath.select(
-              "/ExtractVariables/Source/text()",
-              policy.getElement()
-            );
-
-        if (sourceElement.length) {
-          let source = sourceElement[0].data;
-          condRegExp = !source.match(condRegExp) ? `${source}\.content` : condRegExp;
-          debug(`change condRegExp: ${condRegExp}`);
-        }
-
-        let hasBodyChecks =
-          policy.getSteps().every(step => {
-            // let util = require('util');
-            // debug('step ' + util.format(step));
-            let condition = step.getCondition();
-            if (condition) {
-              debug(`cond expression: [${condition.getExpression()}]`);
-            }
-            else {
-              debug('no Condition');
-            }
-            if (condition && condition.getExpression().match(condRegExp)) {
-              debug('sufficient condition');
-              return true;
-            }
-
-            let parent = step.parent;
-            if (parent && parent.getType() === "FlowPhase") {
-              parent = parent.parent;
-            }
-            if (parent && parent.getType() === "Flow") {
-              debug('parent is Flow');
-              condition = step.parent.getCondition();
-              if (condition && condition.getExpression().match(condRegExp)) {
-                debug('parent has sufficient condition');
-                return true;
-              }
-            }
-            debug('missing or insufficient condition');
-            return false;
-          });
-
-        if ( ! hasBodyChecks) {
-          flagged = true;
-          policy.addMessage({
-            plugin,
-            message:
-            "An appropriate check for a message body was not found on the enclosing Step or Flow."
-          });
-        }
-      }
-      else {
-        debug('not a JSONPayload')
-      }
-    }
-    else {
-      debug('not attached')
-    }
-  }
-  if (typeof(cb) == 'function') {
-    cb(null, flagged);
-  }
-};
+const checker = require('./_extractVariablesCheck.js').check;
 
 module.exports = {
   plugin,
-  onPolicy
+  onPolicy : checker(plugin, 'JSONPayload', debug)
 };

--- a/lib/package/plugins/PO004-extractXMLConditionCheck.js
+++ b/lib/package/plugins/PO004-extractXMLConditionCheck.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2020 Google LLC
+  Copyright 2019-2021 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,8 +17,7 @@
 //extractXMLConditionCheck
 //| &nbsp; |:white_check_mark:| PO004 | Extract Variables with XMLPayload |  A check for a body element must be performed before policy execution. |
 
-const xpath = require("xpath"),
-      ruleId = require("../myUtil.js").getRuleId(),
+const ruleId = require("../myUtil.js").getRuleId(),
       debug = require("debug")("apigeelint:" + ruleId);
 
 const plugin = {
@@ -32,60 +31,9 @@ const plugin = {
         enabled: true
       };
 
-const onPolicy = function(policy,cb) {
-        let condRegExp =
-    "(response.content|response.form|request.content|request.form|message.content|message.form|message.verb|request.verb)";
-        let hadWarning = false;
-        if (policy.getType() === "ExtractVariables") {
-          let xmlPayload = xpath.select(
-                "/ExtractVariables/XMLPayload/text()",
-                policy.getElement()
-              );
-
-          let sourceElement = xpath.select(
-                "/ExtractVariables/Source/text()",
-                policy.getElement()
-              );
-
-          if (sourceElement.length) {
-            let source = sourceElement[0].data;
-            condRegExp = !source.match(condRegExp) ? source : condRegExp;
-          }
-
-
-          if (xmlPayload.length > 0 && policy.getSteps().length > 0) {
-            let hasBodyChecks =
-              policy.getSteps().every( step => {
-                let condition = step.getCondition();
-                if (condition && condition.getExpression().match(condRegExp)) {
-                  return true;
-                }
-                // is the parent a flow? And does it check?
-                if (step.parent && step.parent.getType() === "Flow") {
-                  condition = step.parent.getCondition();
-                  if (condition && condition.getExpression().match(condRegExp)) {
-                    return true;
-                  }
-                }
-                return false;
-              });
-
-            if ( ! hasBodyChecks) {
-              hadWarning = true;
-              policy.addMessage({
-                plugin,
-                message:
-                "An appropriate check for a message body was not found on the enclosing Step or Flow."
-              });
-            }
-          }
-        }
-        if (typeof(cb) == 'function') {
-          cb(null, hadWarning);
-        }
-      };
+const checker = require('./_extractVariablesCheck.js').check;
 
 module.exports = {
   plugin,
-  onPolicy
+  onPolicy : checker(plugin, 'XMLPayload', debug)
 };

--- a/lib/package/plugins/_extractVariablesCheck.js
+++ b/lib/package/plugins/_extractVariablesCheck.js
@@ -1,0 +1,121 @@
+/*
+  Copyright 2019-2021 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const xpath = require("xpath");
+
+const stringNonNullCheckRegexp = (source) => `${source} *(!=|NotEquals|IsNot) *(\"\"|null)`;
+
+const messageCheckRegexp = (source) => stringNonNullCheckRegexp(`(${source}\.content|${source}.formstring)`);
+
+module.exports = {
+  check : (plugin, payloadType, debug) =>
+  function(policy, cb) {
+    let reKnownMessages = "^(request|response|message)$";
+    let condRegExp = "will.be.replaced";
+
+    let flagged = false;
+    if (policy.getType() === "ExtractVariables") {
+      debug('found ExtractVariables policy');
+      if (policy.getSteps().length > 0) {
+        debug(`policy has ${policy.getSteps().length} steps`);
+        let payload = xpath.select(
+              `/ExtractVariables/${payloadType}/text()`,
+              policy.getElement()
+            );
+
+        if (payload.length > 0) {
+          debug(`is ${payloadType}`);
+
+          let sourceElement = xpath.select(
+                "/ExtractVariables/Source/text()",
+                policy.getElement()
+              );
+
+          if (sourceElement.length) {
+            let source = sourceElement[0].data;
+            if (source.match(reKnownMessages)) {
+              condRegExp = messageCheckRegexp(source);
+            }
+            else {
+              // source is either a custom message, or a plain json string.
+              // Look for a check for either of those.
+              condRegExp = `(${messageCheckRegexp(source)}|${stringNonNullCheckRegexp(source)})`;
+            }
+          }
+          else {
+            // source is empty, ∴ implicitly use "message"
+            condRegExp = messageCheckRegexp('message');
+          }
+
+          debug(`condRegExp: ${condRegExp}`);
+          condRegExp = `^${condRegExp}$`;
+
+          let hasBodyChecks =
+            policy.getSteps().every(step => {
+              // let util = require('util');
+              // debug('step ' + util.format(step));
+              let condition = step.getCondition();
+              if (condition) {
+                debug(`cond expression: [${condition.getExpression()}]`);
+              }
+              else {
+                debug('no Condition');
+              }
+              if (condition && condition.getExpression().trim().match(condRegExp)) {
+                debug('sufficient condition');
+                return true;
+              }
+
+              let parent = step.parent;
+              if (parent && parent.getType() === "FlowPhase") {
+                parent = parent.parent;
+              }
+              if (parent && parent.getType() === "Flow") {
+                debug('parent is Flow');
+                condition = step.parent.getCondition();
+                debug(`parent cond expression: [${condition.getExpression()}]`);
+                if (condition && condition.getExpression().trim().match(condRegExp)) {
+                  debug('parent has sufficient condition');
+                  return true;
+                }
+              }
+              debug('missing or insufficient condition');
+              return false;
+            });
+
+          if ( ! hasBodyChecks) {
+            flagged = true;
+            policy.addMessage({
+              plugin,
+              message:
+              "An appropriate check for a message body was not found on the enclosing Step or Flow."
+            });
+          }
+        }
+        else {
+          debug('not a XMLPayload');
+        }
+      }
+      else {
+        debug('not attached');
+
+      }
+    }
+    if (typeof(cb) == 'function') {
+      cb(null, flagged);
+    }
+  }
+};


### PR DESCRIPTION
This change resolves #296 
  
The prior tests were checking only known message variables.
The ExtractVariables policy can also be used on arbitrary strings. The new checks consider that. Same consideration for PO004, which applies to XMLPayload.

This is a correction of an existing function, not a new capability. No change to readme is required.

Before merging it would be good to get confirmation from the original reporter.