### PR TITLE
Fixes issue with "undefined" proxies

### DIFF
--- a/lib/package/Bundle.js
+++ b/lib/package/Bundle.js
@@ -124,9 +124,11 @@ function buildResources(bundle) {
 }
 
 Bundle.prototype.getElement = function () {
-  // read the contents of the file and return it raw
-  if (!this.element) {
-    const filePath = this.filePath;
+  // Read the contents of the file if it exists and return it raw.
+  // There are cases where the filePath ends with /undefined, so 
+  // we don't want to attempt read a file that doesn't exist.
+  const filePath = this.filePath;
+  if (!this.element && fs.existsSync(filePath)) {
     debug(`getElement: filePath:${filePath}`);
     this.element = new Dom().parseFromString(
       fs.readFileSync(filePath).toString()
@@ -345,10 +347,16 @@ Bundle.prototype.addMessage = function (msg) {
     msg.source = msg.entity.getSource();
   }
   if (!msg.line && msg.entity && typeof msg.entity.getElement == "function") {
-    msg.line = msg.entity.getElement().lineNumber;
+    let element = msg.entity.getElement();
+    if(element) {
+      msg.line = element.lineNumber;
+    }
   }
   if (!msg.column && msg.entity && typeof msg.entity.getElement == "function") {
-    msg.column = msg.entity.getElement().columnNumber;
+    let element = msg.entity.getElement();
+    if(element) {
+      msg.column = element.columnNumber;
+    }
   }
   delete msg.entity;
 

--- a/test/fixtures/resources/newBundle/apiproxy/proxies/default.xml
+++ b/test/fixtures/resources/newBundle/apiproxy/proxies/default.xml
@@ -1,0 +1,20 @@
+<ProxyEndpoint name="default">
+  <HTTPProxyConnection>
+    <BasePath>/</BasePath>
+    <Properties/>
+    <VirtualHost>secure</VirtualHost>
+  </HTTPProxyConnection>
+
+  <PreFlow name="PreFlow">
+    <Request />
+    <Response />
+  </PreFlow>
+  <PostFlow name="PostFlow">
+    <Request />
+    <Response />
+  </PostFlow>
+  <RouteRule name="no-route">
+    <!-- this is ok -->
+  </RouteRule>
+
+</ProxyEndpoint>

--- a/test/specs/testBundle.js
+++ b/test/specs/testBundle.js
@@ -1,0 +1,42 @@
+const assert = require("assert"),
+      path = require("path"),
+      Bundle = require("../../lib/package/Bundle.js");
+
+describe("addMessage", function() {
+    it("Should add a message for 'undefined' proxies", function() {
+        const proxyPath = path.resolve(__dirname, '../fixtures/resources/newBundle/apiproxy');
+        const configuration = {
+            debug: true,
+            source: {
+                type: "filesystem",
+                path: proxyPath,
+                bundleType: "apiproxy"
+            },
+            profile: 'apigee',
+            excluded: {},
+            setExitCode: false,
+            output: () => {} // suppress output
+        };
+    
+        const message = "This is a test";
+        const plugin = {
+            ruleId: "TR001",
+            severity: 1, //warning
+            nodeType: "Bundle"
+        };
+
+        let bundle = new Bundle(configuration);
+        bundle.addMessage({
+            plugin,
+            message: message           
+        });
+
+        bundle.getReport(report => {
+            let bundleResult = report.find(element => element.filePath === proxyPath);
+            assert.notEqual(bundleResult, null);
+            assert.equal(bundleResult.warningCount, 1);
+            let m = bundleResult.messages.find(element => element.message === message);
+            assert.equal(m.ruleId, plugin.ruleId);
+        });
+    });
+});


### PR DESCRIPTION
External plugins were unable to add messages to the report if there wasn't a root xml for the proxy/shared flow, as reported in #409. This PR fixes that issue.