### PR TITLE
fix: allow curlies in PropertySetRef

### DIFF
--- a/lib/package/plugins/PO026-assignVariableUsage.js
+++ b/lib/package/plugins/PO026-assignVariableUsage.js
@@ -19,6 +19,7 @@
 const xpath = require("xpath"),
       util = require('util'),
       ruleId = require("../myUtil.js").getRuleId(),
+      pluginUtil = require('./_pluginUtil.js'),
       debug = require("debug")("apigeelint:" + ruleId);
 
 const plugin = {
@@ -99,9 +100,35 @@ const onPolicy = function(policy, cb) {
               if (found.PropertySetRef > 1) {
                 addNodeMessage("There is more than one PropertySetRef element");
               }
+              else if (found.PropertySetRef == 1) {
+                const textnode = xpath.select("PropertySetRef/text()", node),
+                      psrText = textnode[0] && textnode[0].data;
+                if ( ! psrText) {
+                  addMessage(textnode[0].lineNumber, textnode[0].columnNumber,
+                             "The text of the PropertySetRef element must not be empty");
+                }
+                if ( ! pluginUtil.isValidTemplate(psrText)) {
+                  addMessage(textnode[0].lineNumber, textnode[0].columnNumber,
+                             "The text of the PropertySetRef element must be a valid message template");
+                }
+                else if ( !pluginUtil.isValidPropertySetRef(psrText)) {
+                  addMessage(textnode[0].lineNumber, textnode[0].columnNumber,
+                             "The text of the PropertySetRef element must resolve to a string that contains exactly one dot");
+                }
+              }
 
               if (found.Template > 1) {
                 addNodeMessage("There is more than one Template element");
+              }
+              else if (found.Template == 1) {
+                const textnode = xpath.select("Template/text()", node),
+                      templateText = textnode[0] && textnode[0].data;
+                if (templateText) {
+                  if ( ! pluginUtil.isValidTemplate(templateText)) {
+                    addMessage(textnode[0].lineNumber, textnode[0].columnNumber,
+                             "The text of the Template element must be a valid message template");
+                  }
+                }
               }
 
               if (found.Value > 1) {

--- a/lib/package/plugins/PO026-assignVariableUsage.js
+++ b/lib/package/plugins/PO026-assignVariableUsage.js
@@ -40,7 +40,7 @@ const onBundle = function(bundle, cb) {
 
 const onPolicy = function(policy, cb) {
       let flagged = false;
-      let ptype = policy.getType();
+      const ptype = policy.getType();
       if (ptype === "AssignMessage" || ptype === "RaiseFault") {
         const addMessage = (line, column, message) => {
               policy.addMessage({plugin, message, line, column});
@@ -61,16 +61,16 @@ const onPolicy = function(policy, cb) {
             }
 
             // Get the keys after Name
-            var foundKeysStr = Object.keys(found).filter(k => k != 'Name').join(',');
+            const foundKeysStr = Object.keys(found).filter(k => k != 'Name').join(',');
 
             const childNodes = xpath.select("*", node);
             if (childNodes.length == 0) {
               addNodeMessage(`empty AssignVariable. Should have a Name child, and at least one of {${foundKeysStr}}.` );
             }
             else {
-              childNodes.forEach( (child, ix) => {
+              childNodes.forEach( (child, _ix) => {
                 debug(util.format(child));
-                if (found.hasOwnProperty(child.tagName)) {
+                if (typeof found[child.tagName] !== 'undefined') {
                   found[child.tagName]++;
                 }
                 else {
@@ -81,7 +81,7 @@ const onPolicy = function(policy, cb) {
               if (found.Name > 1) {
                 addNodeMessage("There is more than one Name element");
               }
-              else if ( found.Name == 0) {
+              else if (found.Name == 0) {
                 addNodeMessage("There is no Name element");
               }
 
@@ -89,22 +89,15 @@ const onPolicy = function(policy, cb) {
                 addNodeMessage("There is more than one Ref element");
               }
               else if (found.Ref == 1) {
-                let textnode = xpath.select("Ref/text()", node),
-                    refText = textnode[0] && textnode[0].data;
-                if (refText && refText.startsWith('{') && refText.endsWith('}')) {
-                  addMessage(textnode[0].lineNumber, textnode[0].columnNumber, "The text of the Ref element must be a variable name, should not be wrapped in curlies");
+                const textnode = xpath.select("Ref/text()", node),
+                      refText = textnode[0] && textnode[0].data;
+                if (refText && (refText.includes('{') || refText.includes('}'))) {
+                  addMessage(textnode[0].lineNumber, textnode[0].columnNumber, "The text of the Ref element must be a variable name, should not include curlies");
                 }
               }
 
               if (found.PropertySetRef > 1) {
                 addNodeMessage("There is more than one PropertySetRef element");
-              }
-              else if (found.PropertySetRef == 1) {
-                let textnode = xpath.select("PropertySetRef/text()", node),
-                    refText = textnode[0] && textnode[0].data;
-                if (refText && refText.startsWith('{') && refText.endsWith('}')) {
-                  addMessage(textnode[0].lineNumber, textnode[0].columnNumber, "The text of the PropertySetRef element must be a variable name, should not be wrapped in curlies");
-                }
               }
 
               if (found.Template > 1) {
@@ -115,9 +108,10 @@ const onPolicy = function(policy, cb) {
                 addNodeMessage("There is more than one Value element");
               }
 
-              var foundAny = 0;
-              for( var key in found ) {
-                if( found.hasOwnProperty(key) && key != 'Name') {
+              let foundAny = 0;
+              let key;
+              for( key in found ) {
+                if( found[key] && key != 'Name') {
                   foundAny += found[key];
                 }
               }

--- a/lib/package/plugins/_pluginUtil.js
+++ b/lib/package/plugins/_pluginUtil.js
@@ -1,0 +1,91 @@
+
+const STATES = {
+        OUTSIDE_CURLY: 0,
+        INSIDE_CURLY_NO_TEXT: 1,
+        INSIDE_CURLY: 2,
+        INSIDE_FUNCTION_NO_TEXT: 3,
+        INSIDE_FUNCTION: 4
+      };
+
+const isValidTemplate = (expr) => {
+        let state = STATES.OUTSIDE_CURLY;
+        for (const ch of expr) {
+          switch (state) {
+          case STATES.OUTSIDE_CURLY:
+            if (ch == '{') {
+              state = STATES.INSIDE_CURLY_NO_TEXT;
+            }
+            if (ch == '}') {
+              return false;
+            }
+            break;
+
+          case STATES.INSIDE_CURLY_NO_TEXT:
+            if (ch == '}' || ch == '{' || ch == '[' || ch == '(') {
+              return false;
+            }
+            state = STATES.INSIDE_CURLY;
+            break;
+
+          case STATES.INSIDE_CURLY:
+            if (ch == '{' || ch == '[' || ch == ')') {
+              return false;
+            }
+            if (ch == '(') {
+              state = STATES.INSIDE_FUNCTION_NO_TEXT;
+            }
+            if (ch == '}') {
+              state = STATES.OUTSIDE_CURLY;
+            }
+            break;
+
+          case STATES.INSIDE_FUNCTION_NO_TEXT:
+            if (ch == '{' || ch == '[' || ch == '(' || ch == ')' || ch == '}' || ch == ']') {
+              return false;
+            }
+            state = STATES.INSIDE_FUNCTION;
+            break;
+
+          case STATES.INSIDE_FUNCTION:
+            if (ch == '{' || ch == '[' || ch == '(') {
+              return false;
+            }
+            if (ch == ')') {
+              state = STATES.AWAITING_CLOSE_CURLY;
+            }
+            break;
+
+          case STATES.AWAITING_CLOSE_CURLY:
+            if (ch != '}') {
+              return false;
+            }
+            state = STATES.OUTSIDE_CURLY;
+            break;
+
+          default:
+            // should not happen
+            return false;
+          }
+        }
+        return state == STATES.OUTSIDE_CURLY;
+      };
+
+const isValidPropertySetRef = (expr) => {
+        if ( ! isValidTemplate(expr)) {
+          return false;
+        }
+        if (expr.includes('{')) {
+          // There is a variable reference.
+          // Simulate a variable substitution; the result must have AT MOST one dot.
+          const r = new RegExp('{[^}]+}', 'g'),
+                result = expr.replaceAll(r, 'xxx');
+          return (result.match(/\./g) || []).length <= 1;
+        }
+        // No variable reference; the expression must have exactly one dot.
+        return (expr.match(/\./g) || []).length == 1;
+      };
+
+module.exports = {
+  isValidTemplate,
+  isValidPropertySetRef
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,33 +1,33 @@
 {
   "name": "apigeelint",
-  "version": "2.39.0",
+  "version": "2.40.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "apigeelint",
-      "version": "2.39.0",
+      "version": "2.40.0",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.4",
-        "babel-code-frame": "*",
+        "babel-code-frame": "latest",
         "chalk": "4.1.2",
         "commander": "^2.9.0",
-        "debug": "*",
-        "decompress": "*",
-        "eslint": "*",
-        "js-yaml": "*",
+        "debug": "latest",
+        "decompress": "latest",
+        "eslint": "latest",
+        "js-yaml": "latest",
         "jshint": "^2.10.1",
-        "jsonschema": "*",
+        "jsonschema": "latest",
         "lodash": "^4.17.21",
         "minimatch": "^3.0.4",
         "path": ">= 0.11.14",
-        "pdfmake": "*",
-        "pluralize": "*",
+        "pdfmake": "latest",
+        "pluralize": "latest",
         "strip-ansi": "^6.0.1",
-        "table": "*",
-        "text-table": "*",
-        "xpath": "*"
+        "table": "latest",
+        "text-table": "latest",
+        "xpath": "latest"
       },
       "bin": {
         "apigeelint": "cli.js"

--- a/test/fixtures/resources/PO026-apigeex-proxy/apiproxy/policies/AM-config-properties.xml
+++ b/test/fixtures/resources/PO026-apigeex-proxy/apiproxy/policies/AM-config-properties.xml
@@ -5,12 +5,7 @@
         <Name>private.flow.target.basepath</Name>
         <PropertySetRef>{apiproxy.name}.target_basepath</PropertySetRef>
     </AssignVariable>
-    <!--
-    <AssignVariable>
-        <Name>property.flow.target_basepath</Name>
-        <PropertySetRef>{apiproxy.name}.target_basepath</PropertySetRef>
-    </AssignVariable>
-    -->
+
     <AssignVariable>
         <Name>property.logging</Name>
         <PropertySetRef>{apiproxy.name}.logging</PropertySetRef>
@@ -19,20 +14,10 @@
         <Name>property.logging_url</Name>
         <PropertySetRef>{apiproxy.name}.logging_url</PropertySetRef>
     </AssignVariable>
-    <!-- debug apigeelint 
+
     <AssignVariable>
-        <Value>property.flow.target_basepath</Value>
-        <PropertySetRef>{apiproxy.name}.target_basepath</PropertySetRef>
+        <Name>effective-setting</Name>
+        <PropertySetRef>{variable-that-resolves-to-a-string}</PropertySetRef>
     </AssignVariable>
-    <AssignVariable>
-        <Name>private.flow.target.basepath</Name>
-        <Reference>{apiproxy.name}.target_basepath</Reference>
-    </AssignVariable>
-    <AssignVariable>
-        <Variable>private.flow.target.basepath</Variable>
-        <Reference>{apiproxy.name}.target_basepath</Reference>
-    </AssignVariable>
-    <AssignVariable>
-    </AssignVariable>
-    -->
+
 </AssignMessage>

--- a/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-1.xml
+++ b/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-1.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='PropertySetRef-1'>
+  <AssignVariable>
+    <Name>assigned</Name>
+    <!-- ok: could resolve to a string with exactly one dot -->
+    <PropertySetRef>{foobar}</PropertySetRef>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-2.xml
+++ b/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-2.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='PropertySetRef-2'>
+  <AssignVariable>
+    <Name>assigned</Name>
+    <!-- error: invalid template -->
+    <PropertySetRef>{}</PropertySetRef>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-3.xml
+++ b/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-3.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='PropertySetRef-3'>
+  <AssignVariable>
+    <Name>assigned</Name>
+    <!-- ok: could resolve to a thing with exactly one dot -->
+    <PropertySetRef>{apiproxy.name}.logging_url</PropertySetRef>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-4.xml
+++ b/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-4.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='PropertySetRef-4'>
+  <AssignVariable>
+    <Name>assigned</Name>
+    <!-- error: too many dots -->
+    <PropertySetRef>apiproxy.name.logging_url</PropertySetRef>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-5.xml
+++ b/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-5.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='PropertySetRef-5'>
+  <AssignVariable>
+    <Name>assigned</Name>
+    <!-- ok: one dot -->
+    <PropertySetRef>settings.logging_url</PropertySetRef>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-6.xml
+++ b/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-6.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='PropertySetRef-6'>
+  <AssignVariable>
+    <Name>assigned</Name>
+    <!-- ok: who knows what this will resolve to -->
+    <PropertySetRef>{var1}{var2}{var3}</PropertySetRef>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-7.xml
+++ b/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-7.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='PropertySetRef-7'>
+  <AssignVariable>
+    <Name>assigned</Name>
+    <!-- error: for sure this will resolve to a thing with more than one dot.  -->
+    <PropertySetRef>{var1}.{var2}.{var3}</PropertySetRef>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-8.xml
+++ b/test/fixtures/resources/PO026-assignVariable-policies/PropertySetRef-8.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='PropertySetRef-8'>
+  <AssignVariable>
+    <Name>assigned</Name>
+    <!-- ok: this could resolve to a thing with exactly one dot.  -->
+    <PropertySetRef>{flow.var1}.{flow.var2}</PropertySetRef>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/PO026-assignVariable-policies/ResourceUrl.xml
+++ b/test/fixtures/resources/PO026-assignVariable-policies/ResourceUrl.xml
@@ -1,4 +1,4 @@
-<AssignMessage name='AM-AssignVariable-1'>
+<AssignMessage name='AM-AssignVariable-ResourceUrl'>
   <AssignVariable>
     <Name>assigned</Name>
     <ResourceURL>jsc://settings.json</ResourceURL>

--- a/test/specs/BN001-xsdResourceTest.js
+++ b/test/specs/BN001-xsdResourceTest.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2023 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -19,11 +19,12 @@
 
 const assert = require("assert"),
       path = require("path"),
+      debug = require("debug")("apigeelint:BN001-test"),
       bl = require("../../lib/package/bundleLinter.js");
 
 describe(`BN001 - bundle with XSD resource`, () => {
   it('should generate the expected errors', () => {
-    let configuration = {
+    const configuration = {
           debug: true,
           source: {
             type: "filesystem",
@@ -37,10 +38,12 @@ describe(`BN001 - bundle with XSD resource`, () => {
         };
 
     bl.lint(configuration, (bundle) => {
-      let items = bundle.getReport();
+      const items = bundle.getReport();
       assert.ok(items);
       assert.ok(items.length);
-      let actualErrors = items.filter(item => item.messages && item.messages.length);
+      const actualErrors = items.filter(item => item.messages && item.messages.length);
+      debug(JSON.stringify(actualErrors, null, 2));
+
       assert.equal(actualErrors.length, 1);
       assert.ok(actualErrors[0].messages.length);
       assert.equal(actualErrors[0].messages.length, 1);

--- a/test/specs/PO026-assignVariableHygiene.js
+++ b/test/specs/PO026-assignVariableHygiene.js
@@ -22,7 +22,7 @@ const assert = require("assert"),
 
 describe(`PO026 - AssignVariableHygiene`, () => {
   it('should generate the expected errors', () => {
-    let configuration = {
+    const configuration = {
           debug: true,
           source: {
             type: "filesystem",
@@ -35,11 +35,11 @@ describe(`PO026 - AssignVariableHygiene`, () => {
         };
 
     bl.lint(configuration, (bundle) => {
-      let items = bundle.getReport();
+      const items = bundle.getReport();
       assert.ok(items);
       assert.ok(items.length);
 
-      let expected = {
+      const expected = {
             'AM-AssignVariable-MissingNameElement.xml' : [
               {
                 message: "There is no Name element",
@@ -56,7 +56,7 @@ describe(`PO026 - AssignVariableHygiene`, () => {
             ],
             'AM-AssignVariable-RefWithCurlies.xml' : [
               {
-                message: "The text of the Ref element must be a variable name, should not be wrapped in curlies",
+                message: "The text of the Ref element must be a variable name, should not include curlies",
                 line: 7,
                 column: 10
               }
@@ -73,7 +73,7 @@ describe(`PO026 - AssignVariableHygiene`, () => {
                 column: 3
               },
               {
-                message: "The text of the Ref element must be a variable name, should not be wrapped in curlies",
+                message: "The text of the Ref element must be a variable name, should not include curlies",
                 line: 15,
                 column: 10
               },
@@ -106,9 +106,9 @@ describe(`PO026 - AssignVariableHygiene`, () => {
           };
 
       Object.keys(expected).forEach( (policyName, px) => {
-        let policyItems = items.filter( m => m.filePath.endsWith(policyName));
+        const policyItems = items.filter( m => m.filePath.endsWith(policyName));
         assert.equal(policyItems.length, 1);
-        let po026Messages = policyItems[0].messages.filter( m => m.ruleId == 'PO026');
+        const po026Messages = policyItems[0].messages.filter( m => m.ruleId == 'PO026');
         assert.equal(po026Messages.length, expected[policyName].length);
 
         expected[policyName].forEach( (item, ix) => {

--- a/test/specs/PO026-profile.js
+++ b/test/specs/PO026-profile.js
@@ -19,63 +19,39 @@ const assert = require("assert"),
       path = require("path"),
       bl = require("../../lib/package/bundleLinter.js");
 
-describe(`PO026 - PropertySetRef with --profile 'apigeex' for PO026-apigeex-proxy`, () => {
-  it('should NOT generate errors for PropertySetRef', () => {
-    let configuration = {
-          debug: true,
-          source: {
-            type: "filesystem",
-            path: path.resolve(__dirname, '../fixtures/resources/PO026-apigeex-proxy/apiproxy'),
-            bundleType: "apiproxy"
-          },
-          excluded: {},
-          setExitCode: false,
-          output: () => {}, // suppress output
-          profile: "apigeex"
-        };
+const propertySetRefTest = (profile) => () => {
+        const configuration = {
+                debug: true,
+                source: {
+                  type: "filesystem",
+                  path: path.resolve(__dirname, '../fixtures/resources/PO026-apigeex-proxy/apiproxy'),
+                  bundleType: "apiproxy"
+                },
+                excluded: {},
+                setExitCode: false,
+                output: () => {}, // suppress output
+                profile
+              };
+        const expectedCount = (profile == 'apigee') ? 8 : 0;
 
-    bl.lint(configuration, (bundle) => {
-      let items = bundle.getReport();
-      assert.ok(items);
-      assert.ok(items.length);
-      items.forEach( (item) => {
-        // console.log( item );
-        if (item.filePath.endsWith("/apiproxy/policies/AM-config-properties.xml")) {
-            assert.equal(item.errorCount,0);
-        }
-      });
-    });
-  });
+        bl.lint(configuration, (bundle) => {
+          const items = bundle.getReport();
+          assert.ok(items);
+          assert.ok(items.length);
+          items.forEach( (item) => {
+            if (item.filePath.endsWith("/apiproxy/policies/AM-config-properties.xml")) {
+              assert.equal(item.errorCount, expectedCount);
+            }
+          });
+        });
+      };
+
+
+describe(`PO026 - PropertySetRef with various profiles`, () => {
+  it(`should NOT generate errors with profile 'apigeex'`, propertySetRefTest('apigeex'));
+  it(`should generate errors with profile 'apigee'`, propertySetRefTest('apigee'));
 });
 
-describe(`PO026 - PropertySetRef with --profile 'apigee' for PO026-apigeex-proxy`, () => {
-  it('should generate errors for PropertySetRef', () => {
-    let configuration = {
-          debug: true,
-          source: {
-            type: "filesystem",
-            path: path.resolve(__dirname, '../fixtures/resources/PO026-apigeex-proxy/apiproxy'),
-            bundleType: "apiproxy"
-          },
-          excluded: {},
-          setExitCode: false,
-          output: () => {}, // suppress output
-          profile: "apigee"
-        };
-
-    bl.lint(configuration, (bundle) => {
-      let items = bundle.getReport();
-      assert.ok(items);
-      assert.ok(items.length);
-      items.forEach( (item) => {
-        // console.log( item );
-        if (item.filePath.endsWith("/apiproxy/policies/AM-config-properties.xml")) {
-            assert.equal(item.errorCount,6);
-        }
-      });
-    });
-  });
-});
 
 const testID = "PO026",
       Policy = require("../../lib/package/Policy.js"),
@@ -85,9 +61,9 @@ const testID = "PO026",
 
 const resourceUrlTest =
   (suffix, profile, cb) => {
-    let filename = `AM-AssignVariable-${suffix}.xml`;
+    const filename = `AM-AssignVariable-${suffix}.xml`;
     it(`should correctly process ${filename} for profile ${profile}`, () => {
-      let fqfname = path.resolve(__dirname, '../fixtures/resources/PO026-assignVariable-resourceUrl', filename),
+     const fqfname = path.resolve(__dirname, '../fixtures/resources/PO026-assignVariable-resourceUrl', filename),
           policyXml = fs.readFileSync(fqfname, 'utf-8'),
           doc = new Dom().parseFromString(policyXml),
           p = new Policy(doc.documentElement, this);

--- a/test/specs/PO026-profile.js
+++ b/test/specs/PO026-profile.js
@@ -17,6 +17,7 @@
 
 const assert = require("assert"),
       path = require("path"),
+      debug = require("debug")("apigeelint:PO026-test"),
       bl = require("../../lib/package/bundleLinter.js");
 
 const propertySetRefTest = (profile) => () => {
@@ -40,6 +41,7 @@ const propertySetRefTest = (profile) => () => {
           assert.ok(items.length);
           items.forEach( (item) => {
             if (item.filePath.endsWith("/apiproxy/policies/AM-config-properties.xml")) {
+              debug(item);
               assert.equal(item.errorCount, expectedCount);
             }
           });
@@ -59,11 +61,10 @@ const testID = "PO026",
       fs = require("fs"),
       plugin = require(bl.resolvePlugin(testID));
 
-const resourceUrlTest =
-  (suffix, profile, cb) => {
-    const filename = `AM-AssignVariable-${suffix}.xml`;
+const po026Test =
+  (filename, profile, cb) => {
     it(`should correctly process ${filename} for profile ${profile}`, () => {
-     const fqfname = path.resolve(__dirname, '../fixtures/resources/PO026-assignVariable-resourceUrl', filename),
+     const fqfname = path.resolve(__dirname, '../fixtures/resources/PO026-assignVariable-policies', filename),
           policyXml = fs.readFileSync(fqfname, 'utf-8'),
           doc = new Dom().parseFromString(policyXml),
           p = new Policy(doc.documentElement, this);
@@ -81,18 +82,78 @@ const resourceUrlTest =
 
 describe(`PO026 - AssignVariable with ResourceURL`, () => {
 
-  resourceUrlTest('1', 'apigeex', (p, foundIssues) => {
+  po026Test(`ResourceUrl.xml`, 'apigeex', (p, foundIssues) => {
     assert.equal(foundIssues, false);
     assert.ok(p.getReport().messages, "messages undefined");
     assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
   });
 
-  resourceUrlTest('1', 'apigee', (p, foundIssues) => {
+  po026Test(`ResourceUrl.xml`, 'apigee', (p, foundIssues) => {
     assert.equal(foundIssues, true);
     assert.ok(p.getReport().messages, "messages undefined");
     assert.equal(p.getReport().messages.length, 2);
     assert.ok(p.getReport().messages[0].message.indexOf("stray element")>0);
     assert.ok(p.getReport().messages[1].message.indexOf("You should have at least one of")>=0);
+  });
+
+});
+
+
+describe(`PO026 - AssignVariable with PropertySetRef`, () => {
+
+  po026Test(`PropertySetRef-1.xml`, 'apigeex', (p, foundIssues) => {
+    assert.equal(foundIssues, false);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
+    debug(p.getReport().messages);
+  });
+
+  po026Test(`PropertySetRef-2.xml`, 'apigeex', (p, foundIssues) => {
+    assert.equal(foundIssues, true);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 1, JSON.stringify(p.getReport().messages));
+    debug(p.getReport().messages);
+  });
+
+  po026Test(`PropertySetRef-3.xml`, 'apigeex', (p, foundIssues) => {
+    assert.equal(foundIssues, false);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
+    debug(p.getReport().messages);
+  });
+
+  po026Test(`PropertySetRef-4.xml`, 'apigeex', (p, foundIssues) => {
+    assert.equal(foundIssues, true);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 1, JSON.stringify(p.getReport().messages));
+    debug(p.getReport().messages);
+  });
+
+  po026Test(`PropertySetRef-5.xml`, 'apigeex', (p, foundIssues) => {
+    assert.equal(foundIssues, false);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
+    debug(p.getReport().messages);
+  });
+
+  po026Test(`PropertySetRef-6.xml`, 'apigeex', (p, foundIssues) => {
+    assert.equal(foundIssues, false);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
+    debug(p.getReport().messages);
+  });
+
+  po026Test(`PropertySetRef-7.xml`, 'apigeex', (p, foundIssues) => {
+    assert.equal(foundIssues, true);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 1, JSON.stringify(p.getReport().messages));
+    debug(p.getReport().messages);
+  });
+
+  po026Test(`PropertySetRef-8.xml`, 'apigeex', (p, foundIssues) => {
+    assert.equal(foundIssues, false);
+    assert.ok(p.getReport().messages, "messages undefined");
+    assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
   });
 
 });

--- a/test/specs/testTemplateCheck.js
+++ b/test/specs/testTemplateCheck.js
@@ -1,0 +1,64 @@
+/*
+  Copyright 2019-2023 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+/* global describe, it, configuration */
+/* jslint esversion:9 */
+
+const assert = require("assert"),
+      pu = require("../../lib/package/plugins/_pluginUtil.js");
+
+describe("TemplateCheck", function() {
+  const testCases = [
+          ["{}", false],
+          ["{a}", true],
+          ["{{a}", false],
+          ["{{a}}", false],
+          ["{[]}", false],
+          ["{a[]}", false],
+          ["{a", false],
+          ["}a", false],
+          ["{a}}", false],
+          ["}a{", false],
+          ["{a}b", true],
+          ["{a}{b}", true],
+          ["{timeFormatUTCMs(propertyset.set1.timeformat,system.timestamp)}", true],
+          ["{timeFormatUTCMs(propertyset.set1.timeformat,system.timestamp) }", false],
+        ];
+
+  testCases.forEach( (item, _ix) => {
+    const [expression, expectedResult] = item;
+    it(`Check template (${expression}) should return ${expectedResult}`, function() {
+      const actualResult = pu.isValidTemplate(expression);
+      assert.equal(actualResult, expectedResult);
+    });
+  });
+});
+
+describe("PropertySetRefCheck", function() {
+  const testCases = [
+          ["{foo.bar}", true],
+          ["{foo.bar}.{var2}.setting", false],
+          ["{foo.bar}.setting", true],
+          ["{foo.bar}.{flow.var2}", true],
+        ];
+
+  testCases.forEach( (item, _ix) => {
+    const [expression, expectedResult] = item;
+    it(`PropertySetRef (${expression}) should be ${expectedResult?'valid':'not valid'}`, function() {
+      const actualResult = pu.isValidPropertySetRef(expression);
+      assert.equal(actualResult, expectedResult);
+    });
+  });
+});


### PR DESCRIPTION
This change removes the check for curlies in AssignVariable/PropertySetRef.