### PR TITLE
changes how peggy is invoked on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "badge": "mocha --reporter mocha-badge-generator",
     "coverage": "npx nyc --reporter=text mocha",
-    "build-condition-parser": "npx mkdirp build && ./node_modules/peggy/bin/peggy.js -o build/ConditionParser.js lib/peggy/Apigee-Condition.pegjs",
+    "build-condition-parser": "npx mkdirp build && npx peggy -o build/ConditionParser.js lib/peggy/Apigee-Condition.pegjs",
     "postinstall": "npm run build-condition-parser",
     "pretest": "npm run build-condition-parser",
     "test": "mocha"


### PR DESCRIPTION
The postinstall script was attempting to invoke peggy from the node_modules folder directly. This works fine when manually running the postinstall script from the apigeelint repo, but fails when the package is being installed from npm.

I changed the invocation from invoking peggy directly to using `npx`.

Solves issue #407 