### PR TITLE
Don't flag case-insensitive regex as lookaround in PO0018

### DIFF
--- a/lib/package/plugins/PO018-checkRegexLookAround.js
+++ b/lib/package/plugins/PO018-checkRegexLookAround.js
@@ -39,8 +39,8 @@ const onPolicy = function(policy, cb) {
   if (policy.getType() === "RegularExpressionProtection") {
     var patterns = xpath.select(".//Pattern/text()", policy.getElement());
     patterns.forEach(function(pattern) {
-      if (pattern.data.includes("(?")) {
-        //if the pattern includes ($
+      // if the pattern matches (? but not (?i)
+      if (/\(\?(?!i\))/.test(pattern.data)) {
         policy.addMessage({
           plugin,
           line: pattern.lineNumber,

--- a/test/specs/PO018-checkRegexLookAround.js
+++ b/test/specs/PO018-checkRegexLookAround.js
@@ -65,6 +65,18 @@ describe(`${testID} - ${plugin.plugin.name}`, function() {
     '<RegularExpressionProtection async="false" continueOnError="false" enabled="true" name="regExLookAround"><DisplayName>regExLookAround</DisplayName><Source>request</Source><IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables><URIPath><Pattern>(?/(@?[w_?w:*]+([[^]]+])*)?)+</Pattern></URIPath></RegularExpressionProtection>',
     true
   );
+
+  test(
+    3,
+    '<RegularExpressionProtection async="false" continueOnError="false" enabled="true" name="regExLookAround"><DisplayName>regExLookAround</DisplayName><Source>request</Source><IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables><URIPath><Pattern>((?i)/(@?[w_?w:*]+([[^]]+])*)?)+</Pattern></URIPath></RegularExpressionProtection>',
+    false
+  );
+
+  test(
+    4,
+    '<RegularExpressionProtection async="false" continueOnError="false" enabled="true" name="regExLookAround"><DisplayName>regExLookAround</DisplayName><Source>request</Source><IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables><URIPath><Pattern>(?i)(?/(@?[w_?w:*]+([[^]]+])*)?)+</Pattern></URIPath></RegularExpressionProtection>',
+    true
+  );
 });
 
 


### PR DESCRIPTION
The test for regexp lookarounds in PO0018 simply checks whether the string `(?` is present in the `<Pattern>` tag, without taking into account that the regexp might contain `(?i)` in order to flag it as case-insensitive. This change alters the condition to allow for that exception, ironically by using a negative lookahead to check whether the `(?` is followed by `i)`.