### PR TITLE
PO026 incorrectly flags PropertySetRefs with variables at each end

### DIFF
--- a/lib/package/plugins/PO026-assignVariableUsage.js
+++ b/lib/package/plugins/PO026-assignVariableUsage.js
@@ -102,7 +102,7 @@ const onPolicy = function(policy, cb) {
               else if (found.PropertySetRef == 1) {
                 let textnode = xpath.select("PropertySetRef/text()", node),
                     refText = textnode[0] && textnode[0].data;
-                if (refText && refText.startsWith('{') && refText.endsWith('}')) {
+                if (refText && refText.startsWith('{') && refText.indexOf('}') === refText.length - 1) {
                   addMessage(textnode[0].lineNumber, textnode[0].columnNumber, "The text of the PropertySetRef element must be a variable name, should not be wrapped in curlies");
                 }
               }

--- a/test/fixtures/resources/PO026-assignVariable-propertySetRef/AM-AssignVariable-1.xml
+++ b/test/fixtures/resources/PO026-assignVariable-propertySetRef/AM-AssignVariable-1.xml
@@ -1,0 +1,9 @@
+<AssignMessage name='AM-AssignVariable-1'>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <AssignVariable>
+    <!-- the PropertySeteRef element should contain a template
+         that isn't a single variable -->
+    <Name>invalid_propertysetref</Name>
+    <PropertySetRef>{curlies_are_wrong_here}</PropertySetRef>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/PO026-assignVariable-propertySetRef/AM-AssignVariable-2.xml
+++ b/test/fixtures/resources/PO026-assignVariable-propertySetRef/AM-AssignVariable-2.xml
@@ -1,0 +1,9 @@
+<AssignMessage name='AM-AssignVariable-2'>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <AssignVariable>
+    <!-- the PropertySeteRef element should contain a template
+         that isn't a single variable -->
+    <Name>valid_propertysetref</Name>
+    <PropertySetRef>{curlies_are_fine_here}-suffix</PropertySetRef>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/PO026-assignVariable-propertySetRef/AM-AssignVariable-3.xml
+++ b/test/fixtures/resources/PO026-assignVariable-propertySetRef/AM-AssignVariable-3.xml
@@ -1,0 +1,9 @@
+<AssignMessage name='AM-AssignVariable-3'>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <AssignVariable>
+    <!-- the PropertySeteRef element should contain a template
+         that isn't a single variable -->
+    <Name>valid_propertysetref</Name>
+    <PropertySetRef>{curlies_are_fine_here}-fixed-string-{another_curly}</PropertySetRef>
+  </AssignVariable>
+</AssignMessage>

--- a/test/specs/PO026-profile.js
+++ b/test/specs/PO026-profile.js
@@ -83,11 +83,11 @@ const testID = "PO026",
       fs = require("fs"),
       plugin = require(bl.resolvePlugin(testID));
 
-const resourceUrlTest =
-  (suffix, profile, cb) => {
+const singlePolicyFileTest =
+  (fixtureDir, suffix, profile, cb) => {
     let filename = `AM-AssignVariable-${suffix}.xml`;
     it(`should correctly process ${filename} for profile ${profile}`, () => {
-      let fqfname = path.resolve(__dirname, '../fixtures/resources/PO026-assignVariable-resourceUrl', filename),
+      let fqfname = path.resolve(__dirname, '../fixtures/resources/', fixtureDir, filename),
           policyXml = fs.readFileSync(fqfname, 'utf-8'),
           doc = new Dom().parseFromString(policyXml),
           p = new Policy(doc.documentElement, this);
@@ -105,13 +105,13 @@ const resourceUrlTest =
 
 describe(`PO026 - AssignVariable with ResourceURL`, () => {
 
-  resourceUrlTest('1', 'apigeex', (p, foundIssues) => {
+  singlePolicyFileTest('PO026-assignVariable-resourceUrl', '1', 'apigeex', (p, foundIssues) => {
     assert.equal(foundIssues, false);
     assert.ok(p.getReport().messages, "messages undefined");
     assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
   });
 
-  resourceUrlTest('1', 'apigee', (p, foundIssues) => {
+  singlePolicyFileTest('PO026-assignVariable-resourceUrl', '1', 'apigee', (p, foundIssues) => {
     assert.equal(foundIssues, true);
     assert.ok(p.getReport().messages, "messages undefined");
     assert.equal(p.getReport().messages.length, 2);
@@ -119,4 +119,24 @@ describe(`PO026 - AssignVariable with ResourceURL`, () => {
     assert.ok(p.getReport().messages[1].message.indexOf("You should have at least one of")>=0);
   });
 
+});
+
+describe(`PO026 - AssignVariable with PropertySetRef`, () => {
+
+  singlePolicyFileTest('PO026-assignVariable-propertySetRef', '1', 'apigeex', (p, foundIssues) => {
+    assert.equal(foundIssues, true);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 1);
+    assert.ok(p.getReport().messages[0].message === "The text of the PropertySetRef element must be a variable name, should not be wrapped in curlies");
+  });
+  singlePolicyFileTest('PO026-assignVariable-propertySetRef', '2', 'apigeex', (p, foundIssues) => {
+    assert.equal(foundIssues, false);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
+  });
+  singlePolicyFileTest('PO026-assignVariable-propertySetRef', '3', 'apigeex', (p, foundIssues) => {
+    assert.equal(foundIssues, false);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
+  });
 });


### PR DESCRIPTION
The PropertySetRef validation in PO026 only looks at the first and last characters in the string, without considering what comes in between. This PR changes the logic to instead look at whether the first character is `{` and the first index of `}` is at the end of the string.