### PR TITLE
Fix for #331

### DIFF
--- a/lib/package/Endpoint.js
+++ b/lib/package/Endpoint.js
@@ -204,7 +204,7 @@ Endpoint.prototype.getHTTPTargetConnection = function() {
   if (!this.httpTargetConnection) {
     var doc = xpath.select("./HTTPTargetConnection", this.element),
       ep = this;
-    if (doc) {
+    if (doc && doc.length>0) { //need to check if HTTPTargetConnection exist as its not required when using HostedTargets (Issue 331)
         ep.httpTargetConnection = new HTTPTargetConnection(doc[0], ep);
     }
   }

--- a/lib/package/plugins/EP002-misplacedElements.js
+++ b/lib/package/plugins/EP002-misplacedElements.js
@@ -29,6 +29,14 @@ const plugin = {
         enabled: true
       };
 
+let bundleProfile = "apigee";
+const onBundle = function(bundle, cb) {
+  if (bundle.profile) { bundleProfile = bundle.profile; }
+  if (typeof cb == "function") {
+    cb(null, false);
+  }
+};
+      
 const onProxyEndpoint = function(endpoint, cb) {
         debug('onProxyEndpoint');
         let checker = new EndpointChecker(endpoint, true);
@@ -162,11 +170,18 @@ class EndpointChecker {
 
       // exactly one of LocalTarget and HTTPTarget is required
       if (! self.isProxyEndpoint) {
-        let condition = ['LocalTargetConnection', 'HTTPTargetConnection'].map(n => `self::${n}`).join(' or ');
+        let condition = [];
+        if(bundleProfile != "apigee")
+          condition = ['LocalTargetConnection', 'HTTPTargetConnection'].map(n => `self::${n}`).join(' or ');
+        else 
+          condition = ['LocalTargetConnection', 'HTTPTargetConnection', 'HostedTarget'].map(n => `self::${n}`).join(' or '); //Apigee Edge can have <HostedTarget> without HTTPTargetConnection or LocalTargetConnection 
         let targetChildren = xpath.select(`*[${condition}]`, self.endpoint.element);
         if (targetChildren.length == 0) {
           self.flagged = true;
-          _markEndpoint(self.endpoint, `Missing a required *TargetConnection`, 1, 2);
+          if(bundleProfile != "apigee")
+            _markEndpoint(self.endpoint, `Missing a required *TargetConnection`, 1, 2);
+          else 
+            _markEndpoint(self.endpoint, `Missing a required *TargetConnection or HostedTarget`, 1, 2);
         }
         else if (targetChildren.length != 1) {
           self.flagged = true;
@@ -213,6 +228,7 @@ class EndpointChecker {
 
 module.exports = {
   plugin,
+  onBundle,
   onProxyEndpoint,
   onTargetEndpoint
 };


### PR DESCRIPTION
Fix for 331
- For Apigee Edge, with HostedTarget, the HTTPTargetConnection becomes optional in the TargetEndpoint
- Added checks in the EP002 plugin to check for 'LocalTargetConnection', 'HTTPTargetConnection', 'HostedTarget' if the profile is Apigee