### PR TITLE
fix(CC001): correct parsing of multiline Conditions

### DIFF
--- a/lib/package/Condition.js
+++ b/lib/package/Condition.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Google LLC
+  Copyright 2019, 2023 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,14 +14,14 @@
   limitations under the License.
 */
 
-var TruthTable = require("./TruthTable.js");
+const TruthTable = require("./TruthTable.js");
 
 function Condition(element, parent) {
   this.parent = parent;
   this.element = element;
 }
 
-Condition.prototype.getExpression = function() {
+Condition.prototype.getExpression = function () {
   return (
     (this.element.childNodes &&
       this.element.childNodes[0] &&
@@ -30,51 +30,53 @@ Condition.prototype.getExpression = function() {
   );
 };
 
-Condition.prototype.getMessages = function() {
+Condition.prototype.getMessages = function () {
   return this.parent.getMessages();
 };
 
-Condition.prototype.getElement = function() {
+Condition.prototype.getElement = function () {
   return this.element;
 };
 
-Condition.prototype.getParent = function() {
+Condition.prototype.getParent = function () {
   return this.parent;
 };
 
-Condition.prototype.getLines = function(start, stop) {
+Condition.prototype.getLines = function (start, stop) {
   return this.parent.getLines(start, stop);
 };
 
-Condition.prototype.getSource = function() {
+Condition.prototype.getSource = function () {
   if (!this.source) {
-    var start = this.element.lineNumber - 1,
+    const start = this.element.lineNumber - 1,
       stop = this.element.nextSibling.lineNumber - 1;
     this.source = this.getLines(start, stop);
   }
   return this.source;
 };
 
-Condition.prototype.getTruthTable = function() {
+Condition.prototype.getTruthTable = function () {
   if (!this.truthTable) {
-    this.truthTable = new TruthTable(this.getExpression());
+    this.truthTable = new TruthTable(
+      this.getExpression().replace(/(\n| +)/g, " ")
+    );
   }
   return this.truthTable;
 };
 
-Condition.prototype.addMessage = function(msg) {
+Condition.prototype.addMessage = function (msg) {
   if (!msg.hasOwnProperty("entity")) {
     msg.entity = this;
   }
   this.parent.addMessage(msg);
 };
 
-Condition.prototype.onConditions = function(pluginFunction, cb) {
+Condition.prototype.onConditions = function (pluginFunction, cb) {
   pluginFunction(this, cb);
 };
 
-Condition.prototype.summarize = function() {
-  var summary = {};
+Condition.prototype.summarize = function () {
+  const summary = {};
   summary.type = "Condition";
   summary.condition = this.getExpression();
   try {

--- a/lib/package/plugins/CC001-checkConditionForLiterals.js
+++ b/lib/package/plugins/CC001-checkConditionForLiterals.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2020 Google LLC
+  Copyright 2019-2023 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -14,27 +14,32 @@
   limitations under the License.
 */
 
-const plugin = {
-        ruleId : require("../myUtil.js").getRuleId(),
-        name: "Literals in Conditionals",
-        message:
-        "Single term literals statically evaluate to True or False and needlessly complicate a conditional at best, at worst they create dead code or are misleading in implying condtional execution.",
-        fatal: false,
-        severity: 1, //warning
-        nodeType: "Condition",
-        enabled: true
-      };
+const ruleId = require("../myUtil.js").getRuleId(),
+  debug = require("debug")("apigeelint:" + ruleId);
 
-const onCondition = function(condition, cb) {
-  condition.getTruthTable().getAST(function(ast) {
-    let hasLiteral = false,
-        nodes = [ast],
-        actions = [{ action: "root", parent: undefined }];
+const plugin = {
+  ruleId,
+  name: "Literals in Conditionals",
+  message:
+    "Single term literals statically evaluate to True or False and needlessly complicate a conditional at best, at worst they create dead code or are misleading in implying condtional execution.",
+  fatal: false,
+  severity: 1, //warning
+  nodeType: "Condition",
+  enabled: true
+};
+
+const onCondition = function (condition, cb) {
+  debug(`onCondition (${condition.getExpression()})`);
+  condition.getTruthTable().getAST(function (ast) {
+    let hasLiteral = false;
+    const nodes = [ast],
+      actions = [{ action: "root", parent: undefined }];
 
     while (nodes[0] && !hasLiteral) {
-      let node = nodes.pop(),
+      const node = nodes.pop(),
         parentAction = actions.pop();
 
+      debug(`node (${JSON.stringify(node)})`);
       if (
         node.type === "constant" &&
         (!parentAction.parent ||
@@ -55,7 +60,7 @@ const onCondition = function(condition, cb) {
         });
       } else if (node.args) {
         //lets also capture the prior action
-        let act = { action: node.action, parent: undefined };
+        const act = { action: node.action, parent: undefined };
         if (parentAction && parentAction.action) {
           act.parent = parentAction.action;
         }


### PR DESCRIPTION
With this change, the CC001 now correctly parses a Condition string that occupies multiple lines. Previously, that plugin could flag the Condition as containing a string literal.  