### PR TITLE
new BN010 plugin to check for Missing policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ This is the current list:
 | &nbsp; |:white_check_mark:| BN007 | Bundle size - resource callouts. |  Large bundles are a symptom of poor design. A high number of resource callouts is indicative of underutilizing out of the box Apigee policies. |
 | &nbsp; |:white_medium_square:| BN008 | IgnoreUnresolvedVariables and FaultRules |  Use of IgnoreUnresolvedVariables without the use of FaultRules may lead to unexpected errors. |
 | &nbsp; |:white_check_mark:| BN009 | Statistics Collector - duplicate policies |  Warn on duplicate policies when no conditions are present or conditions are duplicates. |
+| &nbsp; |:white_check_mark:| BN010 | Missing policies | Issue an error if a referenced policy is not present in the bundle. |
 | Proxy Definition | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_medium_square:| PD001 | RouteRules to Targets | RouteRules should map to defined Targets |
 | &nbsp; |:white_check_mark:| PD002 | Unreachable Route Rules - defaults |  Only one RouteRule should be present without a condition |

--- a/lib/package/plugins/BN001-checkBundleStructure.js
+++ b/lib/package/plugins/BN001-checkBundleStructure.js
@@ -14,11 +14,6 @@
   limitations under the License.
 */
 
-//bundleStructure.js
-//for every policy check fileName per Apigee recommendations
-//for every policy check if fileName matches policyName
-//plugin methods and variables
-
 const fs = require("fs"),
       ruleId = require("../myUtil.js").getRuleId();
 

--- a/lib/package/plugins/BN006-policyCount.js
+++ b/lib/package/plugins/BN006-policyCount.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2020 Google LLC
+  Copyright 2019-2022 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,12 +14,8 @@
   limitations under the License.
 */
 
-//for every policy check fileName per Apigee recommendations
-//for every policy check if fileName matches policyName
-//plugin methods and variables
-
-const ruleId = require("../myUtil.js").getRuleId(),
-      debug = require("debug")("apigeelint:" + ruleId);
+const ruleId = require("../myUtil.js").getRuleId();
+      // debug = require("debug")("apigeelint:" + ruleId);
 
 const plugin = {
         ruleId,
@@ -32,29 +28,24 @@ const plugin = {
         enabled: true
       };
 
+const POLICY_COUNT_LIMIT = 100;
 
 const onBundle = function(bundle, cb) {
-  let limit = 100,
-      warnErr = false;
+  let flagged = false;
 
-  if (bundle.policies && bundle.policies.length > limit) {
+  if (bundle.policies && bundle.policies.length > POLICY_COUNT_LIMIT) {
     bundle.addMessage({
       plugin,
       message:
-        "Bundle size (" +
-        bundle.policies.length +
-        ") exceeds recommended limit of " +
-        limit +
-        ". Consider refactoring into two or more bundles. Large bundle take longer to deploy and are more difficult to debug and maintain."
+        `Policy count (${bundle.policies.length}) exceeds recommended limit of ${POLICY_COUNT_LIMIT}. ` +
+        `Consider refactoring into two or more bundles. Large bundles take longer to deploy and are more difficult to debug and maintain.`
     });
-    warnErr = true;
+    flagged = true;
   }
   if (typeof(cb) == 'function') {
-    cb(null, warnErr);
+    cb(null, flagged);
   }
 };
-
-//var checkBundle = function(bundle) {};
 
 module.exports = {
   plugin,

--- a/lib/package/plugins/BN010-missingPolicies.js
+++ b/lib/package/plugins/BN010-missingPolicies.js
@@ -1,0 +1,59 @@
+/*
+  Copyright 2019-2022 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const ruleId = require("../myUtil.js").getRuleId();
+
+const plugin = {
+        ruleId,
+        name: "Missing policies",
+        message: "Missing policies will prevent bundle import.",
+        fatal: false,
+        severity: 2, //1 == warn 2 == error
+        nodeType: "Bundle",
+        enabled: true
+      };
+
+let thisBundle = null;
+const onBundle = function(bundle, cb) {
+        thisBundle = bundle;
+        if (typeof(cb) == 'function') {
+          cb(null, false);
+        }
+      };
+
+const onStep =
+  function(step, cb) {
+    const source = step.getSource(),
+          stepName = step.getName();
+    let flagged = false,
+        found = thisBundle.getPolicies().find( policy => policy.getName() == stepName);
+    if (! found) {
+      let element = step.getElement(),
+          line = element.lineNumber,
+          column = element.columnNumber;
+      step.addMessage({ source, line, column, plugin, message: `Missing policy "${stepName}"`});
+      flagged = true;
+    }
+    if (typeof(cb) == 'function') {
+      cb(null, flagged);
+    }
+  };
+
+module.exports = {
+  plugin,
+  onBundle,
+  onStep
+};

--- a/test/fixtures/resources/BN010-missing-policy/apiproxy/BN010-missing-policies.xml
+++ b/test/fixtures/resources/BN010-missing-policy/apiproxy/BN010-missing-policies.xml
@@ -1,0 +1,10 @@
+<APIProxy revision="1" name="BN010-missing-policies">
+  <ConfigurationVersion minorVersion="0" majorVersion="4"/>
+  <CreatedAt>1489339923158</CreatedAt>
+  <CreatedBy>dino</CreatedBy>
+  <Description/>
+  <DisplayName>BN010-missing-policies</DisplayName>
+  <LastModifiedAt>1489340418969</LastModifiedAt>
+  <LastModifiedBy>orgAdmin</LastModifiedBy>
+  <TargetEndpoints/>
+</APIProxy>

--- a/test/fixtures/resources/BN010-missing-policy/apiproxy/policies/AM-CleanResponseHeaders.xml
+++ b/test/fixtures/resources/BN010-missing-policy/apiproxy/policies/AM-CleanResponseHeaders.xml
@@ -1,0 +1,5 @@
+<AssignMessage name='AM-CleanResponseHeaders'>
+  <Remove>
+    <Headers/>
+  </Remove>
+</AssignMessage>

--- a/test/fixtures/resources/BN010-missing-policy/apiproxy/policies/AM-InjectProxyVersionHeader.xml
+++ b/test/fixtures/resources/BN010-missing-policy/apiproxy/policies/AM-InjectProxyVersionHeader.xml
@@ -1,0 +1,7 @@
+<AssignMessage name="AM-InjectProxyVersionHeader">
+  <Set>
+    <Headers>
+      <Header name="apiproxy">{apiproxy.name} r{apiproxy.revision}</Header>
+    </Headers>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/BN010-missing-policy/apiproxy/policies/JS-1.xml
+++ b/test/fixtures/resources/BN010-missing-policy/apiproxy/policies/JS-1.xml
@@ -1,0 +1,16 @@
+<Javascript name='JS-1' timeLimit='200' >
+  <Source>
+    function getProp(setname, shortpropname) {
+      try {
+        var name = 'propertyset.' + setname + '.' + shortpropname;
+        var c = String(context.getVariable(name));
+        return c;
+      }
+      catch (e) {
+        return String(e);
+      }
+    }
+    var keys = ['value1','value2','bailiwick','identifier']
+    keys.forEach(function(k) {getProp('set1',k);});
+  </Source>
+</Javascript>

--- a/test/fixtures/resources/BN010-missing-policy/apiproxy/policies/RF-UnknownRequest.xml
+++ b/test/fixtures/resources/BN010-missing-policy/apiproxy/policies/RF-UnknownRequest.xml
@@ -1,0 +1,16 @@
+<RaiseFault name='RF-UnknownRequest'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <FaultResponse>
+    <Set>
+      <Payload contentType='application/json'>{
+  "error" : {
+    "code" : 404.01,
+    "message" : "that request was unknown; try a different request."
+  }
+}
+</Payload>
+      <StatusCode>404</StatusCode>
+      <ReasonPhrase>Not Found</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+</RaiseFault>

--- a/test/fixtures/resources/BN010-missing-policy/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/BN010-missing-policy/apiproxy/proxies/endpoint1.xml
@@ -1,0 +1,72 @@
+<ProxyEndpoint name="endpoint1">
+  <Description>Proxy Endpoint 1</Description>
+  <HTTPProxyConnection>
+    <BasePath>/BN010-missing-policies-example</BasePath>
+    <Properties/>
+    <VirtualHost>secure</VirtualHost>
+  </HTTPProxyConnection>
+
+  <FaultRules/>
+  <DefaultFaultRule name="fault-rule">
+    <Step>
+      <Name>AM-InjectProxyVersionHeader</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <PreFlow name="PreFlow">
+    <Request>
+      <Step>
+        <Name>JS-1</Name>
+      </Step>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-CleanResponseHeaders</Name>
+      </Step>
+    </Response>
+  </PreFlow>
+  <PostFlow name="PostFlow">
+    <Request>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-InjectProxyVersionHeader</Name>
+      </Step>
+    </Response>
+  </PostFlow>
+  <PostClientFlow name="PostClientFlow">
+    <Request>
+    </Request>
+    <Response>
+    </Response>
+  </PostClientFlow>
+
+  <Flows>
+
+    <Flow name="flow1">
+      <Request>
+      </Request>
+      <Response>
+        <Step>
+          <Name>AM-Response-1</Name>
+        </Step>
+      </Response>
+      <Condition>(proxy.pathsuffix MatchesPath "/t1") and (request.verb = "GET")</Condition>
+    </Flow>
+
+    <Flow name="unknown request">
+      <Request>
+        <Step>
+          <Name>RF-UnknownRequest</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+    </Flow>
+
+  </Flows>
+
+  <RouteRule name="NoRouteRule"/>
+
+</ProxyEndpoint>

--- a/test/specs/BN010-1.js
+++ b/test/specs/BN010-1.js
@@ -1,0 +1,53 @@
+/*
+  Copyright 2019-2022 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+/* global describe, it */
+
+const assert = require("assert"),
+      path = require("path"),
+      testID = "BN010",
+      bl = require("../../lib/package/bundleLinter.js");
+
+describe(`${testID} - bundle with reference to missing policy`, () => {
+  it('should generate the expected error', () => {
+    let configuration = {
+          debug: true,
+          source: {
+            type: "filesystem",
+            path: path.resolve(__dirname, '../fixtures/resources/BN010-missing-policy/apiproxy'),
+            bundleType: "apiproxy"
+          },
+          profile: 'apigee',
+          excluded: {},
+          setExitCode: false,
+          output: () => {} // suppress output
+        };
+
+    bl.lint(configuration, (bundle) => {
+      let items = bundle.getReport();
+      assert.ok(items);
+      assert.ok(items.length);
+      let actualErrors = items.filter(item => item.messages && item.messages.length &&
+                                      item.messages.find( m => m.ruleId == testID));
+      assert.equal(actualErrors.length, 1);
+      assert.ok(actualErrors[0].messages.length);
+      let diags = JSON.stringify(actualErrors[0].messages);
+      assert.equal(actualErrors[0].messages.length, 1, diags);
+      assert.ok(actualErrors[0].messages[0].message, diags);
+      assert.equal(actualErrors[0].messages[0].message, 'Missing policy "AM-Response-1"',
+               actualErrors[0].messages[0].message);
+    });
+  });
+});


### PR DESCRIPTION
new BN010 plugin checks for policies that are referenced in the bundle, but not present. 