### PR TITLE
PO026 isValidTemplate incorrectly rejects createUuid

### DIFF
--- a/lib/package/plugins/_pluginUtil.js
+++ b/lib/package/plugins/_pluginUtil.js
@@ -7,9 +7,27 @@ const STATES = {
         INSIDE_FUNCTION: 4
       };
 
+const NO_ARG_FUNCTIONS = ['createUuid', 'randomLong'];
+
+const isValidNoArgFunction = (expr, ix) => {
+  for (const fn of NO_ARG_FUNCTIONS) {
+    const charBefore = expr[ix - fn.length - 1];
+    if (charBefore != '{') continue;
+
+    const sub = expr.substring(ix - fn.length, ix);
+    if (sub == fn) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 const isValidTemplate = (expr) => {
         let state = STATES.OUTSIDE_CURLY;
+        let ix = -1;
         for (const ch of expr) {
+          ix += 1;
           switch (state) {
           case STATES.OUTSIDE_CURLY:
             if (ch == '{') {
@@ -40,8 +58,13 @@ const isValidTemplate = (expr) => {
             break;
 
           case STATES.INSIDE_FUNCTION_NO_TEXT:
-            if (ch == '{' || ch == '[' || ch == '(' || ch == ')' || ch == '}' || ch == ']') {
+            if (ch == '{' || ch == '[' || ch == '(' || ch == '}' || ch == ']') {
               return false;
+            }
+            if (ch == ')') {
+              // check that the string leading up to this point is a permitted
+              // function call
+              return isValidNoArgFunction(expr, ix - 1);
             }
             state = STATES.INSIDE_FUNCTION;
             break;

--- a/test/specs/testTemplateCheck.js
+++ b/test/specs/testTemplateCheck.js
@@ -35,6 +35,9 @@ describe("TemplateCheck", function() {
           ["{a}{b}", true],
           ["{timeFormatUTCMs(propertyset.set1.timeformat,system.timestamp)}", true],
           ["{timeFormatUTCMs(propertyset.set1.timeformat,system.timestamp) }", false],
+          ["{createUuid()}", true],
+          ["{badcreateUuid()}", false],
+          ["{createUuid(]}", false],
         ];
 
   testCases.forEach( (item, _ix) => {


### PR DESCRIPTION
https://github.com/apigee/apigeelint/pull/383 introduces a new error where the template check fails to consider function calls that take no arguments. I think it's only `createUuid` and `randomLong` that are affected by this, but I've written the change in such a way as to be readily extendable to other functions as well