### PR TITLE
feat(plugin): FE001 plugin to check use of Authentication element

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ This is the current list:
 | Endpoints | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| EP001 | CORS Policy attachment | Check for multiple CORS policies, or attachment to Target Endpoint. |
 | &nbsp; |:white_check_mark:| EP002 | Misplaced Elements | Check for commonly misplaced configuration elements in Proxy and Target Endpoints. |
+| Features | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
+| &nbsp; |:white_check_mark:| FE001 | Use of Authentication element | Check for the Authentication element in policies or in Target Endpoints. |
 | Deprecation | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| DC001 | ConcurrentRateLimit Policy Deprecation |  Check usage of deprecated policy ConcurrentRateLimit. |
 | &nbsp; |:white_check_mark:| DC002 | OAuth V1 Policies Deprecation |  Check usage of deprecated OAuth V1 policies. |

--- a/lib/package/plugins/FE001-authentication.js
+++ b/lib/package/plugins/FE001-authentication.js
@@ -1,0 +1,176 @@
+/*
+  Copyright 2019-2023 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const myUtil = require("../myUtil.js"),
+  xpath = require("xpath"),
+  //util = require("util"),
+  ruleId = myUtil.getRuleId(),
+  debug = require("debug")("apigeelint:" + ruleId);
+
+const plugin = {
+  ruleId,
+  name: "Check for use of Authentication element in ServiceCallout, ExternalCallout and TargetEndpoint",
+  fatal: false,
+  severity: 2, //1= warning, 2=error
+  nodeType: "Feature",
+  enabled: true
+};
+
+const policiesToCheck = {
+  ServiceCallout: {
+    path: `/ServiceCallout/HTTPTargetConnection/Authentication`,
+    validChildren: ["HeaderName", "GoogleIDToken", "GoogleAccessToken"]
+  },
+  ExternalCallout: {
+    path: `/ExternalCallout/GrpcConnection/Authentication`,
+    validChildren: ["HeaderName", "GoogleIDToken"]
+  }
+};
+
+let bundleProfile = "apigee";
+const onBundle = function (bundle, cb) {
+  if (bundle.profile) {
+    bundleProfile = bundle.profile;
+  }
+  if (typeof cb == "function") {
+    cb(null, false);
+  }
+};
+
+const checkAuthElements = function (
+  selection,
+  addMessage,
+  label,
+  validChildren
+) {
+  if (selection.length > 1) {
+    addMessage(
+      selection[1].lineNumber,
+      selection[1].columnNumber,
+      `${label} has multiple Authentication elements. You should have a maximum of one.`
+    );
+  }
+  const authNode = selection[0];
+  const children = xpath.select("*", authNode);
+  if (children.length == 0) {
+    addMessage(
+      authNode.lineNumber,
+      authNode.columnNumber,
+      `misconfigured (empty) Authentication element.`
+    );
+  } else {
+    children.forEach((child) => {
+      if (!validChildren.includes(child.nodeName)) {
+        addMessage(
+          child.lineNumber,
+          child.columnNumber,
+          `Authentication element has unsupported child (${child.nodeName}).`
+        );
+      }
+    });
+
+    const tokenNodes = children
+      .filter((child) => validChildren.includes(child.nodeName))
+      .filter((child) => child.nodeName.endsWith("Token"));
+    if (tokenNodes.length == 0) {
+      const possibleElements = validChildren.filter((c) => c != "HeaderName");
+      const message =
+        possibleElements.length == 1
+          ? `Authentication element needs a child ${possibleElements[0]}`
+          : `Authentication element needs a child, one of [${possibleElements.join(
+              ","
+            )}]`;
+      addMessage(authNode.lineNumber, authNode.columnNumber, message);
+    } else if (tokenNodes.length > 1) {
+      addMessage(
+        tokenNodes[1].lineNumber,
+        tokenNodes[1].columnNumber,
+        `element ${tokenNodes[1].nodeName} is invalid here, because there is more than one *Token element.`
+      );
+    }
+  }
+};
+
+const onPolicy = function (policy, cb) {
+  let foundIssue = false;
+  const policyType = policy.getType();
+  const check = policiesToCheck[policyType];
+  if (check) {
+    const selection = policy.select(check.path);
+    if (selection && selection[0]) {
+      if (bundleProfile != "apigeex") {
+        foundIssue = true;
+        policy.addMessage({
+          plugin,
+          line: selection[0].lineNumber,
+          column: selection[0].columnNumber,
+          message: `Policy uses an Authentication element. Not supported in this profile.`
+        });
+      } else {
+        const addMessage = (line, column, message) => {
+          foundIssue = true;
+          policy.addMessage({ plugin, line, column, message });
+        };
+        checkAuthElements(selection, addMessage, "Policy", check.validChildren);
+      }
+    }
+  }
+  if (typeof cb == "function") {
+    cb(null, foundIssue);
+  }
+};
+
+const onTargetEndpoint = function (endpoint, cb) {
+  debug("onTargetEndpoint");
+  let foundIssue = false;
+  const httpTargets = xpath.select("HTTPTargetConnection", endpoint.element);
+  if (httpTargets && httpTargets[0]) {
+    debug("found HTTPTargetConnection");
+    const authNodes = xpath.select("Authentication", httpTargets[0]);
+    if (authNodes && authNodes[0]) {
+      debug("found Authentication");
+      if (bundleProfile != "apigeex") {
+        foundIssue = true;
+        endpoint.addMessage({
+          plugin,
+          line: authNodes[0].lineNumber,
+          column: authNodes[0].columnNumber,
+          message: `Endpoint uses an Authentication element. Not supported in this profile.`
+        });
+      } else {
+        const addMessage = (line, column, message) => {
+          foundIssue = true;
+          endpoint.addMessage({ plugin, line, column, message });
+        };
+        checkAuthElements(authNodes, addMessage, "TargetEndpoint", [
+          "GoogleIDToken",
+          "GoogleAccessToken"
+        ]);
+      }
+    }
+  }
+  if (typeof cb == "function") {
+    cb(null, foundIssue);
+  }
+  return foundIssue;
+};
+
+module.exports = {
+  plugin,
+  onBundle,
+  onPolicy,
+  onTargetEndpoint
+};

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/flightdata.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/flightdata.xml
@@ -1,0 +1,12 @@
+<APIProxy name="flightdata">
+  <ConfigurationVersion majorVersion="4" minorVersion="0"/>
+  <CreatedAt>1491498008040</CreatedAt>
+  <Description/>
+  <DisplayName>flightdata</DisplayName>
+  <LastModifiedAt>1491517153495</LastModifiedAt>
+  <Policies/>
+  <Resources/>
+  <Spec/>
+  <TargetServers/>
+  <validate>false</validate>
+</APIProxy>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-Clean-Response-Headers.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-Clean-Response-Headers.xml
@@ -1,0 +1,20 @@
+<AssignMessage name='AM-Clean-Response-Headers'>
+  <Remove>
+    <Headers>
+      <Header name='X-Robots-Tag'/>
+      <Header name='Cache-Control'/>
+      <Header name='Pragma'/>
+      <Header name='Expires'/>
+      <Header name='P3P'/>
+      <Header name='Content-Security-Policy'/>
+      <Header name='X-Content-Type-Options'/>
+      <Header name='X-XSS-Protection'/>
+      <Header name='Server'/>
+      <Header name='Set-Cookie'/>
+      <Header name='Accept-Ranges'/>
+      <Header name='Vary'/>
+      <Header name='Content-Disposition'/>
+    </Headers>
+  </Remove>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+</AssignMessage>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='AM-Inject-Proxy-Revision-Header'>
+  <Set>
+    <Headers>
+      <Header name='apiproxy'>{apiproxy.name} r{apiproxy.revision}</Header>
+    </Headers>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-PreparedQuery-1.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-PreparedQuery-1.xml
@@ -1,0 +1,6 @@
+<AssignMessage name='AM-PreparedQuery-1'>
+  <AssignVariable>
+    <Name>bq_query</Name>
+    <Template>SELECT airline, code FROM [bigquery-samples.airline_ontime_data.airline_id_codes] WHERE airline != 'Description' group by airline, code order by airline limit 32</Template>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-PreparedQuery-2.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-PreparedQuery-2.xml
@@ -1,0 +1,6 @@
+<AssignMessage name='AM-PreparedQuery-2'>
+  <AssignVariable>
+    <Name>bq_query</Name>
+    <Template>SELECT airline, code FROM [bigquery-samples.airline_ontime_data.airline_id_codes] WHERE airline != 'Description' group by airline, code order by airline limit 100</Template>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-PreparedQuery-3.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-PreparedQuery-3.xml
@@ -1,0 +1,6 @@
+<AssignMessage name='AM-PreparedQuery-3'>
+  <AssignVariable>
+    <Name>bq_query</Name>
+    <Template>SELECT airline, code FROM [bigquery-samples.airline_ontime_data.airline_id_codes] WHERE airline != 'Description' group by airline, code order by airline limit 500</Template>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-PreparedQuery-4.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-PreparedQuery-4.xml
@@ -1,0 +1,6 @@
+<AssignMessage name='AM-PreparedQuery-4'>
+  <AssignVariable>
+    <Name>bq_query</Name>
+    <Template>SELECT airline, count(*) AS total_count FROM [bigquery-samples.airline_ontime_data.flights] WHERE departure_airport = '{param1}' AND date = '{param2}' GROUP BY airline</Template>
+  </AssignVariable>
+</AssignMessage>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-Query.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/AM-Query.xml
@@ -1,0 +1,15 @@
+<AssignMessage name='AM-Query'>
+  <AssignTo>request</AssignTo>
+  <AssignVariable>
+    <Name>target.copy.pathsuffix</Name>
+    <Value>false</Value>
+  </AssignVariable>
+  <Set>
+    <Headers>
+      <Header name='Accept'>application/json</Header>
+    </Headers>
+    <Payload contentType='application/json'>{"query": "{bq_query}"}
+    </Payload>
+    <Verb>POST</Verb>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/EC-1-valid.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/EC-1-valid.xml
@@ -1,0 +1,30 @@
+<ExternalCallout name="EC-1-valid">
+
+  <GrpcConnection>
+    <Server name="grpcserver"/>
+    <!--
+        For Apigee X, connecting to a service in Cloud Run, include an
+        Authentication element like the following. Your Audience value will be
+        different.
+
+        Then, you will need to deploy the proxy with an account with "runAs"
+        permissions, and specify a service account.
+    -->
+
+    <Authentication>
+      <GoogleIDToken>
+        <Audience>https://external-callout-2s6vjmoabq-uw.a.run.app</Audience>
+        <IncludeEmail>false</IncludeEmail>
+      </GoogleIDToken>
+    </Authentication>
+
+  </GrpcConnection>
+
+  <TimeoutMs>5000</TimeoutMs>
+  <Configurations>
+    <Property name="with.request.content">true</Property>
+    <Property name="with.request.headers">true</Property>
+    <Property name="with.response.content">true</Property>
+    <Property name="with.response.headers">true</Property>
+  </Configurations>
+</ExternalCallout>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/EC-2-accesstoken.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/EC-2-accesstoken.xml
@@ -1,0 +1,27 @@
+<ExternalCallout name="EC-2-accesstoken">
+
+  <GrpcConnection>
+    <Server name="grpcserver"/>
+    <!--
+        For Apigee X, ExternalCallout must not use AccessToken.
+        only GoogleIDToken is supported.
+    -->
+
+    <Authentication>
+      <GoogleAccessToken>
+        <Scopes>
+          <Scope>SCOPE</Scope>
+        </Scopes>
+      </GoogleAccessToken>
+    </Authentication>
+
+  </GrpcConnection>
+
+  <TimeoutMs>5000</TimeoutMs>
+  <Configurations>
+    <Property name="with.request.content">true</Property>
+    <Property name="with.request.headers">true</Property>
+    <Property name="with.response.content">true</Property>
+    <Property name="with.response.headers">true</Property>
+  </Configurations>
+</ExternalCallout>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/EV-PathParams-4.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/EV-PathParams-4.xml
@@ -1,0 +1,7 @@
+<ExtractVariables name='EV-PathParams-4'>
+  <Source>request</Source>
+  <URIPath>
+    <Pattern ignoreCase="true">/airports/{param1}/counts/{param2}</Pattern>
+  </URIPath>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</ExtractVariables>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/JS-Convert-Response.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/JS-Convert-Response.xml
@@ -1,0 +1,21 @@
+<Javascript name='JS-Convert-Response'>
+  <Source><![CDATA[
+var c = JSON.parse(context.getVariable('response.content'));
+if (Number(c.totalRows) >0) {
+  var fieldnames = c.schema.fields.map(function(field){
+        return field.name;
+      });
+  var rows = c.rows.map(function(row) {
+        var values = row.f.map(function(f){ return f.v; });
+        var result = {};
+        fieldnames.forEach(function(name, ix){ result[name] = values[ix]; });
+        return result;
+      });
+  c.rows = rows;
+}
+delete c.kind;
+delete c.jobReference;
+context.setVariable('response.content', JSON.stringify(c,null,2)+'\n');
+]]>
+  </Source>
+</Javascript>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/RF-Unknown-Request.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/RF-Unknown-Request.xml
@@ -1,0 +1,16 @@
+<RaiseFault name='RF-Unknown-Request'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <FaultResponse>
+    <Set>
+      <Payload contentType='application/json'>{
+  "error" : {
+    "code" : 404.01,
+    "message" : "that request was unknown; try a different request."
+  }
+}
+</Payload>
+      <StatusCode>404</StatusCode>
+      <ReasonPhrase>Not Found</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+</RaiseFault>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/SC-1-valid.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/SC-1-valid.xml
@@ -1,0 +1,32 @@
+<ServiceCallout name='SC-1-valid'>
+  <Request variable='myrequestvariable'>
+    <Set>
+      <Headers>
+        <Header name='whatever'>anything here</Header>
+      </Headers>
+      <Verb>POST</Verb>
+    </Set>
+  </Request>
+  <Response>tokenResponse</Response>
+
+  <HTTPTargetConnection>
+
+    <Authentication>
+      <GoogleAccessToken>
+        <Scopes>
+          <Scope>SCOPE</Scope>
+        </Scopes>
+      </GoogleAccessToken>
+    </Authentication>
+
+    <SSLInfo>
+        <Enabled>true</Enabled>
+        <IgnoreValidationErrors>true</IgnoreValidationErrors>
+        <TrustStore>ref://truststore-1</TrustStore>
+    </SSLInfo>
+    <Properties>
+      <Property name='success.codes'>2xx, 3xx</Property>
+    </Properties>
+    <URL>https://www.my-site.com/service</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/policies/SC-2-multiple-token-nodes.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/policies/SC-2-multiple-token-nodes.xml
@@ -1,0 +1,37 @@
+<ServiceCallout name='SC-2-multiple-token-nodes'>
+  <Request variable='myrequestvariable'>
+    <Set>
+      <Headers>
+        <Header name='whatever'>anything here</Header>
+      </Headers>
+      <Verb>POST</Verb>
+    </Set>
+  </Request>
+  <Response>tokenResponse</Response>
+
+  <HTTPTargetConnection>
+
+    <Authentication>
+      <GoogleAccessToken>
+        <Scopes>
+          <Scope>SCOPE</Scope>
+        </Scopes>
+      </GoogleAccessToken>
+      <GoogleAccessToken>
+        <Scopes>
+          <Scope>SCOPE</Scope>
+        </Scopes>
+      </GoogleAccessToken>
+    </Authentication>
+
+    <SSLInfo>
+        <Enabled>true</Enabled>
+        <IgnoreValidationErrors>true</IgnoreValidationErrors>
+        <TrustStore>ref://truststore-1</TrustStore>
+    </SSLInfo>
+    <Properties>
+      <Property name='success.codes'>2xx, 3xx</Property>
+    </Properties>
+    <URL>https://www.my-site.com/service</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/proxies/endpoint1.xml
@@ -1,0 +1,128 @@
+<ProxyEndpoint name="endpoint1">
+
+  <HTTPProxyConnection>
+    <BasePath>/flightdata</BasePath>
+  </HTTPProxyConnection>
+
+  <FaultRules/>
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Revision-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <PreFlow name="PreFlow">
+    <Request>
+    </Request>
+    <Response/>
+  </PreFlow>
+
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response>
+      <Step>
+        <Name>JS-Convert-Response</Name>
+      </Step>
+      <Step>
+        <Name>AM-Inject-Proxy-Revision-Header</Name>
+      </Step>
+    </Response>
+  </PostFlow>
+
+  <PostClientFlow name="PostFlow">
+    <Request/>
+    <Response>
+    </Response>
+  </PostClientFlow>
+
+  <Flows>
+
+    <Flow name="airlines32">
+      <Request>
+        <Step>
+          <Name>AM-PreparedQuery-1</Name>
+        </Step>
+        <Step>
+          <Name>SC-1-valid</Name>
+        </Step>
+        <Step>
+          <Name>SC-2-multiple-token-nodes</Name>
+        </Step>
+        <Step>
+          <Name>EC-1-valid</Name>
+        </Step>
+        <Step>
+          <Name>EC-2-accesstoken</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/airlines32" and request.verb = "GET"</Condition>
+    </Flow>
+
+
+    <Flow name="airlines100">
+      <Request>
+        <Step>
+          <Name>AM-PreparedQuery-2</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/airlines100" and request.verb = "GET"</Condition>
+    </Flow>
+
+
+    <Flow name="airlines500">
+      <Request>
+        <Step>
+          <Name>AM-PreparedQuery-3</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/airlines500" and request.verb = "GET"</Condition>
+    </Flow>
+
+
+    <Flow name="airport-counts">
+      <Request>
+        <!-- if query is parameterized, extract the fields -->
+        <Step>
+          <Name>EV-PathParams-4</Name>
+        </Step>
+
+        <Step>
+          <Name>AM-PreparedQuery-4</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/airports/*/counts/*" and request.verb = "GET"</Condition>
+    </Flow>
+
+
+    <Flow name="unknown request">
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+    </Flow>
+
+  </Flows>
+
+
+  <RouteRule name="rule1">
+    <TargetEndpoint>target-2</TargetEndpoint>
+    <Condition>proxy.pathsuffix MatchesPath "/airlines32" and request.verb = "GET"</Condition>
+  </RouteRule>
+
+  <RouteRule name="rule0">
+    <TargetEndpoint>target-1</TargetEndpoint>
+  </RouteRule>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/targets/target-1.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/targets/target-1.xml
@@ -1,0 +1,43 @@
+<TargetEndpoint name="target-1">
+  <PreFlow name="PreFlow">
+    <Request>
+        <Step>
+          <Name>AM-Query</Name>
+        </Step>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Clean-Response-Headers</Name>
+      </Step>
+    </Response>
+  </PreFlow>
+
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response>
+    </Response>
+  </PostFlow>
+
+  <Flows/>
+
+  <HTTPTargetConnection>
+
+   <!-- tell Apigee to invoke this with a Google Access Token -->
+    <Authentication>
+      <GoogleAccessToken>
+        <Scopes>
+          <Scope>https://www.googleapis.com/auth/cloud-platform</Scope>
+        </Scopes>
+      </GoogleAccessToken>
+    </Authentication>
+
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+      <TrustStore>ref://truststore-1</TrustStore>
+    </SSLInfo>
+    <Properties/>
+    <!-- assemble the target path -->
+    <URL>https://bigquery.googleapis.com/bigquery/v2/projects/infinite-chain-292422/queries</URL>
+  </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/targets/target-2.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/targets/target-2.xml
@@ -1,0 +1,38 @@
+<TargetEndpoint name="target-2">
+  <PreFlow name="PreFlow">
+    <Request>
+        <Step>
+          <Name>AM-Query</Name>
+        </Step>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Clean-Response-Headers</Name>
+      </Step>
+    </Response>
+  </PreFlow>
+
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response>
+    </Response>
+  </PostFlow>
+
+  <Flows/>
+
+  <HTTPTargetConnection>
+
+   <!-- empty element -->
+    <Authentication>
+    </Authentication>
+
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+      <TrustStore>ref://truststore-1</TrustStore>
+    </SSLInfo>
+    <Properties/>
+    <!-- assemble the target path -->
+    <URL>https://bigquery.googleapis.com/bigquery/v2/projects/infinite-chain-292422/queries</URL>
+  </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/FE001-Authentication/apiproxy/targets/target-3.xml
+++ b/test/fixtures/resources/FE001-Authentication/apiproxy/targets/target-3.xml
@@ -1,0 +1,47 @@
+<TargetEndpoint name="target-3">
+  <PreFlow name="PreFlow">
+    <Request>
+        <Step>
+          <Name>AM-Query</Name>
+        </Step>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Clean-Response-Headers</Name>
+      </Step>
+    </Response>
+  </PreFlow>
+
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response>
+    </Response>
+  </PostFlow>
+
+  <Flows/>
+
+  <HTTPTargetConnection>
+
+   <!-- multiple token elements -->
+   <Authentication>
+     <GoogleAccessToken>
+        <Scopes>
+          <Scope>SCOPE</Scope>
+        </Scopes>
+      </GoogleAccessToken>
+      <GoogleIDToken>
+        <Audience>https://external-callout-2s6vjmoabq-uw.a.run.app</Audience>
+        <IncludeEmail>false</IncludeEmail>
+      </GoogleIDToken>
+    </Authentication>
+
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+      <TrustStore>ref://truststore-1</TrustStore>
+    </SSLInfo>
+    <Properties/>
+    <!-- assemble the target path -->
+    <URL>https://bigquery.googleapis.com/bigquery/v2/projects/infinite-chain-292422/queries</URL>
+  </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/specs/FE001-Authentication-element.js
+++ b/test/specs/FE001-Authentication-element.js
@@ -1,0 +1,119 @@
+/*
+  Copyright 2019-2023 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const ruleId = "FE001",
+  assert = require("assert"),
+  path = require("path"),
+  util = require("util"),
+  debug = require("debug")(`apigeelint:${ruleId}`),
+  bl = require("../../lib/package/bundleLinter.js");
+
+describe(`${ruleId} - bundle with Authentication elements`, () => {
+  const profiles = ["apigee", "apigeex"];
+
+  profiles.forEach((profile) =>
+    it(`should generate the expected errors for profile ${profile}`, () => {
+      const configuration = {
+        debug: true,
+        source: {
+          type: "filesystem",
+          path: path.resolve(
+            __dirname,
+            "../fixtures/resources/FE001-Authentication/apiproxy"
+          ),
+          bundleType: "apiproxy"
+        },
+        profile,
+        excluded: {},
+        setExitCode: false,
+        output: () => {} // suppress output
+      };
+
+      bl.lint(configuration, (bundle) => {
+        const items = bundle.getReport();
+        assert.ok(items);
+        assert.ok(items.length);
+        const fe001Issues = items.filter(
+          (item) =>
+            item.messages &&
+            item.messages.length &&
+            item.messages.find((m) => m.ruleId == ruleId)
+        );
+        if (profile == "apigeex") {
+          assert.equal(fe001Issues.length, 4);
+          debug(util.format(fe001Issues));
+
+          const ep2 = fe001Issues.find((e) =>
+            e.filePath.endsWith("target-2.xml")
+          );
+          assert.ok(ep2);
+          debug(util.format(ep2.messages));
+          let messages = ep2.messages.filter((m) => m.ruleId == ruleId);
+          assert.equal(messages.length, 1);
+          assert.ok(messages[0].message);
+          assert.equal(
+            messages[0].message,
+            "misconfigured (empty) Authentication element."
+          );
+
+          const policy1 = fe001Issues.find((e) =>
+            e.filePath.endsWith("SC-2-multiple-token-nodes.xml")
+          );
+          assert.ok(policy1);
+          debug(util.format(policy1.messages));
+          messages = policy1.messages.filter((m) => m.ruleId == ruleId);
+          assert.equal(messages.length, 1);
+          assert.ok(messages[0].message);
+
+          const policy2 = fe001Issues.find((e) =>
+            e.filePath.endsWith("EC-2-accesstoken.xml")
+          );
+          assert.ok(policy2);
+          debug(util.format(policy2.messages));
+          messages = policy2.messages.filter((m) => m.ruleId == ruleId);
+
+          assert.equal(messages.length, 2);
+          assert.ok(messages[0].message);
+          assert.ok(messages[1].message);
+        } else {
+          assert.equal(fe001Issues.length, 7);
+          debug(util.format(fe001Issues));
+          const itemsFlagged = fe001Issues.map((issue) =>
+            issue.filePath.substring(issue.filePath.lastIndexOf("/") + 1)
+          );
+          const expectedItemsFlagged = [
+            "target-1.xml",
+            "target-2.xml",
+            "target-3.xml",
+            "SC-1-valid.xml",
+            "EC-1-valid.xml",
+            "EC-2-accesstoken.xml",
+            "SC-2-multiple-token-nodes.xml"
+          ];
+          for (let i = 0; i < expectedItemsFlagged; i++) {
+            assert.ok(
+              itemsFlagged.includes(expectedItemsFlagged[i]),
+              expectedItemsFlagged[i]
+            );
+          }
+          assert.equal(itemsFlagged.length, expectedItemsFlagged.length);
+        }
+      });
+    })
+  );
+});


### PR DESCRIPTION
add a new plugin to check the use of the Authentication element in ServiceCallout, ExternalCallout, and TargetEndpoint. Because this check looks at two distinct policies and an endpoint, it didn't fit into any of the existing plugin categories.  Rather than breaking it into 3 new plugins, one for each policy and one for the targetendpoint, I added a new "feature" plugin type, and created this plugin (FE001) as the first of its type. It checks for this feature in all three places. 