### PR TITLE
new plugin for CORS policy hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ This is the current list:
 | &nbsp; |:white_check_mark:| PO029 | Known policy type | Check that all policies are of a known type. |
 | &nbsp; |:white_check_mark:| PO030 | ExpirySettings | ExpirySettings should use exactly one child element, no deprecated elements. |
 | &nbsp; |:white_check_mark:| PO031 | AssignMessage content-type | When assigning to Payload, you should also assign content-type, exactly once. |
+| &nbsp; |:white_check_mark:| PO032 | CORS policy hygiene | In a CORS policy, wildcard origins should generate a warning. And other hygiene checks.|
 | FaultRules | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| FR001 | No Condition on FaultRule | Use Condition elements on FaultRules, unless it is the fallback rule. |
 | &nbsp; |:white_check_mark:| FR002 | DefaultFaultRule Structure | DefaultFaultRule should have only supported child elements, at most one AlwaysEnforce element, and at most one Condition element. |

--- a/lib/package/bundleLinter.js
+++ b/lib/package/bundleLinter.js
@@ -197,8 +197,12 @@ const resolvePlugin = idOrFilename => {
           }
         }
         else if (pluginIdRe1.test(idOrFilename)) {
-          let p = fs.readdirSync(path.resolve(getPluginPath())).find( p => p.startsWith(idOrFilename));
-          return p ? path.resolve(getPluginPath(), p) : null;
+          let p = fs.readdirSync(path.resolve(getPluginPath()))
+            .filter( p => p.startsWith(idOrFilename) && p.endsWith(".js"));
+          if (p.length>1) {
+            throw new Error("plugin conflict: " + JSON.stringify(p));
+          }
+          return p.length ? path.resolve(getPluginPath(), p[0]) : null;
         }
         return null;
       };

--- a/lib/package/plugins/PO032-CORS-hygiene.js
+++ b/lib/package/plugins/PO032-CORS-hygiene.js
@@ -23,7 +23,6 @@ const plugin = {
         ruleId,
         name: "CORS/hygiene",
         fatal: false,
-        severity: 1, // warning
         nodeType: "Policy",
         enabled: true
       };
@@ -34,35 +33,35 @@ function checkAllowOrigins(policy, addMessage) {
     debug(`${policy.fileName} found ${nodeset.length} AllowOrigins elements`);
     if (nodeset.length>1) {
       nodeset.slice(1).forEach( node =>
-                                addMessage(node.lineNumber, node.columnNumber, "extraneous AllowOrigins element"));
+                                addMessage.error(node.lineNumber, node.columnNumber, "extraneous AllowOrigins element"));
     }
     // check the 1st element (ideally it is the only one)
     let elt = nodeset[0],
-    originsText = xpath.select1('text()', elt);
+        originsText = xpath.select1('text()', elt);
     originsText = originsText && originsText.data.trim();
     let origins = originsText && originsText.split(',').map(x => x.trim()) || [];
     origins.forEach( o => {
       if (o) {
         if (o.trim() == '*') {
           if (origins.length == 1) {
-            addMessage(elt.lineNumber, elt.columnNumber, "using a wildcard for AllowOrigins defeats the purpose of CORS.");
+            addMessage.warn(elt.lineNumber, elt.columnNumber, "using a wildcard for AllowOrigins defeats the purpose of CORS.");
           }
           else {
-            addMessage(elt.lineNumber, elt.columnNumber, "do not use a wildcard for AllowOrigins as well as other specific origins.");
+            addMessage.error(elt.lineNumber, elt.columnNumber, "do not use a wildcard for AllowOrigins as well as other specific origins.");
           }
         }
         else if (o.endsWith('/')) {
-          addMessage(elt.lineNumber, elt.columnNumber, "The Origin should not end with a slash.");
+          addMessage.error(elt.lineNumber, elt.columnNumber, "The Origin should not end with a slash.");
         }
         else if (o == '{request.header.origin}') {
-          addMessage(elt.lineNumber, elt.columnNumber, "Using {request.header.origin} in AllowOrigins defeats the purpose of CORS.");
+          addMessage.warn(elt.lineNumber, elt.columnNumber, "Using {request.header.origin} in AllowOrigins defeats the purpose of CORS.");
         }
       }
     });
   }
   else {
     debug(`${policy.fileName} found no AllowOrigins elements`);
-    addMessage(policy.getElement().lineNumber, policy.getElement().columnNumber, "There is no AllowOrigins element. All cross-origin requests will fail.");
+    addMessage.warn(policy.getElement().lineNumber, policy.getElement().columnNumber, "There is no AllowOrigins element. All cross-origin requests will fail.");
   }
 }
 
@@ -72,7 +71,7 @@ function checkAllowCredentials(policy, addMessage) {
     debug(`${policy.fileName} found ${nodeset1.length} AllowCredentials elements`);
     if (nodeset1.length>1) {
       nodeset1.slice(1).forEach( node =>
-                                addMessage(node.lineNumber, node.columnNumber, "extraneous AllowCredentials element"));
+                                addMessage.error(node.lineNumber, node.columnNumber, "extraneous AllowCredentials element"));
     }
 
     // check the first one, ideally it is the only one
@@ -80,30 +79,16 @@ function checkAllowCredentials(policy, addMessage) {
         allowText = xpath.select1('text()', elt);
     allowText = allowText && allowText.data.trim();
     if ( ! allowText) {
-      addMessage(elt.lineNumber, elt.columnNumber, "missing value for AllowCredentials element.");
+      addMessage.error(elt.lineNumber, elt.columnNumber, "missing value for AllowCredentials element.");
     }
     else if (allowText != 'false' && allowText != 'true') {
-      addMessage(elt.lineNumber, elt.columnNumber, "invalid value for AllowCredentials element.");
+      addMessage.error(elt.lineNumber, elt.columnNumber, "invalid value for AllowCredentials element.");
     }
   }
-  // else {
-  //   debug(`${policy.fileName} found no AllowCredentials elements`);
-  //   // I had a belief that if there is an AllowHeaders that specifies Authorization,
-  //   // and no AllowCredentials element, the user agent would reject. But that's not so.
-  //   const nodeset2 = xpath.select("/CORS/AllowHeaders", policy.getElement());
-  //   if (nodeset2.length == 1) {
-  //     let elt = nodeset2[0],
-  //         headerText = xpath.select1('text()', elt),
-  //         headers = headerText.split(',').map(x => x.trim());
-  //     headers.forEach( h => {
-  //       if (h.toLowerCase() == 'authorization') {
-  //         // not sure if this is true, to be verified
-  //         addMessage(elt.lineNumber, elt.columnNumber,
-  //                    `If you specify ${h} in AllowHeaders, you must also specify <AllowCredentials>true</AllowCredentials>.`);
-  //       }
-  //     });
-  //   }
-  // }
+  // I had a belief that if there is an AllowHeaders that specifies
+  // Authorization, and no AllowCredentials element, the user agent would reject
+  // a call with an Authorization header. But according to my tests with Chrome,
+  // that's not so.
 }
 
 function checkAllowHeaders(policy, addMessage) {
@@ -120,27 +105,25 @@ function checkHeadersElement(verb, policy, addMessage) {
     debug(`${policy.fileName} found ${nodeset.length} ${elementName} elements`);
     if (nodeset.length>1) {
       nodeset.slice(1).forEach( node =>
-                                addMessage(node.lineNumber, node.columnNumber, `extraneous ${elementName} element`));
+                                addMessage.error(node.lineNumber, node.columnNumber, `extraneous ${elementName} element`));
+    }
+    // check the first one, ideally there is only one
+    let elt = nodeset[0],
+    allowText = xpath.select1('text()', elt);
+    allowText = allowText && allowText.data.trim();
+    if ( ! allowText) {
+      addMessage.error(elt.lineNumber, elt.columnNumber, `missing value for ${elementName} element.`);
     }
     else {
-      // there is exactly one
-      let elt = nodeset[0],
-          allowText = xpath.select1('text()', elt);
-      allowText = allowText && allowText.data.trim();
-      if ( ! allowText) {
-        addMessage(elt.lineNumber, elt.columnNumber, `missing value for ${elementName} element.`);
-      }
-      else {
-        let headers = allowText.split(',').map(x => x.trim()) || [];
-        headers.forEach( h => {
-          if ( ! h || h.indexOf(' ')>0) {
-            addMessage(elt.lineNumber, elt.columnNumber, `The value in the ${elementName} element is misformatted.`);
-          }
-          else if (h == '*' && headers.length != 0){
-            addMessage(elt.lineNumber, elt.columnNumber, `Do not use a wildcard as well as specific values in the ${elementName} element.`);
-          }
-        });
-      }
+      let headers = allowText.split(',').map(x => x.trim()) || [];
+      headers.forEach( h => {
+        if ( ! h || h.indexOf(' ')>0) {
+          addMessage.error(elt.lineNumber, elt.columnNumber, `The value in the ${elementName} element is misformatted.`);
+        }
+        else if (h == '*' && headers.length != 0){
+          addMessage.error(elt.lineNumber, elt.columnNumber, `Do not use a wildcard as well as specific values in the ${elementName} element.`);
+        }
+      });
     }
   }
 }
@@ -151,7 +134,7 @@ function checkAllowMethods(policy, addMessage) {
     debug(`${policy.fileName} found ${nodeset.length} AllowMethods elements`);
     if (nodeset.length>1) {
       nodeset.slice(1).forEach( node =>
-                                addMessage(node.lineNumber, node.columnNumber, "extraneous AllowMethods element"));
+                                addMessage.error(node.lineNumber, node.columnNumber, "extraneous AllowMethods element"));
     }
 
     // check the first one, ideally it is the only one
@@ -159,13 +142,13 @@ function checkAllowMethods(policy, addMessage) {
         allowText = xpath.select1('text()', elt);
     allowText = allowText && allowText.data.trim();
     if ( ! allowText) {
-      addMessage(elt.lineNumber, elt.columnNumber, "missing value for AllowMethods element.");
+      addMessage.error(elt.lineNumber, elt.columnNumber, "missing value for AllowMethods element.");
     }
     else {
       let methods = allowText.split(',').map(x => x.trim()) || [];
       methods.forEach( m => {
         if ( ! m || m.indexOf(' ')>0) {
-          addMessage(elt.lineNumber, elt.columnNumber, "The value in the AllowMethods element is misformatted.");
+          addMessage.error(elt.lineNumber, elt.columnNumber, "The value in the AllowMethods element is misformatted.");
         }
       });
     }
@@ -174,9 +157,15 @@ function checkAllowMethods(policy, addMessage) {
 
 const onPolicy = function(policy, cb) {
         let flagged = false;
-        const addMessage = (line, column, message) => {
-                policy.addMessage({plugin, message, line, column});
-                flagged = true;
+        const addMessage = {
+                warn: (line, column, message) => {
+                  policy.addMessage({plugin, message, line, column, severity: 1 /* warning */ });
+                  flagged = true;
+                },
+                error : (line, column, message) => {
+                  policy.addMessage({plugin, message, line, column, severity: 2 /* error */ });
+                  flagged = true;
+                }
               };
         if (policy.getType() === "CORS") {
           checkAllowOrigins(policy, addMessage);

--- a/lib/package/plugins/PO032-CORS-hygiene.js
+++ b/lib/package/plugins/PO032-CORS-hygiene.js
@@ -1,0 +1,196 @@
+/*
+  Copyright 2019-2022 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const xpath = require("xpath"),
+      util = require('util'),
+      ruleId = require("../myUtil.js").getRuleId(),
+      debug = require("debug")("apigeelint:" + ruleId);
+
+const plugin = {
+        ruleId,
+        name: "CORS/hygiene",
+        fatal: false,
+        severity: 1, // warning
+        nodeType: "Policy",
+        enabled: true
+      };
+
+function checkAllowOrigins(policy, addMessage) {
+  const nodeset = xpath.select("/CORS/AllowOrigins", policy.getElement());
+  if (nodeset.length>0) {
+    debug(`${policy.fileName} found ${nodeset.length} AllowOrigins elements`);
+    if (nodeset.length>1) {
+      nodeset.slice(1).forEach( node =>
+                                addMessage(node.lineNumber, node.columnNumber, "extraneous AllowOrigins element"));
+    }
+    // check the 1st element (ideally it is the only one)
+    let elt = nodeset[0],
+    originsText = xpath.select1('text()', elt);
+    originsText = originsText && originsText.data.trim();
+    let origins = originsText && originsText.split(',').map(x => x.trim()) || [];
+    origins.forEach( o => {
+      if (o) {
+        if (o.trim() == '*') {
+          if (origins.length == 1) {
+            addMessage(elt.lineNumber, elt.columnNumber, "using a wildcard for AllowOrigins defeats the purpose of CORS.");
+          }
+          else {
+            addMessage(elt.lineNumber, elt.columnNumber, "do not use a wildcard for AllowOrigins as well as other specific origins.");
+          }
+        }
+        else if (o.endsWith('/')) {
+          addMessage(elt.lineNumber, elt.columnNumber, "The Origin should not end with a slash.");
+        }
+        else if (o == '{request.header.origin}') {
+          addMessage(elt.lineNumber, elt.columnNumber, "Using {request.header.origin} in AllowOrigins defeats the purpose of CORS.");
+        }
+      }
+    });
+  }
+  else {
+    debug(`${policy.fileName} found no AllowOrigins elements`);
+    addMessage(policy.getElement().lineNumber, policy.getElement().columnNumber, "There is no AllowOrigins element. All cross-origin requests will fail.");
+  }
+}
+
+function checkAllowCredentials(policy, addMessage) {
+  const nodeset1 = xpath.select("/CORS/AllowCredentials", policy.getElement());
+  if (nodeset1.length>0) {
+    debug(`${policy.fileName} found ${nodeset1.length} AllowCredentials elements`);
+    if (nodeset1.length>1) {
+      nodeset1.slice(1).forEach( node =>
+                                addMessage(node.lineNumber, node.columnNumber, "extraneous AllowCredentials element"));
+    }
+
+    // check the first one, ideally it is the only one
+    let elt = nodeset1[0],
+        allowText = xpath.select1('text()', elt);
+    allowText = allowText && allowText.data.trim();
+    if ( ! allowText) {
+      addMessage(elt.lineNumber, elt.columnNumber, "missing value for AllowCredentials element.");
+    }
+    else if (allowText != 'false' && allowText != 'true') {
+      addMessage(elt.lineNumber, elt.columnNumber, "invalid value for AllowCredentials element.");
+    }
+  }
+  // else {
+  //   debug(`${policy.fileName} found no AllowCredentials elements`);
+  //   // I had a belief that if there is an AllowHeaders that specifies Authorization,
+  //   // and no AllowCredentials element, the user agent would reject. But that's not so.
+  //   const nodeset2 = xpath.select("/CORS/AllowHeaders", policy.getElement());
+  //   if (nodeset2.length == 1) {
+  //     let elt = nodeset2[0],
+  //         headerText = xpath.select1('text()', elt),
+  //         headers = headerText.split(',').map(x => x.trim());
+  //     headers.forEach( h => {
+  //       if (h.toLowerCase() == 'authorization') {
+  //         // not sure if this is true, to be verified
+  //         addMessage(elt.lineNumber, elt.columnNumber,
+  //                    `If you specify ${h} in AllowHeaders, you must also specify <AllowCredentials>true</AllowCredentials>.`);
+  //       }
+  //     });
+  //   }
+  // }
+}
+
+function checkAllowHeaders(policy, addMessage) {
+   checkHeadersElement('Allow', policy, addMessage) ;
+}
+function checkExposeHeaders(policy, addMessage) {
+   checkHeadersElement('Expose', policy, addMessage) ;
+}
+
+function checkHeadersElement(verb, policy, addMessage) {
+  const elementName = `${verb}Headers`; // AllowHeaders, ExposeHeaders
+  const nodeset = xpath.select(`/CORS/${elementName}`, policy.getElement());
+  if (nodeset.length>0) {
+    debug(`${policy.fileName} found ${nodeset.length} ${elementName} elements`);
+    if (nodeset.length>1) {
+      nodeset.slice(1).forEach( node =>
+                                addMessage(node.lineNumber, node.columnNumber, `extraneous ${elementName} element`));
+    }
+    else {
+      // there is exactly one
+      let elt = nodeset[0],
+          allowText = xpath.select1('text()', elt);
+      allowText = allowText && allowText.data.trim();
+      if ( ! allowText) {
+        addMessage(elt.lineNumber, elt.columnNumber, `missing value for ${elementName} element.`);
+      }
+      else {
+        let headers = allowText.split(',').map(x => x.trim()) || [];
+        headers.forEach( h => {
+          if ( ! h || h.indexOf(' ')>0) {
+            addMessage(elt.lineNumber, elt.columnNumber, `The value in the ${elementName} element is misformatted.`);
+          }
+          else if (h == '*' && headers.length != 0){
+            addMessage(elt.lineNumber, elt.columnNumber, `Do not use a wildcard as well as specific values in the ${elementName} element.`);
+          }
+        });
+      }
+    }
+  }
+}
+
+function checkAllowMethods(policy, addMessage) {
+  const nodeset = xpath.select("/CORS/AllowMethods", policy.getElement());
+  if (nodeset.length>0) {
+    debug(`${policy.fileName} found ${nodeset.length} AllowMethods elements`);
+    if (nodeset.length>1) {
+      nodeset.slice(1).forEach( node =>
+                                addMessage(node.lineNumber, node.columnNumber, "extraneous AllowMethods element"));
+    }
+
+    // check the first one, ideally it is the only one
+    let elt = nodeset[0],
+        allowText = xpath.select1('text()', elt);
+    allowText = allowText && allowText.data.trim();
+    if ( ! allowText) {
+      addMessage(elt.lineNumber, elt.columnNumber, "missing value for AllowMethods element.");
+    }
+    else {
+      let methods = allowText.split(',').map(x => x.trim()) || [];
+      methods.forEach( m => {
+        if ( ! m || m.indexOf(' ')>0) {
+          addMessage(elt.lineNumber, elt.columnNumber, "The value in the AllowMethods element is misformatted.");
+        }
+      });
+    }
+  }
+}
+
+const onPolicy = function(policy, cb) {
+        let flagged = false;
+        const addMessage = (line, column, message) => {
+                policy.addMessage({plugin, message, line, column});
+                flagged = true;
+              };
+        if (policy.getType() === "CORS") {
+          checkAllowOrigins(policy, addMessage);
+          checkAllowCredentials(policy, addMessage);
+          checkAllowHeaders(policy, addMessage);
+          checkAllowMethods(policy, addMessage);
+          checkExposeHeaders(policy, addMessage);
+        }
+        if (typeof(cb) == 'function') {
+          cb(null, flagged);
+        }
+      };
+
+module.exports = {
+  plugin,
+  onPolicy
+};

--- a/test/fixtures/resources/PO032/fail/AllowCredentials-Duplicated.xml
+++ b/test/fixtures/resources/PO032/fail/AllowCredentials-Duplicated.xml
@@ -1,0 +1,12 @@
+<CORS name="AllowCredentials-Duplicated">
+  <AllowOrigins>https://dinochiesa.github.io</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <!-- Two AllowHeaders elements -->
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <AllowCredentials>true</AllowCredentials>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/AllowCredentials-invalid-value.xml
+++ b/test/fixtures/resources/PO032/fail/AllowCredentials-invalid-value.xml
@@ -1,0 +1,10 @@
+<CORS name="AllowCredentials-invalid-value">
+  <AllowOrigins>https://dinochiesa.github.io</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>invalid</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/AllowCredentials-missing-value.xml
+++ b/test/fixtures/resources/PO032/fail/AllowCredentials-missing-value.xml
@@ -1,0 +1,10 @@
+<CORS name="AllowCredentials-missing-value">
+  <AllowOrigins>https://dinochiesa.github.io</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials></AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/AllowHeaders-Duplicated.xml
+++ b/test/fixtures/resources/PO032/fail/AllowHeaders-Duplicated.xml
@@ -1,0 +1,12 @@
+<CORS name="AllowHeaders-Duplicated">
+  <AllowOrigins>https://dinochiesa.github.io</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <!-- Two AllowHeaders elements -->
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <AllowHeaders>foo,bar</AllowHeaders>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/AllowHeaders-Misformatted.xml
+++ b/test/fixtures/resources/PO032/fail/AllowHeaders-Misformatted.xml
@@ -1,0 +1,11 @@
+<CORS name="AllowHeaders-Misformatted" >
+  <AllowOrigins>https://dinochiesa.github.io</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <!-- missing comma in headers -->
+  <AllowHeaders>origin, x-requested-with content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/AllowMethods-Duplicated.xml
+++ b/test/fixtures/resources/PO032/fail/AllowMethods-Duplicated.xml
@@ -1,0 +1,12 @@
+<CORS name="AllowMethods-Duplicated">
+  <AllowOrigins>https://dinochiesa.github.io</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <!-- Two AllowHeaders elements -->
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <AllowMethods>GET,POST</AllowMethods>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/AllowMethods-Misformatted.xml
+++ b/test/fixtures/resources/PO032/fail/AllowMethods-Misformatted.xml
@@ -1,0 +1,11 @@
+<CORS name="AllowMethods-Misformatted" >
+  <AllowOrigins>https://dinochiesa.github.io</AllowOrigins>
+  <!-- missing comma in methods -->
+  <AllowMethods>GET, POST, PUT DELETE</AllowMethods>
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/AllowMethods-missing-value.xml
+++ b/test/fixtures/resources/PO032/fail/AllowMethods-missing-value.xml
@@ -1,0 +1,10 @@
+<CORS name="AllowMethods-missing-value" >
+  <AllowOrigins>https://dinochiesa.github.io</AllowOrigins>
+  <AllowMethods></AllowMethods>
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/AllowOrigin-Multiple-with-Wildcard.xml
+++ b/test/fixtures/resources/PO032/fail/AllowOrigin-Multiple-with-Wildcard.xml
@@ -1,0 +1,11 @@
+<CORS name="AllowOrigin-Multiple-with-Wildcard" >
+  <!-- multiple origins including wildcard -->
+  <AllowOrigins>https://foo.bar, *</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/AllowOrigin-Origin-ends-with-slash.xml
+++ b/test/fixtures/resources/PO032/fail/AllowOrigin-Origin-ends-with-slash.xml
@@ -1,0 +1,11 @@
+<CORS name="AllowOrigin-Origin-ends-with-slash" >
+  <AllowOrigins>https://dinochiesa.github.io/</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <!-- missing comma in headers -->
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/AllowOrigin-Wildcard.xml
+++ b/test/fixtures/resources/PO032/fail/AllowOrigin-Wildcard.xml
@@ -1,0 +1,11 @@
+<CORS name="AllowOrigin-Wildcard" >
+  <!-- wildcard origin -->
+  <AllowOrigins>*</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/AllowOrigin-request-header-origin.xml
+++ b/test/fixtures/resources/PO032/fail/AllowOrigin-request-header-origin.xml
@@ -1,0 +1,11 @@
+<CORS name="AllowOrigin-request-header-origin" >
+  <!-- request.header.origin defeats the purpose -->
+  <AllowOrigins>{request.header.origin}</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/ExposeHeaders-Dupe.xml
+++ b/test/fixtures/resources/PO032/fail/ExposeHeaders-Dupe.xml
@@ -1,0 +1,12 @@
+<CORS name="ExposeHeaders-Dupe">
+  <AllowOrigins>https://dinochiesa.github.io</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <!-- Two ExposeHeaders elements -->
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <ExposeHeaders>apiproxy</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/test/fixtures/resources/PO032/fail/messages.js
+++ b/test/fixtures/resources/PO032/fail/messages.js
@@ -1,0 +1,16 @@
+// These are the error messages only for the failed policies.
+module.exports = {
+  "AllowHeaders-Misformatted.xml" : "The value in the AllowHeaders element is misformatted.",
+  "AllowHeaders-Duplicated.xml" : "extraneous AllowHeaders element",
+  "AllowCredentials-Duplicated.xml" : "extraneous AllowCredentials element",
+  "AllowOrigin-Origin-ends-with-slash.xml" : "The Origin should not end with a slash.",
+  "AllowOrigin-Wildcard.xml" : "using a wildcard for AllowOrigins defeats the purpose of CORS.",
+  "AllowMethods-Duplicated.xml": "extraneous AllowMethods element",
+  "AllowMethods-Misformatted.xml" : "The value in the AllowMethods element is misformatted.",
+  "AllowMethods-missing-value.xml" : "missing value for AllowMethods element.",
+  "AllowOrigin-Multiple-with-Wildcard.xml": "do not use a wildcard for AllowOrigins as well as other specific origins.",
+  "AllowOrigin-request-header-origin.xml" : "Using {request.header.origin} in AllowOrigins defeats the purpose of CORS.",
+  "AllowCredentials-invalid-value.xml" : "invalid value for AllowCredentials element.",
+  "AllowCredentials-missing-value.xml" : "missing value for AllowCredentials element.",
+  "ExposeHeaders-Dupe.xml" : "extraneous ExposeHeaders element"
+};

--- a/test/fixtures/resources/PO032/pass/CORS-1.xml
+++ b/test/fixtures/resources/PO032/pass/CORS-1.xml
@@ -1,0 +1,11 @@
+<CORS name="CORS-1" enabled="true">
+  <!--    <AllowOrigins>{request.header.origin}</AllowOrigins> -->
+  <AllowOrigins>https://dinochiesa.github.io</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/test/fixtures/resources/PO032/pass/CORS-Multiple-Origins.xml
+++ b/test/fixtures/resources/PO032/pass/CORS-Multiple-Origins.xml
@@ -1,0 +1,10 @@
+<CORS name="CORS-Multiple-Origins-with-Wildcard" >
+  <AllowOrigins>https://foo.bar, https://example.org</AllowOrigins>
+  <AllowMethods>GET, POST, PUT, DELETE</AllowMethods>
+  <AllowHeaders>origin, x-requested-with, content-type</AllowHeaders>
+  <ExposeHeaders>via, x-request-id</ExposeHeaders>
+  <MaxAge>180</MaxAge>
+  <AllowCredentials>true</AllowCredentials>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/test/specs/PO032-CORS-hygiene-test.js
+++ b/test/specs/PO032-CORS-hygiene-test.js
@@ -1,0 +1,92 @@
+/*
+  Copyright 2019-2022 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const testID = "PO032",
+      assert = require("assert"),
+      fs = require("fs"),
+      util = require('util'),
+      path = require("path"),
+      bl = require("../../lib/package/bundleLinter.js"),
+      plugin = require(bl.resolvePlugin(testID)),
+      Policy = require("../../lib/package/Policy.js"),
+      Dom = require("@xmldom/xmldom").DOMParser,
+      rootDir = path.resolve(__dirname, '../fixtures/resources/PO032'),
+      debug = require("debug")("apigeelint:" + testID);
+
+const loadPolicy = (sourceDir, shortFileName) => {
+    let fqPath = path.join(sourceDir, shortFileName),
+        policyXml = fs.readFileSync(fqPath).toString('utf-8'),
+        doc = new Dom().parseFromString(policyXml),
+        p = new Policy(doc.documentElement, this);
+        p.getElement = () => doc.documentElement;
+        p.fileName = shortFileName;
+        return p;
+  };
+
+describe(`${testID} - policy passes hygiene evaluation`, function() {
+  let sourceDir = path.join(rootDir, 'pass');
+  let testOne = (shortFileName) => {
+        let policy = loadPolicy(sourceDir, shortFileName);
+        let policyType = policy.getType();
+        it(`check ${shortFileName} passes`, () => {
+          assert.notEqual(policyType, undefined, `${policyType} should be defined`);
+          plugin.onPolicy(policy, (e, foundIssues) => {
+            assert.equal(e, undefined, "should be undefined");
+            assert.equal(foundIssues, false, "should be no issues");
+            let messages = policy.getReport().messages;
+            assert.ok(messages, "messages should exist");
+            assert.equal(messages.length, 0, "unexpected number of messages");
+          });
+        });
+      };
+
+  fs.readdirSync(sourceDir)
+    .filter( shortFileName => shortFileName.endsWith(".xml"))
+    .forEach( testOne );
+
+});
+
+describe(`${testID} - policy does not pass hygiene evaluation`, () => {
+  let sourceDir = path.join(rootDir, 'fail');
+  const expectedErrorMessages = require(path.join(sourceDir, 'messages.js'));
+  let testOne = (shortFileName) => {
+        let policy = loadPolicy(sourceDir, shortFileName);
+        let policyType = policy.getType();
+        it(`check ${shortFileName} throws error`, () => {
+          assert.notEqual(policyType, undefined, `${policyType} should be defined`);
+          plugin.onPolicy(policy, (e, foundIssues) => {
+            assert.equal(undefined, e, "should be undefined");
+            assert.equal(true, foundIssues, "should be issues");
+            let messages = policy.getReport().messages;
+            assert.ok(messages, "messages should exist");
+            //console.log(util.format(messages));
+            assert.equal(1, messages.length, "unexpected number of messages");
+            assert.ok(messages[0].message, 'did not find message member');
+            let expected = expectedErrorMessages[policy.fileName];
+            assert.ok(expected, 'test configuration failure: did not find an expected message');
+            assert.equal(expected, messages[0].message, 'did not find expected message');
+            debug(`message[0]: ${messages[0].message}`);
+          });
+        });
+      };
+
+  fs.readdirSync(sourceDir)
+    .filter( shortFileName => shortFileName.endsWith(".xml"))
+    .forEach( testOne );
+
+});


### PR DESCRIPTION
This is a new plugin, to check the hygiene of the CORS policy. 

errors:
- for any origins that end in slash
- for elements that are duplicated
- for values that are misformatted

warnings:
- use wildcard for AllowOrigins
- use {request.header.origin} for AllowOrigins
- if AllowOrigins does not exist

The warning for "wildcard for AllowOrigins" may trigger often, especially for proxies in development. 