### PR TITLE
Allow spaces in template function arguments

### DIFF
--- a/lib/package/plugins/PO026-assignVariableUsage.js
+++ b/lib/package/plugins/PO026-assignVariableUsage.js
@@ -17,153 +17,176 @@
 //| &nbsp; |:white_medium_square:| PO026 | AssignVariable Usage | With AssignVariable, check various usage issues. The Name element must be present. The Ref element, if any, should not be surrounded in curlies. |
 
 const xpath = require("xpath"),
-      util = require('util'),
-      ruleId = require("../myUtil.js").getRuleId(),
-      pluginUtil = require('./_pluginUtil.js'),
-      debug = require("debug")("apigeelint:" + ruleId);
+  util = require("util"),
+  ruleId = require("../myUtil.js").getRuleId(),
+  pluginUtil = require("./_pluginUtil.js"),
+  debug = require("debug")("apigeelint:" + ruleId);
 
 const plugin = {
-        ruleId,
-        name: "AssignVariableUsage",
-        fatal: false,
-        severity: 2, //error
-        nodeType: "AssignMessage",
-        enabled: true
-      };
+  ruleId,
+  name: "AssignVariableUsage",
+  fatal: false,
+  severity: 2, //error
+  nodeType: "AssignMessage",
+  enabled: true,
+};
 
 let profile = "apigee";
-const onBundle = function(bundle, cb) {
+const onBundle = function (bundle, cb) {
   profile = bundle.profile;
   if (typeof cb == "function") {
     cb(null, false);
   }
 };
 
-const onPolicy = function(policy, cb) {
-      let flagged = false;
-      const ptype = policy.getType();
-      if (ptype === "AssignMessage" || ptype === "RaiseFault") {
-        const addMessage = (line, column, message) => {
-              policy.addMessage({plugin, message, line, column});
-              flagged = true;
-            };
-        const xpathExpr = (ptype === "AssignMessage")? "/AssignMessage/AssignVariable" : "/RaiseFault/FaultResponse/AssignVariable";
-        const avNodes = xpath.select(xpathExpr, policy.getElement());
-        if (avNodes && avNodes.length>0) {
-          debug(`${policy.fileName} found ${avNodes.length} AssignVariable elements`);
-          avNodes.forEach( (node, ix) => {
-            const addNodeMessage = (message) =>
-                    addMessage(node.lineNumber, node.columnNumber, message);
+const onPolicy = function (policy, cb) {
+  let flagged = false;
+  const ptype = policy.getType();
+  if (ptype === "AssignMessage" || ptype === "RaiseFault") {
+    const addMessage = (line, column, message) => {
+      policy.addMessage({ plugin, message, line, column });
+      flagged = true;
+    };
+    const xpathExpr =
+      ptype === "AssignMessage"
+        ? "/AssignMessage/AssignVariable"
+        : "/RaiseFault/FaultResponse/AssignVariable";
+    const avNodes = xpath.select(xpathExpr, policy.getElement());
+    if (avNodes && avNodes.length > 0) {
+      debug(
+        `${policy.fileName} found ${avNodes.length} AssignVariable elements`,
+      );
+      avNodes.forEach((node, ix) => {
+        const addNodeMessage = (message) =>
+          addMessage(node.lineNumber, node.columnNumber, message);
 
-            debug(`Configuration profile is: ${profile}`);
-            let found = { Name:0, Ref:0, Value:0, Template:0 };
-            if( profile === "apigeex") {
-              found = { ...found, PropertySetRef:0, ResourceURL:0 };
-            }
+        debug(`Configuration profile is: ${profile}`);
+        let found = { Name: 0, Ref: 0, Value: 0, Template: 0 };
+        if (profile === "apigeex") {
+          found = { ...found, PropertySetRef: 0, ResourceURL: 0 };
+        }
 
-            // Get the keys after Name
-            const foundKeysStr = Object.keys(found).filter(k => k != 'Name').join(',');
+        // Get the keys after Name
+        const foundKeysStr = Object.keys(found)
+          .filter((k) => k != "Name")
+          .join(",");
 
-            const childNodes = xpath.select("*", node);
-            if (childNodes.length == 0) {
-              addNodeMessage(`empty AssignVariable. Should have a Name child, and at least one of {${foundKeysStr}}.` );
-            }
-            else {
-              childNodes.forEach( (child, _ix) => {
-                debug(util.format(child));
-                if (typeof found[child.tagName] !== 'undefined') {
-                  found[child.tagName]++;
-                }
-                else {
-                  addMessage(child.lineNumber, child.columnNumber, `There is a stray element (${child.tagName})`);
-                }
-              });
-
-              if (found.Name > 1) {
-                addNodeMessage("There is more than one Name element");
-              }
-              else if (found.Name == 0) {
-                addNodeMessage("There is no Name element");
-              }
-
-              if (found.Ref > 1) {
-                addNodeMessage("There is more than one Ref element");
-              }
-              else if (found.Ref == 1) {
-                const textnode = xpath.select("Ref/text()", node),
-                      refText = textnode[0] && textnode[0].data;
-                if (refText && (refText.includes('{') || refText.includes('}'))) {
-                  addMessage(textnode[0].lineNumber, textnode[0].columnNumber, "The text of the Ref element must be a variable name, should not include curlies");
-                }
-              }
-
-              if (found.PropertySetRef > 1) {
-                addNodeMessage("There is more than one PropertySetRef element");
-              }
-              else if (found.PropertySetRef == 1) {
-                const textnode = xpath.select("PropertySetRef/text()", node),
-                      psrText = textnode[0] && textnode[0].data;
-                if ( ! psrText) {
-                  addMessage(textnode[0].lineNumber, textnode[0].columnNumber,
-                             "The text of the PropertySetRef element must not be empty");
-                }
-                let r = pluginUtil.validateTemplate(psrText);
-                if ( r) {
-                  addMessage(textnode[0].lineNumber, textnode[0].columnNumber,
-                             `The text of the PropertySetRef element must be a valid message template (${r})`);
-                }
-                else {
-                  r = pluginUtil.validatePropertySetRef(psrText);
-                  if (r) {
-                  addMessage(textnode[0].lineNumber, textnode[0].columnNumber,
-                             `Error in the text of the PropertySetRef element: ${r}`);
-                  }
-                }
-              }
-
-              if (found.Template > 1) {
-                addNodeMessage("There is more than one Template element");
-              }
-              else if (found.Template == 1) {
-                const textnode = xpath.select("Template/text()", node),
-                      templateText = textnode[0] && textnode[0].data;
-                if (templateText) {
-                  const r = pluginUtil.validateTemplate(templateText);
-                  if ( r ) {
-                    addMessage(textnode[0].lineNumber, textnode[0].columnNumber,
-                               r.error);
-                  }
-                }
-              }
-
-              if (found.Value > 1) {
-                addNodeMessage("There is more than one Value element");
-              }
-
-              let foundAny = 0;
-              let key;
-              for( key in found ) {
-                if( found[key] && key != 'Name') {
-                  foundAny += found[key];
-                }
-              }
-              if( foundAny === 0) {
-                addNodeMessage( `You should have at least one of: {${foundKeysStr}}`);
-              }
+        const childNodes = xpath.select("*", node);
+        if (childNodes.length == 0) {
+          addNodeMessage(
+            `empty AssignVariable. Should have a Name child, and at least one of {${foundKeysStr}}.`,
+          );
+        } else {
+          childNodes.forEach((child, _ix) => {
+            debug(util.format(child));
+            if (typeof found[child.tagName] !== "undefined") {
+              found[child.tagName]++;
+            } else {
+              addMessage(
+                child.lineNumber,
+                child.columnNumber,
+                `There is a stray element (${child.tagName})`,
+              );
             }
           });
+
+          if (found.Name > 1) {
+            addNodeMessage("There is more than one Name element");
+          } else if (found.Name == 0) {
+            addNodeMessage("There is no Name element");
+          }
+
+          if (found.Ref > 1) {
+            addNodeMessage("There is more than one Ref element");
+          } else if (found.Ref == 1) {
+            const textnode = xpath.select("Ref/text()", node),
+              refText = textnode[0] && textnode[0].data;
+            if (refText && (refText.includes("{") || refText.includes("}"))) {
+              addMessage(
+                textnode[0].lineNumber,
+                textnode[0].columnNumber,
+                "The text of the Ref element must be a variable name, should not include curlies",
+              );
+            }
+          }
+
+          if (found.PropertySetRef > 1) {
+            addNodeMessage("There is more than one PropertySetRef element");
+          } else if (found.PropertySetRef == 1) {
+            const textnode = xpath.select("PropertySetRef/text()", node),
+              psrText = textnode[0] && textnode[0].data;
+            if (!psrText) {
+              addMessage(
+                textnode[0].lineNumber,
+                textnode[0].columnNumber,
+                "The text of the PropertySetRef element must not be empty",
+              );
+            }
+            let r = pluginUtil.validateTemplate(psrText);
+            if (r) {
+              addMessage(
+                textnode[0].lineNumber,
+                textnode[0].columnNumber,
+                `The text of the PropertySetRef element must be a valid message template (${r})`,
+              );
+            } else {
+              r = pluginUtil.validatePropertySetRef(psrText);
+              if (r) {
+                addMessage(
+                  textnode[0].lineNumber,
+                  textnode[0].columnNumber,
+                  `Error in the text of the PropertySetRef element: ${r}`,
+                );
+              }
+            }
+          }
+
+          if (found.Template > 1) {
+            addNodeMessage("There is more than one Template element");
+          } else if (found.Template == 1) {
+            const textnode = xpath.select("Template/text()", node),
+              templateText = textnode[0] && textnode[0].data;
+            if (templateText) {
+              const r = pluginUtil.validateTemplate(templateText);
+              if (r) {
+                addMessage(
+                  textnode[0].lineNumber,
+                  textnode[0].columnNumber,
+                  "error: " + util.format(r),
+                );
+              }
+            }
+          }
+
+          if (found.Value > 1) {
+            addNodeMessage("There is more than one Value element");
+          }
+
+          let foundAny = 0;
+          let key;
+          for (key in found) {
+            if (found[key] && key != "Name") {
+              foundAny += found[key];
+            }
+          }
+          if (foundAny === 0) {
+            addNodeMessage(
+              `You should have at least one of: {${foundKeysStr}}`,
+            );
+          }
         }
-        else {
-          debug(`${policy.fileName} found no AssignVariable elements`);
-        }
-      }
-      if (typeof(cb) == 'function') {
-        cb(null, flagged);
-      }
-    };
+      });
+    } else {
+      debug(`${policy.fileName} found no AssignVariable elements`);
+    }
+  }
+  if (typeof cb == "function") {
+    cb(null, flagged);
+  }
+};
 
 module.exports = {
   plugin,
   onBundle,
-  onPolicy
+  onPolicy,
 };

--- a/lib/package/plugins/_pluginUtil.js
+++ b/lib/package/plugins/_pluginUtil.js
@@ -76,6 +76,9 @@ const validateFunctionArgs = (expr, fnStart, argsStart, end) => {
   // if (argsString.includes(' ')) {
   //   return {fn, error: 'spaces in argument string'};
   // }
+  if (argsString != "" && argsString.trim() == "") {
+    return { fn, error: "spaces between parens" };
+  }
   if (argsString == "" && !ZERO_ARG_FUNCTIONS.includes(fn)) {
     return { fn, error: `empty arg string` };
   }

--- a/lib/package/plugins/_pluginUtil.js
+++ b/lib/package/plugins/_pluginUtil.js
@@ -1,196 +1,242 @@
 const debug = require("debug")("apigeelint:template");
 
 const STATES = {
-        UNDEFINED           : -1,
-        OUTSIDE_CURLY           : 0,
-        INSIDE_CURLY_NO_TEXT    : 1,
-        INSIDE_CURLY            : 2,
-        INSIDE_VARREF           : 3,
-        INSIDE_FNARGS_NO_TEXT : 4,
-        INSIDE_FNARGS         : 5
-      };
+  UNDEFINED: -1,
+  OUTSIDE_CURLY: 0,
+  INSIDE_CURLY_NO_TEXT: 1,
+  INSIDE_CURLY: 2,
+  INSIDE_VARREF: 3,
+  INSIDE_FNARGS_NO_TEXT: 4,
+  INSIDE_FNARGS: 5,
+};
 
 const CODES = {
-        UPPER_A : 65,
-        UPPER_Z : 90,
-        LOWER_a : 97,
-        LOWER_z : 122,
-        ZERO    : 48,
-        NINE    : 57
-      };
+  UPPER_A: 65,
+  UPPER_Z: 90,
+  LOWER_a: 97,
+  LOWER_z: 122,
+  ZERO: 48,
+  NINE: 57,
+};
 
-const ZERO_ARG_FUNCTIONS = [ 'createUuid', 'randomLong' ];
+const ZERO_ARG_FUNCTIONS = ["createUuid", "randomLong"];
 
 const FUNCTION_NAMES = [
-        "sha1Hex", "sha1Base64", "sha256Hex", "sha256Base64", "sha384Hex", "sha384Base64",
-        "sha512Hex", "sha512Base64", "md5Hex", "md5Base64", "xPath", "xpath", "jsonPath",
-        "substring", "firstnonnull", "replaceAll", "replaceFirst", "createUuid", "randomLong",
-        "hmacMd5", "hmacSha1", "hmacSha224", "hmacSha256", "hmacSha384", "hmacSha512",
-        "timeFormat", "timeFormatMs", "timeFormatUTC", "timeFormatUTCMs", "xeger",
-        "encodeHTML", "escapeJSON", "escapeXML", "escapeXML11", "toUpperCase", "toLowerCase",
-        "encodeBase64", "decodeBase64"
-      ];
+  "sha1Hex",
+  "sha1Base64",
+  "sha256Hex",
+  "sha256Base64",
+  "sha384Hex",
+  "sha384Base64",
+  "sha512Hex",
+  "sha512Base64",
+  "md5Hex",
+  "md5Base64",
+  "xPath",
+  "xpath",
+  "jsonPath",
+  "substring",
+  "firstnonnull",
+  "replaceAll",
+  "replaceFirst",
+  "createUuid",
+  "randomLong",
+  "hmacMd5",
+  "hmacSha1",
+  "hmacSha224",
+  "hmacSha256",
+  "hmacSha384",
+  "hmacSha512",
+  "timeFormat",
+  "timeFormatMs",
+  "timeFormatUTC",
+  "timeFormatUTCMs",
+  "xeger",
+  "encodeHTML",
+  "escapeJSON",
+  "escapeXML",
+  "escapeXML11",
+  "toUpperCase",
+  "toLowerCase",
+  "encodeBase64",
+  "decodeBase64",
+];
 
 const validateFunction = (expr, start, end) => {
-        const fn = expr.substring(start, end);
-        if (FUNCTION_NAMES.find( f => fn == f)) {
-          return { fn };
-        }
-        return {fn, error: 'unknown function'};
-      };
+  const fn = expr.substring(start, end);
+  if (FUNCTION_NAMES.find((f) => fn == f)) {
+    return { fn };
+  }
+  return { fn, error: "unknown function" };
+};
 
 const validateFunctionArgs = (expr, fnStart, argsStart, end) => {
-        const fn = expr.substring(fnStart, argsStart - 1);
-        const argsString = expr.substring(argsStart, end);
-        if (argsString.includes(' ')) {
-          return {fn, error: 'spaces in argument string'};
-        }
-        if (argsString == '' && !ZERO_ARG_FUNCTIONS.includes(fn)) {
-          return {fn, error: `empty arg string`};
-        }
-        return { fn };
-      };
+  const fn = expr.substring(fnStart, argsStart - 1);
+  const argsString = expr.substring(argsStart, end);
+  // if (argsString.includes(' ')) {
+  //   return {fn, error: 'spaces in argument string'};
+  // }
+  if (argsString == "" && !ZERO_ARG_FUNCTIONS.includes(fn)) {
+    return { fn, error: `empty arg string` };
+  }
+  return { fn };
+};
 
-const stateToString = s =>
-        Object.keys(STATES).find( key => STATES[key] == s);
-
+const stateToString = (s) =>
+  Object.keys(STATES).find((key) => STATES[key] == s);
 
 /*
  * returns undefined for valid template. Returns an explanatory string if invalid.
  **/
 const validateTemplate = (expr) => {
-        let state = STATES.OUTSIDE_CURLY;
-        const states = [];
-        let code, fnStart = -1, argsStart = -1;
-        let ix = -1;
-        try {
-          for (const ch of expr) {
-                ix++;
-            debug(`state(${stateToString(state)}) ch(${ch})`);
-            switch (state) {
-            case STATES.OUTSIDE_CURLY:
-            case STATES.INSIDE_CURLY:
-              if (ch == '{') {
-                states.push(state);
-                state = STATES.INSIDE_CURLY_NO_TEXT;
-                fnStart = ix;
-              }
-              if (ch == '}') {
-                if (state == STATES.OUTSIDE_CURLY) {
-                return `unexpected close curly at position ${ix}`;
-                }
-                state = states.pop();
-              }
-              break;
-
-            case STATES.INSIDE_CURLY_NO_TEXT:
-              if (ch == '}') {
-                return `empty function name at position ${ix}`;
-              }
-              if (ch == '{' || ch == '[' || ch == '(') {
-                return `unexpected character at position ${ix}: ${ch}`;
-              }
-              code = ch.charCodeAt(0);
-              // examine first character. A numeric is invalid.
-              if (code >= CODES.ZERO && code <= CODES.NINE) {
-                return `unexpected character at position ${ix}: ${ch}`;
-              }
-              // a non-alphabetic means it's not a variable or function.
-              else if (!(code >= CODES.UPPER_A && code <= CODES.UPPER_Z) && !(code >= CODES.LOWER_a && code <= CODES.LOWER_z)) {
-                state = STATES.INSIDE_CURLY;
-              }
-              else {
-                state = STATES.INSIDE_VARREF;
-              }
-              break;
-
-            case STATES.INSIDE_VARREF:
-              if (ch == '{' || ch == '[' || ch == ')') {
-                return `unexpected character at position ${ix}: ${ch}`;
-              }
-              if (ch == '(') {
-                const r = validateFunction(expr, fnStart + 1, ix);
-                if ( r.error ) {
-                  return `unsupported function name (${r.fn})`;
-                }
-                argsStart = ix;
-                state = STATES.INSIDE_FNARGS_NO_TEXT;
-              }
-              if (ch == '}') {
-                state = states.pop();
-              }
-              break;
-
-            case STATES.INSIDE_FNARGS_NO_TEXT:
-              if (ch == '{' || ch == '[' || ch == '(' || ch == '}' || ch == ']') {
-                return `unexpected character at position ${ix}: ${ch}`;
-              }
-              if (ch == ')') {
-                const r = validateFunctionArgs(expr, fnStart + 1, argsStart + 1, ix);
-                if ( r.error ) {
-                  return `${r.error} for function ${r.fn}`;
-                }
-                state = STATES.AWAITING_CLOSE_CURLY;
-              }
-              else {
-                state = STATES.INSIDE_FNARGS;
-              }
-              break;
-
-            case STATES.INSIDE_FNARGS:
-              if (ch == '{' || ch == '[' || ch == '(') {
-                return `unexpected character at position ${ix}: ${ch}`;
-              }
-              if (ch == ')') {
-                const r = validateFunctionArgs(expr, fnStart + 1, argsStart + 1, ix);
-                if ( r.error ) {
-                  return `${r.error} for function ${r.fn}`;
-                }
-                state = STATES.AWAITING_CLOSE_CURLY;
-              }
-              break;
-
-            case STATES.AWAITING_CLOSE_CURLY:
-              if (ch != '}') {
-                return `unexpected character at position ${ix}: ${ch}`;
-              }
-              state = states.pop();
-              break;
-
-            default:
-              // should not happen
-              debug(`unknown state (${state})`);
-              return 'parse faillure';
-            }
+  let state = STATES.OUTSIDE_CURLY;
+  const states = [];
+  let code,
+    fnStart = -1,
+    argsStart = -1;
+  let ix = -1;
+  try {
+    for (const ch of expr) {
+      ix++;
+      debug(`state(${stateToString(state)}) ch(${ch})`);
+      switch (state) {
+        case STATES.OUTSIDE_CURLY:
+        case STATES.INSIDE_CURLY:
+          if (ch == "{") {
+            states.push(state);
+            state = STATES.INSIDE_CURLY_NO_TEXT;
+            fnStart = ix;
           }
-        } catch(e) {
-          // stack underflow
-          debug(`stack underflow? exception (${e})`);
-          return 'extraneous close-brace at position ${ix}';
-        }
-        debug(`final state(${stateToString(state)})`);
-        return state == STATES.OUTSIDE_CURLY ? undefined : 'unterminated curly brace';
-      };
+          if (ch == "}") {
+            if (state == STATES.OUTSIDE_CURLY) {
+              return `unexpected close curly at position ${ix}`;
+            }
+            state = states.pop();
+          }
+          break;
+
+        case STATES.INSIDE_CURLY_NO_TEXT:
+          if (ch == "}") {
+            return `empty function name at position ${ix}`;
+          }
+          if (ch == "{" || ch == "[" || ch == "(") {
+            return `unexpected character at position ${ix}: ${ch}`;
+          }
+          code = ch.charCodeAt(0);
+          // examine first character. A numeric is invalid.
+          if (code >= CODES.ZERO && code <= CODES.NINE) {
+            return `unexpected character at position ${ix}: ${ch}`;
+          }
+          // a non-alphabetic means it's not a variable or function.
+          else if (
+            !(code >= CODES.UPPER_A && code <= CODES.UPPER_Z) &&
+            !(code >= CODES.LOWER_a && code <= CODES.LOWER_z)
+          ) {
+            state = STATES.INSIDE_CURLY;
+          } else {
+            state = STATES.INSIDE_VARREF;
+          }
+          break;
+
+        case STATES.INSIDE_VARREF:
+          if (ch == "{" || ch == "[" || ch == ")") {
+            return `unexpected character at position ${ix}: ${ch}`;
+          }
+          if (ch == "(") {
+            const r = validateFunction(expr, fnStart + 1, ix);
+            if (r.error) {
+              return `unsupported function name (${r.fn})`;
+            }
+            argsStart = ix;
+            state = STATES.INSIDE_FNARGS_NO_TEXT;
+          }
+          if (ch == "}") {
+            state = states.pop();
+          }
+          break;
+
+        case STATES.INSIDE_FNARGS_NO_TEXT:
+          if (ch == "{" || ch == "[" || ch == "(" || ch == "}" || ch == "]") {
+            return `unexpected character at position ${ix}: ${ch}`;
+          }
+          if (ch == ")") {
+            const r = validateFunctionArgs(
+              expr,
+              fnStart + 1,
+              argsStart + 1,
+              ix,
+            );
+            if (r.error) {
+              return `${r.error} for function ${r.fn}`;
+            }
+            state = STATES.AWAITING_CLOSE_CURLY;
+          } else {
+            state = STATES.INSIDE_FNARGS;
+          }
+          break;
+
+        case STATES.INSIDE_FNARGS:
+          if (ch == "{" || ch == "[" || ch == "(") {
+            return `unexpected character at position ${ix}: ${ch}`;
+          }
+          if (ch == ")") {
+            const r = validateFunctionArgs(
+              expr,
+              fnStart + 1,
+              argsStart + 1,
+              ix,
+            );
+            if (r.error) {
+              return `${r.error} for function ${r.fn}`;
+            }
+            state = STATES.AWAITING_CLOSE_CURLY;
+          }
+          break;
+
+        case STATES.AWAITING_CLOSE_CURLY:
+          if (ch != "}") {
+            return `unexpected character at position ${ix}: ${ch}`;
+          }
+          state = states.pop();
+          break;
+
+        default:
+          // should not happen
+          debug(`unknown state (${state})`);
+          return "parse faillure";
+      }
+    }
+  } catch (e) {
+    // stack underflow
+    debug(`stack underflow? exception (${e})`);
+    return "extraneous close-brace at position ${ix}";
+  }
+  debug(`final state(${stateToString(state)})`);
+  return state == STATES.OUTSIDE_CURLY ? undefined : "unterminated curly brace";
+};
 
 const validatePropertySetRef = (expr) => {
-        let r = validateTemplate(expr);
-        if ( r ) {
-          return r;
-        }
-        if (expr.includes('{')) {
-          // There is a variable reference.
-          // Simulate a variable substitution; the result must have at most one dot.
-          const re = new RegExp('{[^}]+}', 'g'),
-                result = expr.replaceAll(re, 'xxx');
-          return ((result.match(/\./g) || []).length > 1) ?
-            'there is more than one dot in the template result' : undefined;
-        }
-        // No variable reference; the expression must have exactly one dot.
-        r = (expr.match(/\./g) || []).length;
-        return (r == 1) ? undefined : `there are ${r} dots ( !=1 ) in the template result`;
-      };
+  let r = validateTemplate(expr);
+  if (r) {
+    return r;
+  }
+  if (expr.includes("{")) {
+    // There is a variable reference.
+    // Simulate a variable substitution; the result must have at most one dot.
+    const re = new RegExp("{[^}]+}", "g"),
+      result = expr.replaceAll(re, "xxx");
+    return (result.match(/\./g) || []).length > 1
+      ? "there is more than one dot in the template result"
+      : undefined;
+  }
+  // No variable reference; the expression must have exactly one dot.
+  r = (expr.match(/\./g) || []).length;
+  return r == 1
+    ? undefined
+    : `there are ${r} dots ( !=1 ) in the template result`;
+};
 
 module.exports = {
   validateTemplate,
-  validatePropertySetRef
+  validatePropertySetRef,
 };

--- a/test/fixtures/resources/PO026-assignVariable-policies/Template-1.xml
+++ b/test/fixtures/resources/PO026-assignVariable-policies/Template-1.xml
@@ -11,4 +11,8 @@
 }
 </Template>
   </AssignVariable>
+  <AssignVariable>
+    <Name>timeStamp</Name>
+    <Template>{timeFormatUTCMs('yyyy-MM-dd HH-mm-ss',system.timestamp)} UTC</Template>
+  </AssignVariable>
 </AssignMessage>

--- a/test/specs/testTemplateCheck.js
+++ b/test/specs/testTemplateCheck.js
@@ -17,62 +17,79 @@
 /* jslint esversion:9 */
 
 const assert = require("assert"),
-      pu = require("../../lib/package/plugins/_pluginUtil.js");
+  pu = require("../../lib/package/plugins/_pluginUtil.js");
 
-describe("TemplateCheck", function() {
+describe("TemplateCheck", function () {
   const testCases = [
-          ["{}", "empty function name at position 1"],
-          ["{a}", undefined],
-          ["{{a}", 'unexpected character at position 1: {'],
-          ["{{a}}", 'unexpected character at position 1: {'],
-          ["{[]}", 'unexpected character at position 1: ['],
-          ["{a[]}", 'unexpected character at position 2: ['],
-          ["{a", 'unterminated curly brace'],
-          ["}a", 'unexpected close curly at position 0'],
-          ["{a}}", 'unexpected close curly at position 3'],
-          ["}a{", 'unexpected close curly at position 0'],
-          ["{a}b", undefined],
-          ["{a}{b}", undefined],
-          ["{a}.{b}", undefined],
-          ["{a.b}", undefined],
-          ["{3}", 'unexpected character at position 1: 3'],
-          ["{timeFormatUTCMs(propertyset.set1.timeformat,system.timestamp)}", undefined],
-          ["{timeFormatUTCMs(propertyset.set1.timeformat,system.timestamp) }",
-           'unexpected character at position 62:  '],
-          [`{  "organization": "{organization.name}", "environment": "{environment.name}" } `, undefined],
-          [`{  "organization": "{organization.name}", "environment": "{environment.{name}}" } `,
-           'unexpected character at position 71: {'],
-          [`{  "organization": "{organization.name}", "other": {"environment": "{environment.name}" } } `,
-           undefined],
-          ["{createUuid()}", undefined],
-          ["{createUuid( )}", 'spaces in argument string for function createUuid'],
-          ["{timeFormatUTCMs()}", 'empty arg string for function timeFormatUTCMs'],
-          ["{notARealfunction()}", 'unsupported function name (notARealfunction)'],
-          ["{createUuid[]}", 'unexpected character at position 11: ['],
-          ["{ createUuid() }", undefined], // but ineffective
-        ];
+    ["{}", "empty function name at position 1"],
+    ["{a}", undefined],
+    ["{{a}", "unexpected character at position 1: {"],
+    ["{{a}}", "unexpected character at position 1: {"],
+    ["{[]}", "unexpected character at position 1: ["],
+    ["{a[]}", "unexpected character at position 2: ["],
+    ["{a", "unterminated curly brace"],
+    ["}a", "unexpected close curly at position 0"],
+    ["{a}}", "unexpected close curly at position 3"],
+    ["}a{", "unexpected close curly at position 0"],
+    ["{a}b", undefined],
+    ["{a}{b}", undefined],
+    ["{a}.{b}", undefined],
+    ["{a.b}", undefined],
+    ["{3}", "unexpected character at position 1: 3"],
+    [
+      "{timeFormatUTCMs(propertyset.set1.timeformat,system.timestamp)}",
+      undefined,
+    ],
+    [
+      "{timeFormatUTCMs(propertyset.set1.timeformat,system.timestamp) }",
+      "unexpected character at position 62:  ",
+    ],
+    [
+      `{  "organization": "{organization.name}", "environment": "{environment.name}" } `,
+      undefined,
+    ],
+    [
+      `{  "organization": "{organization.name}", "environment": "{environment.{name}}" } `,
+      "unexpected character at position 71: {",
+    ],
+    [
+      `{  "organization": "{organization.name}", "other": {"environment": "{environment.name}" } } `,
+      undefined,
+    ],
+    ["{createUuid()}", undefined],
+    ["{createUuid( )}", "spaces between parens for function createUuid"],
+    ["{timeFormatUTCMs()}", "empty arg string for function timeFormatUTCMs"],
+    ["{notARealfunction()}", "unsupported function name (notARealfunction)"],
+    ["{createUuid[]}", "unexpected character at position 11: ["],
+    ["{ createUuid() }", undefined], // but ineffective
+  ];
 
-  testCases.forEach( (item, _ix) => {
+  testCases.forEach((item, _ix) => {
     const [expression, expectedError] = item;
-    it(`validateTemplate (${expression}) should return ${expectedError}`, function() {
+    it(`validateTemplate (${expression}) should return ${expectedError}`, function () {
       const actualResult = pu.validateTemplate(expression);
       assert.equal(actualResult, expectedError);
     });
   });
 });
 
-describe("PropertySetRefCheck", function() {
+describe("PropertySetRefCheck", function () {
   const testCases = [
-          ["{foo.bar}", undefined],
-          ["{foo.bar}.{var2}.setting", 'there is more than one dot in the template result'],
-          ["foo.bar.var2.setting", 'there are 3 dots ( !=1 ) in the template result'],
-          ["{foo.bar}.setting", undefined],
-          ["{foo.bar}.{flow.var2}", undefined],
-        ];
+    ["{foo.bar}", undefined],
+    [
+      "{foo.bar}.{var2}.setting",
+      "there is more than one dot in the template result",
+    ],
+    ["foo.bar.var2.setting", "there are 3 dots ( !=1 ) in the template result"],
+    ["{foo.bar}.setting", undefined],
+    ["{foo.bar}.{flow.var2}", undefined],
+  ];
 
-  testCases.forEach( (item, _ix) => {
+  testCases.forEach((item, _ix) => {
     const [expression, expectedResult] = item;
-    it(`PropertySetRef (${expression}) should be ${expectedResult?'valid':'not valid'}`, function() {
+    it(`PropertySetRef (${expression}) should be ${
+      expectedResult ? "valid" : "not valid"
+    }`, function () {
       const actualResult = pu.validatePropertySetRef(expression);
       assert.equal(actualResult, expectedResult);
     });


### PR DESCRIPTION
This corrects #387 .

Also, run prettier on affected .js files.