### PR TITLE
Update BN001-checkBundleStructure.js

### DIFF
--- a/lib/package/plugins/BN001-checkBundleStructure.js
+++ b/lib/package/plugins/BN001-checkBundleStructure.js
@@ -163,6 +163,7 @@ const bundleStructure = function (bundleType) {
       {
         name: "resources",
         required: false,
+        files: { extensions: [] },
         folders: [
           {
             name: "jsc",


### PR DESCRIPTION
This PR solves issue #404 and flags any file that is a direct child of the `resources` folder of a proxy or sharedflow.