### PR TITLE
fix: do not call xpath.select() with non element

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 apigeelint
-Copyright (c) 2018-2022 Google LLC
+Copyright (c) 2018-2024 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -330,8 +330,9 @@ responses are on an ad-hoc, volunteer basis.
 
 If you simply have questions, we recommend asking on the [Apigee
 forum](https://www.googlecloudcommunity.com/gc/Apigee/bd-p/cloud-apigee/) on
-GoogleCloudCommunity. Apigee experts regularly check that forum.
-checked by Apigee experts.
+[GoogleCloudCommunity.com](https://www.googlecloudcommunity.com/).  Apigee
+experts regularly check that forum.
+
 
 Apigee customers should use [formal support channels](https://cloud.google.com/apigee/support) for Apigee product related concerns.
 
@@ -339,7 +340,7 @@ Apigee customers should use [formal support channels](https://cloud.google.com/a
 
 ## License and Copyright
 
-This material is [Copyright (c) 2018-2022 Google LLC](./NOTICE).
+This material is [Copyright (c) 2018-2024 Google LLC](./NOTICE).
 and is licensed under the [Apache 2.0 License](LICENSE).
 
 ## Disclaimer

--- a/lib/package/Endpoint.js
+++ b/lib/package/Endpoint.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,24 +15,30 @@
 */
 
 const Flow = require("./Flow.js"),
-      RouteRule = require("./RouteRule.js"),
-      FaultRule = require("./FaultRule.js"),
-      xpath = require("xpath"),
-      myUtil = require("./myUtil.js"),
-      debug = require("debug")("apigeelint:Endpoint"),
-      util = require("util"),
-      fs = require("fs"),
-      getcb = myUtil.curry(myUtil.diagcb, debug),
-      HTTPProxyConnection = require("./HTTPProxyConnection.js"),
-      HTTPTargetConnection = require("./HTTPTargetConnection.js"),
-      bundleTypes = require('./BundleTypes.js');
+  RouteRule = require("./RouteRule.js"),
+  FaultRule = require("./FaultRule.js"),
+  xpath = require("xpath"),
+  myUtil = require("./myUtil.js"),
+  debug = require("debug")("apigeelint:Endpoint"),
+  util = require("util"),
+  fs = require("fs"),
+  getcb = myUtil.curry(myUtil.diagcb, debug),
+  HTTPProxyConnection = require("./HTTPProxyConnection.js"),
+  HTTPTargetConnection = require("./HTTPTargetConnection.js"),
+  bundleTypes = require("./BundleTypes.js");
 
 function Endpoint(element, parent, fname, bundletype) {
   debug(`> new Endpoint() ${fname}`);
-  this.bundleType = bundletype ? bundletype : "apiproxy" //default to apiproxy if bundletype not passed
+  this.bundleType = bundletype ? bundletype : "apiproxy"; //default to apiproxy if bundletype not passed
   this.fileName = fname;
   this.parent = parent; // the bundle
   this.element = element;
+  this.preFlow = null;
+  this.postFlow = null;
+  this.postClientFlow = null;
+  this.sharedFlow = null;
+  this.httpProxyConnection = null;
+  this.httpTargetConnection = null;
   this.report = {
     filePath: myUtil.effectivePath(fname, this.bundleType),
     errorCount: 0,
@@ -44,25 +50,21 @@ function Endpoint(element, parent, fname, bundletype) {
   debug(`< new Endpoint() ${fname}`);
 }
 
-Endpoint.prototype.getName = function() {
+Endpoint.prototype.getName = function () {
   if (!this.name) {
     this.name = xpath.select("string(./@name)", this.element);
   }
   return this.name;
 };
 
-Endpoint.prototype.getReport = function() {
+Endpoint.prototype.getReport = function () {
   // sort messages by line, column
   this.report.messages.sort((a, b) => {
-    if (a.line && !b.line)
-      return -1;
-    if (b.line && !a.line)
-      return 1;
+    if (a.line && !b.line) return -1;
+    if (b.line && !a.line) return 1;
     if (a.line == b.line) {
-      if (a.column && !b.column)
-        return -1;
-      if (b.column && !a.column)
-        return 1;
+      if (a.column && !b.column) return -1;
+      if (b.column && !a.column) return 1;
       return a.column - b.column;
     }
     return a.line - b.line;
@@ -70,15 +72,15 @@ Endpoint.prototype.getReport = function() {
   return this.report;
 };
 
-Endpoint.prototype.getFileName = function() {
+Endpoint.prototype.getFileName = function () {
   return this.fileName;
 };
 
-Endpoint.prototype.select = function(xs) {
+Endpoint.prototype.select = function (xs) {
   return xpath.select(xs, this.getElement());
 };
 
-Endpoint.prototype.getLines = function(start, stop) {
+Endpoint.prototype.getLines = function (start, stop) {
   //actually parse the source into lines if we haven't already and return the requested subset
   var result = "";
   if (!this.lines) {
@@ -108,25 +110,24 @@ Endpoint.prototype.getLines = function(start, stop) {
   return result;
 };
 
-Endpoint.prototype.getSource = function() {
+Endpoint.prototype.getSource = function () {
   if (!this.source) {
-    var start = this.element.lineNumber - 1,
+    const start = this.element.lineNumber - 1,
       stop = Number.MAX_SAFE_INTEGER;
     if (this.element.nextSibling && this.element.nextSibling.lineNumber) {
       this.source = this.element.nextSibling.lineNumber - 1;
-    }
-    else {
+    } else {
       this.source = this.getLines(start, stop);
     }
   }
   return this.source;
 };
 
-Endpoint.prototype.getType = function() {
+Endpoint.prototype.getType = function () {
   return this.element.tagName;
 };
 
-Endpoint.prototype.getProxyName = function() {
+Endpoint.prototype.getProxyName = function () {
   if (!this.proxyName) {
     this.proxyName =
       this.fileName +
@@ -137,117 +138,110 @@ Endpoint.prototype.getProxyName = function() {
   return this.proxyName;
 };
 
-Endpoint.prototype.getPreFlow = function() {
-  if (!this.preFlow) {
-    var doc = xpath.select("./PreFlow", this.element);
-    if (doc && doc[0]) {
-      this.preFlow = new Flow(doc[0], this);
-    }
+Endpoint.prototype.getPreFlow = function () {
+  debug("> getPreFlow()");
+  if (this.preFlow == null) {
+    const n = xpath.select("./PreFlow", this.element);
+    this.preFlow = n && n[0] && new Flow(n[0], this);
   }
+  debug("< getPreFlow()");
   return this.preFlow;
 };
 
-Endpoint.prototype.getPostFlow = function() {
-  if (!this.postFlow) {
-    var doc = xpath.select("./PostFlow", this.element);
-    if (doc && doc[0]) {
-      this.postFlow = new Flow(doc[0], this);
-    }
+Endpoint.prototype.getPostFlow = function () {
+  debug("> getPostFlow()");
+  if (this.postFlow == null) {
+    const n = xpath.select("./PostFlow", this.element);
+    this.postFlow = n && n[0] && new Flow(n[0], this);
   }
+  debug("< getPostFlow()");
   return this.postFlow;
 };
 
-Endpoint.prototype.getPostClientFlow = function() {
-  if (!this.postClientFlow) {
-    var doc = xpath.select("./PostClientFlow", this.element);
-    if (doc && doc[0]) {
-      this.postClientFlow = new Flow(doc[0], this);
-    }
+Endpoint.prototype.getPostClientFlow = function () {
+  debug("> getPostClientFlow()");
+  if (this.postClientFlow == null) {
+    const n = xpath.select("./PostClientFlow", this.element);
+    this.postClientFlow = n && n[0] && new Flow(n[0], this);
   }
+  debug("< getPostClientFlow()");
   return this.postClientFlow;
 };
 
-Endpoint.prototype.getSharedFlow = function() {
-  if (!this.sharedFlow) {
-    var doc = xpath.select(".", this.element);
-    if (doc && doc[0]) {
-      this.sharedFlow = new Flow(doc[0], this);
-    }
+Endpoint.prototype.getSharedFlow = function () {
+  debug("> getSharedFlow()");
+  if (this.sharedFlow == null) {
+    const n = xpath.select("/SharedFlow", this.element);
+    this.sharedFlow = n && n[0] && new Flow(n[0], this);
   }
+  debug("< getSharedFlow()");
   return this.sharedFlow;
 };
 
-Endpoint.prototype.getRouteRules = function() {
+Endpoint.prototype.getRouteRules = function () {
   if (!this.routeRules) {
     let ep = this;
-    ep.routeRules =
-      xpath
+    ep.routeRules = xpath
       .select("./RouteRule", this.element)
-      .map(elt => new RouteRule(elt, ep));
+      .map((elt) => new RouteRule(elt, ep));
   }
   return this.routeRules;
 };
 
-Endpoint.prototype.getHTTPProxyConnection = function() {
-  if (!this.httpProxyConnection) {
-    var doc = xpath.select("./HTTPProxyConnection", this.element),
-      ep = this;
-    if (doc) {
-        ep.httpProxyConnection = new HTTPProxyConnection(doc[0], ep);
-    }
+Endpoint.prototype.getHTTPProxyConnection = function () {
+  if (this.httpProxyConnection == null) {
+    const n = xpath.select("./HTTPProxyConnection", this.element);
+    this.httpProxyConnection = n && n[0] && new HTTPProxyConnection(n[0], this);
   }
   return this.httpProxyConnection;
 };
 
-Endpoint.prototype.getHTTPTargetConnection = function() {
-  if (!this.httpTargetConnection) {
-    var doc = xpath.select("./HTTPTargetConnection", this.element),
-      ep = this;
-    if (doc && doc.length>0) { //need to check if HTTPTargetConnection exist as its not required when using HostedTargets (Issue 331)
-        ep.httpTargetConnection = new HTTPTargetConnection(doc[0], ep);
-    }
+Endpoint.prototype.getHTTPTargetConnection = function () {
+  if (this.httpTargetConnection == null) {
+    const n = xpath.select("./HTTPTargetConnection", this.element);
+    this.httpTargetConnection =
+      n && n[0] && new HTTPTargetConnection(n[0], this);
   }
   return this.httpTargetConnection;
 };
 
-Endpoint.prototype.getFlows = function() {
-  debug('> getFlows()');
+Endpoint.prototype.getFlows = function () {
+  debug("> getFlows()");
   if (!this.flows) {
     // Flows is always a child of toplevel element
     let nodes = xpath.select("/*/Flows", this.element),
-        ep = this,
-        flows = [];
+      ep = this,
+      flows = [];
     if (nodes) {
-      nodes.forEach(function(flowsElement) {
+      nodes.forEach(function (flowsElement) {
         // get a child flow from here
-        xpath
-          .select("Flow", flowsElement)
-          .forEach(elt => {
-            if (elt.attributes && elt.attributes[0]) {
-              debug(`Flow ${elt.attributes[0].name}='${elt.attributes[0].value}'`);
-            }
-            else {
-              debug(`Flow`);
-            }
-            let f = new Flow(elt, ep);
-            debug(`getFlows() flow= ${f.element.tagName}`);
-            flows.push(f);
-          });
+        xpath.select("Flow", flowsElement).forEach((elt) => {
+          if (elt.attributes && elt.attributes[0]) {
+            debug(
+              `Flow ${elt.attributes[0].name}='${elt.attributes[0].value}'`
+            );
+          } else {
+            debug(`Flow`);
+          }
+          let f = new Flow(elt, ep);
+          debug(`getFlows() flow= ${f.element.tagName}`);
+          flows.push(f);
+        });
       });
     }
     this.flows = flows;
   }
-  debug('< getFlows()');
+  debug("< getFlows()");
   return this.flows;
 };
 
-Endpoint.prototype.getAllFlows = function() {
-  debug('> getAllFlows()');
+Endpoint.prototype.getAllFlows = function () {
+  debug("> getAllFlows()");
   if (!this.allFlows) {
     self = this;
     let allFlows = [];
 
-    if(this.bundleType === bundleTypes.BundleType.SHAREDFLOW){
+    if (this.bundleType === bundleTypes.BundleType.SHAREDFLOW) {
       allFlows.push(this.getSharedFlow());
     } else {
       allFlows.push(this.getPreFlow());
@@ -258,32 +252,32 @@ Endpoint.prototype.getAllFlows = function() {
     allFlows.push.apply(allFlows, this.getFlows());
     this.allFlows = allFlows;
   }
-  debug('< getAllFlows()');
+  debug("< getAllFlows()");
   return this.allFlows;
 };
 
-Endpoint.prototype.getFaultRules = function() {
-  debug('> getFaultRules()');
+Endpoint.prototype.getFaultRules = function () {
+  debug("> getFaultRules()");
   if (!this.faultRules) {
-    var doc = xpath.select("./FaultRules/FaultRule", this.element),
-        ep = this;
+    const n = xpath.select("./FaultRules/FaultRule", this.element),
+      ep = this;
     ep.faultRules = [];
-    if (doc) {
-      doc.forEach(function(frElement) {
+    if (n) {
+      n.forEach(function (frElement) {
         ep.faultRules.push(new FaultRule(frElement, ep));
       });
     }
   }
-  debug('< getFaultRules()');
+  debug("< getFaultRules()");
   return this.faultRules;
 };
 
-Endpoint.prototype.getDefaultFaultRule = function() {
+Endpoint.prototype.getDefaultFaultRule = function () {
   if (!this.defaultFaultRule) {
-    var doc = xpath.select("./DefaultFaultRule", this.element),
+    const n = xpath.select("./DefaultFaultRule", this.element),
       ep = this;
-    if (doc) {
-      doc.forEach(function(frElement) {
+    if (n) {
+      n.forEach(function (frElement) {
         ep.defaultFaultRule = new FaultRule(frElement, ep);
       });
     }
@@ -291,28 +285,31 @@ Endpoint.prototype.getDefaultFaultRule = function() {
   return this.defaultFaultRule;
 };
 
-Endpoint.prototype.getSteps = function() {
-  debug('> getSteps()');
-  if ( ! this.steps) {
-    let ep = this, steps = [];
-    ep.getAllFlows()
-      .forEach(flow =>
-               flow &&
-               [flow.getFlowRequest(),
-                flow.getFlowResponse(),
-                flow.getSharedFlow()]
-               .forEach(flowphase =>
-                        flowphase &&
-                        flowphase.getSteps()
-                        .forEach(step => steps.push(step))));
-    ep.getFaultRules()
-      .forEach( fr =>
-                fr &&
-                fr.getSteps().forEach(step => steps.push(step)));
+Endpoint.prototype.getSteps = function () {
+  debug("> getSteps()");
+  if (!this.steps) {
+    let ep = this,
+      steps = [];
+
+    ep.getAllFlows().forEach((flow) => {
+      if (flow) {
+        const flowphases = flow.getSharedFlow()
+          ? [flow.getSharedFlow()]
+          : [flow.getFlowRequest(), flow.getFlowResponse()];
+        flowphases.forEach((flowphase) => {
+          flowphase && steps.push(...flowphase.getSteps());
+        });
+      }
+    });
+
+    ep.getFaultRules().forEach(
+      (fr) => fr && fr.getSteps().forEach((step) => steps.push(step))
+    );
 
     if (ep.getDefaultFaultRule()) {
-      ep.getDefaultFaultRule().getSteps().forEach(step =>
-                                                  steps.push(step));
+      ep.getDefaultFaultRule()
+        .getSteps()
+        .forEach((step) => steps.push(step));
     }
     this.steps = steps;
     debug(`  getSteps() found ${steps.length} steps`);
@@ -321,114 +318,133 @@ Endpoint.prototype.getSteps = function() {
   return this.steps;
 };
 
-Endpoint.prototype.onSteps = function(pluginFunction, callback) {
+Endpoint.prototype.onSteps = function (pluginFunction, callback) {
   const endpoint = this,
-        flows = endpoint.getFlows(),
-        faultrules = endpoint.getFaultRules();
+    flows = endpoint.getFlows(),
+    faultrules = endpoint.getFaultRules();
   debug(`> onSteps: endpoint name: '${endpoint.getName()}'`);
   try {
     if (endpoint.getPreFlow()) {
       endpoint.getPreFlow().onSteps(pluginFunction, getcb("onSteps preflow"));
     }
-    if (flows && flows.length >0) {
-      flows.forEach( fl =>
-                     fl.onSteps(pluginFunction, getcb(`onSteps flow '${fl.getName()}'`)));
+    if (flows && flows.length > 0) {
+      flows.forEach((fl) =>
+        fl.onSteps(pluginFunction, getcb(`onSteps flow '${fl.getName()}'`))
+      );
     }
 
     if (endpoint.getPostFlow()) {
-      endpoint.getPostFlow().onSteps(pluginFunction, getcb('onSteps postflow'));
+      endpoint.getPostFlow().onSteps(pluginFunction, getcb("onSteps postflow"));
     } else {
-      debug('onSteps: no postflow');
+      debug("onSteps: no postflow");
     }
     if (endpoint.getDefaultFaultRule()) {
-      debug('onSteps: defaultFaultRule');
-      endpoint.getDefaultFaultRule().onSteps(pluginFunction, getcb('onSteps dfr'));
+      debug("onSteps: defaultFaultRule");
+      endpoint
+        .getDefaultFaultRule()
+        .onSteps(pluginFunction, getcb("onSteps dfr"));
     } else {
-      debug('onSteps: no defaultFaultRule');
+      debug("onSteps: no defaultFaultRule");
     }
 
-    if (faultrules && faultrules.length>0) {
-      faultrules.forEach( fr =>
-                          fr.onSteps(pluginFunction, getcb('onSteps faultrules')) );
-
+    if (faultrules && faultrules.length > 0) {
+      faultrules.forEach((fr) =>
+        fr.onSteps(pluginFunction, getcb("onSteps faultrules"))
+      );
     } else {
       debug("onSteps: no faultRules");
     }
-  }
-  catch (exc1) {
-    debug('exception: ' + exc1);
+  } catch (exc1) {
+    debug("exception: " + exc1);
     debug(exc1.stack);
   }
 
-  if (callback)
-    callback(null, {});
+  if (callback) callback(null, {});
   debug(`< onSteps: endpoint name: '${endpoint.getName()}'`);
 };
 
-Endpoint.prototype.onConditions = function(pluginFunction, callback) {
+Endpoint.prototype.onConditions = function (pluginFunction, callback) {
   const endpoint = this,
-        flows = endpoint.getFlows(),
-        faultrules = endpoint.getFaultRules(),
-        routerules = endpoint.getRouteRules();
+    flows = endpoint.getFlows(),
+    faultrules = endpoint.getFaultRules(),
+    routerules = endpoint.getRouteRules();
   debug(`onConditions: endpoint name: ${endpoint.getName()}`);
 
   try {
     if (endpoint.getPreFlow()) {
-      endpoint.getPreFlow().onConditions(pluginFunction, getcb("onConditions preflow"));
+      endpoint
+        .getPreFlow()
+        .onConditions(pluginFunction, getcb("onConditions preflow"));
     } else {
-      debug('onConditions: no PreFlow');
+      debug("onConditions: no PreFlow");
     }
-    if (flows && flows.length >0) {
-      flows.forEach( fl =>
-                     fl.onConditions(pluginFunction, getcb(`onConditions flow '${fl.getName()}'`)));
+    if (flows && flows.length > 0) {
+      flows.forEach((fl) =>
+        fl.onConditions(
+          pluginFunction,
+          getcb(`onConditions flow '${fl.getName()}'`)
+        )
+      );
     } else {
-      debug('onConditions: no Flows');
+      debug("onConditions: no Flows");
     }
     if (endpoint.getPostFlow()) {
-      endpoint.getPostFlow().onConditions(pluginFunction, getcb('onConditions postflow'));
+      endpoint
+        .getPostFlow()
+        .onConditions(pluginFunction, getcb("onConditions postflow"));
     } else {
-      debug('onConditions: no PostFlow');
+      debug("onConditions: no PostFlow");
     }
     if (endpoint.getDefaultFaultRule()) {
-      endpoint.getDefaultFaultRule().getSteps().forEach( step =>
-                                                         step.onConditions(pluginFunction, getcb('onConditions dfr')));
+      endpoint
+        .getDefaultFaultRule()
+        .getSteps()
+        .forEach((step) =>
+          step.onConditions(pluginFunction, getcb("onConditions dfr"))
+        );
     } else {
-      debug('onConditions: no DefaultFaultRule');
+      debug("onConditions: no DefaultFaultRule");
     }
-    if (faultrules && faultrules.length>0) {
-      faultrules.forEach( fr => {
+    if (faultrules && faultrules.length > 0) {
+      faultrules.forEach((fr) => {
         fr.onConditions(pluginFunction, getcb(`faultrule '${fr.getName()}'`));
-        fr.getSteps().forEach( step =>
-                               step.onConditions(pluginFunction, getcb(`onConditions faultrule '${fr.getName()}'`)));
+        fr.getSteps().forEach((step) =>
+          step.onConditions(
+            pluginFunction,
+            getcb(`onConditions faultrule '${fr.getName()}'`)
+          )
+        );
       });
     } else {
       debug("onConditions: no FaultRules");
     }
-    if (routerules && routerules.length>0) {
-      routerules.forEach( rr =>
-                          rr.onConditions(pluginFunction, getcb(`onConditions routerule '${rr.getName()}'`)));
+    if (routerules && routerules.length > 0) {
+      routerules.forEach((rr) =>
+        rr.onConditions(
+          pluginFunction,
+          getcb(`onConditions routerule '${rr.getName()}'`)
+        )
+      );
     } else {
       debug("onConditions: no RouteRules");
     }
-  }
-  catch (exc1) {
-    debug('exception: ' + exc1);
+  } catch (exc1) {
+    debug("exception: " + exc1);
     debug(exc1.stack);
   }
 
-  if (callback)
-    callback(null, {});
+  if (callback) callback(null, {});
 };
 
-Endpoint.prototype.getElement = function() {
+Endpoint.prototype.getElement = function () {
   return this.element;
 };
 
-Endpoint.prototype.getParent = function() {
+Endpoint.prototype.getParent = function () {
   return this.parent;
 };
 
-Endpoint.prototype.addMessage = function(msg) {
+Endpoint.prototype.addMessage = function (msg) {
   debug(`> addMessage`);
   //Severity should be one of the following: 0 = off, 1 = warning, 2 = error
   if (msg.hasOwnProperty("plugin")) {
@@ -467,26 +483,24 @@ Endpoint.prototype.addMessage = function(msg) {
   }
 };
 
-Endpoint.prototype.summarize = function() {
-  debug('> summarize');
+Endpoint.prototype.summarize = function () {
+  debug("> summarize");
   let summary = {
-        name : this.getName(),
-        type : this.getType(),
-      };
+    name: this.getName(),
+    type: this.getType()
+  };
 
-  if(this.bundleType === bundleTypes.BundleType.SHAREDFLOW){
-    debug('summarize - is SharedFlow');
-    summary.flows =
-      this.getSharedFlow().summarize();
-  }
-  else {
-    debug('summarize - is Apiproxy');
+  if (this.bundleType === bundleTypes.BundleType.SHAREDFLOW) {
+    debug("summarize - is SharedFlow");
+    summary.flows = this.getSharedFlow().summarize();
+  } else {
+    debug("summarize - is Apiproxy");
     summary.proxyName = this.getProxyName();
 
     let faultRules = this.getFaultRules();
     if (faultRules) {
       summary.faultRules = [];
-      faultRules.forEach(function(fr) {
+      faultRules.forEach(function (fr) {
         summary.faultRules.push(fr.summarize());
       });
     }
@@ -495,14 +509,14 @@ Endpoint.prototype.summarize = function() {
       (this.getDefaultFaultRule() && this.getDefaultFaultRule().summarize()) ||
       {};
 
-    summary.preFlow = (this.getPreFlow() && this.getPreFlow().summarize()) || {};
+    summary.preFlow =
+      (this.getPreFlow() && this.getPreFlow().summarize()) || {};
 
-    summary.flows = this.getFlows().map(flow => flow.summarize());
+    summary.flows = this.getFlows().map((flow) => flow.summarize());
 
     summary.postFlow =
       (this.getPostFlow() && this.getPostFlow().summarize()) || {};
-    summary.routeRules = this.getRouteRules().map(rr => rr.summarize());
-
+    summary.routeRules = this.getRouteRules().map((rr) => rr.summarize());
   }
   return summary;
 };

--- a/lib/package/Flow.js
+++ b/lib/package/Flow.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2020 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,25 +15,27 @@
 */
 
 const xpath = require("xpath"),
-      FlowPhase = require("./FlowPhase.js"),
-      Condition = require("./Condition.js"),
-      myUtil = require("./myUtil.js"),
-      debug = require("debug")("apigeelint:Flow"),
-      getcb = myUtil.curry(myUtil.diagcb, debug);
+  FlowPhase = require("./FlowPhase.js"),
+  Condition = require("./Condition.js"),
+  myUtil = require("./myUtil.js"),
+  debug = require("debug")("apigeelint:Flow"),
+  getcb = myUtil.curry(myUtil.diagcb, debug);
 
 function Flow(element, parent) {
   this.parent = parent; // like ProxyEndpoint , TargetEndpoint
   this.element = element;
   this.condition = null;
   this.flowResponse = null;
+  this.flowRequest = null;
   this.sharedflow = null;
   this.description = null;
+  this.name = null;
   let self = this;
   debug(`Flow ctor: self: ${self.element.tagName}`);
 }
 
-Flow.prototype.getName = function() {
-  if (!this.name) {
+Flow.prototype.getName = function () {
+  if (this.name == null) {
     var attr = xpath.select("./@name", this.element);
     this.name = (attr[0] && attr[0].value) || "";
   }
@@ -41,11 +43,11 @@ Flow.prototype.getName = function() {
   return this.name;
 };
 
-Flow.prototype.getMessages = function() {
+Flow.prototype.getMessages = function () {
   return this.parent.getMessages();
 };
 
-Flow.prototype.getType = function() {
+Flow.prototype.getType = function () {
   if (!this.type) {
     // Flow | PreFlow || PostFlow || PostClientFlow
     //this.type = xpath.select("name(/*)", this.element);
@@ -54,7 +56,7 @@ Flow.prototype.getType = function() {
   return this.type;
 };
 
-Flow.prototype.getFlowName = function() {
+Flow.prototype.getFlowName = function () {
   if (!this.flowName) {
     this.flowName =
       myUtil.getFileName(this) + ":" + myUtil.buildTagBreadCrumb(this.element);
@@ -65,55 +67,57 @@ Flow.prototype.getFlowName = function() {
   return this.flowName;
 };
 
-Flow.prototype.getDescription = function() {
+Flow.prototype.getDescription = function () {
   if (this.description == null) {
-    let doc = xpath.select("./Description", this.element);
+    const nodes = xpath.select("./Description", this.element);
     this.description =
-      (doc &&
-        doc[0] &&
-        doc[0].childNodes[0] &&
-        doc[0].childNodes[0].nodeValue) ||
+      (nodes &&
+        nodes[0] &&
+        nodes[0].childNodes[0] &&
+        nodes[0].childNodes[0].nodeValue) ||
       "";
   }
   return this.description;
 };
 
-Flow.prototype.getCondition = function() {
+Flow.prototype.getCondition = function () {
   if (this.condition == null) {
-    let element = xpath.select("./Condition", this.element);
-    this.condition = element && element[0] && new Condition(element[0], this);
+    const n = xpath.select("./Condition", this.element);
+    this.condition = n && n[0] && new Condition(n[0], this);
   }
   return this.condition;
 };
 
-Flow.prototype.getFlowRequest = function() {
-  if (!this.flowRequest) {
-    //odd... in preflow I need the parentNode
-    //in Flow I don't... what is wrong
-    let doc = xpath.select("./Request", this.element);
-    this.flowRequest = new FlowPhase(doc[0] || "", this);
+Flow.prototype.getFlowRequest = function () {
+  debug(`> getFlowRequest: ${this.getFlowName()}`);
+  if (this.flowRequest == null) {
+    const n = xpath.select("./Request", this.element);
+    this.flowRequest = n && n[0] && new FlowPhase(n[0], this);
   }
+  debug(`< getFlowRequest`);
   return this.flowRequest;
 };
 
-Flow.prototype.getFlowResponse = function() {
+Flow.prototype.getFlowResponse = function () {
+  debug(`> getFlowResponse: ${this.getFlowName()}`);
   let self = this;
-  if ( ! this.flowResponse) {
-    let doc = xpath.select("./Response", this.element);
-    this.flowResponse = (doc && doc[0]) ? new FlowPhase(doc[0], this) : false;
+  if (this.flowResponse == null) {
+    const n = xpath.select("./Response", this.element);
+    this.flowResponse = n && n[0] && new FlowPhase(n[0], this);
   }
+  debug(`< getFlowResponse`);
   return this.flowResponse;
 };
 
-Flow.prototype.getSharedFlow = function() {
+Flow.prototype.getSharedFlow = function () {
   if (this.sharedflow == null) {
-    let doc = xpath.select(".", this.element);
-    this.sharedflow = doc && doc[0] && new FlowPhase(doc[0], this);
+    const n = xpath.select("/SharedFlow", this.element);
+    this.sharedflow = n && n[0] && new FlowPhase(n[0], this);
   }
   return this.sharedflow;
 };
 
-Flow.prototype.onSteps = function(pluginFunction, callback) {
+Flow.prototype.onSteps = function (pluginFunction, callback) {
   let flow = this;
   if (flow.getFlowRequest()) {
     flow.getFlowRequest().onSteps(pluginFunction, getcb(`onSteps Request`));
@@ -124,13 +128,17 @@ Flow.prototype.onSteps = function(pluginFunction, callback) {
   callback(null, {});
 };
 
-Flow.prototype.onConditions = function(pluginFunction, callback) {
+Flow.prototype.onConditions = function (pluginFunction, callback) {
   let flow = this;
   if (flow.getFlowRequest()) {
-    flow.getFlowRequest().onConditions(pluginFunction, getcb(`onConditions Request`));
+    flow
+      .getFlowRequest()
+      .onConditions(pluginFunction, getcb(`onConditions Request`));
   }
   if (flow.getFlowResponse()) {
-    flow.getFlowResponse().onConditions(pluginFunction, getcb(`onConditions Response`));
+    flow
+      .getFlowResponse()
+      .onConditions(pluginFunction, getcb(`onConditions Response`));
   }
   if (flow.getCondition()) {
     pluginFunction(flow.getCondition(), getcb(`onConditions Flow`));
@@ -138,44 +146,46 @@ Flow.prototype.onConditions = function(pluginFunction, callback) {
   callback(null, {});
 };
 
-Flow.prototype.getElement = function() {
+Flow.prototype.getElement = function () {
   return this.element;
 };
 
-Flow.prototype.getLines = function(start, stop) {
+Flow.prototype.getLines = function (start, stop) {
   return this.parent.getLines(start, stop);
 };
 
-Flow.prototype.getSource = function() {
+Flow.prototype.getSource = function () {
   if (!this.source) {
     var start = this.element.lineNumber - 1,
-        stop = this.element.nextSibling.lineNumber - 1;
+      stop = this.element.nextSibling.lineNumber - 1;
     this.source = this.getLines(start, stop);
   }
   return this.source;
 };
 
-Flow.prototype.getParent = function() {
+Flow.prototype.getParent = function () {
   return this.parent;
 };
 
-Flow.prototype.addMessage = function(msg) {
+Flow.prototype.addMessage = function (msg) {
   if (!msg.hasOwnProperty("entity")) {
     msg.entity = this;
   }
   this.parent.addMessage(msg);
 };
 
-Flow.prototype.summarize = function() {
+Flow.prototype.summarize = function () {
   let summary = {
-        name : this.getName(),
-        description : this.getDescription(),
-        type : this.getType(),
-        flowName : this.getFlowName(),
-        condition : (this.getCondition() && this.getCondition().summarize()) || {},
-        requestPhase : (this.getFlowRequest() && this.getFlowRequest().summarize()) || {},
-        responsePhase : (this.getFlowResponse() && this.getFlowResponse().summarize()) || {}
-      };
+    name: this.getName(),
+    description: this.getDescription(),
+    type: this.getType(),
+    flowName: this.getFlowName(),
+    condition: (this.getCondition() && this.getCondition().summarize()) || {},
+    requestPhase:
+      (this.getFlowRequest() && this.getFlowRequest().summarize()) || {},
+    responsePhase:
+      (this.getFlowResponse() && this.getFlowResponse().summarize()) || {}
+  };
   return summary;
 };
 

--- a/lib/package/Policy.js
+++ b/lib/package/Policy.js
@@ -33,7 +33,7 @@ function Policy(path, fn, parent, doc) {
     warningCount: 0,
     fixableErrorCount: 0,
     fixableWarningCount: 0,
-    messages: [],
+    messages: []
   };
 }
 
@@ -98,7 +98,7 @@ Policy.prototype.getDisplayName = function () {
       if (nodes[0].childNodes && nodes[0].childNodes[0]) {
         this.displayName = nodes[0].childNodes[0].nodeValue;
         debug(
-          `policy(${this.name}) DisplayName(${nodes[0].childNodes[0].nodeValue})`,
+          `policy(${this.name}) DisplayName(${nodes[0].childNodes[0].nodeValue})`
         );
       } else {
         this.displayName = "";
@@ -120,7 +120,7 @@ Policy.prototype.getElement = function () {
   //read the contents of the file and return it raw
   if (!this.element) {
     this.element = new Dom().parseFromString(
-      fs.readFileSync(this.filePath).toString(),
+      fs.readFileSync(this.filePath).toString()
     );
   }
   return this.element;
@@ -197,22 +197,25 @@ Policy.prototype.getSteps = function () {
     //endpoints
     bundle.getEndpoints().forEach(function (ep) {
       //flows
-      ep.getAllFlows().forEach(function (fl) {
-        if (fl) {
-          var fps = [fl.getFlowRequest()];
-          fps.push(fl.getFlowResponse());
-          fps.push(fl.getSharedFlow());
-          fps.forEach(function (fp) {
-            if (fp) {
-              fp.getSteps().forEach(function (st) {
-                if (st.getName() === policyName) {
-                  steps.push(st);
-                }
-              });
+      ep.getAllFlows().forEach((flow) => {
+        if (flow) {
+          const flowphases = flow.getSharedFlow()
+            ? [flow.getSharedFlow()]
+            : [flow.getFlowRequest(), flow.getFlowResponse()];
+
+          flowphases.forEach((flowphase) => {
+            if (flowphase) {
+              const stepsForFlow = flowphase
+                .getSteps()
+                .filter((step) => step.getName() === policyName);
+              if (stepsForFlow.length) {
+                steps.push(...stepsForFlow);
+              }
             }
           });
         }
       });
+
       //faultrules
       ep.getFaultRules().forEach(function (fr) {
         if (fr) {

--- a/lib/package/Policy.js
+++ b/lib/package/Policy.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/lib/package/myUtil.js
+++ b/lib/package/myUtil.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2020 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 */
 
 let xpath = require("xpath"),
-    util = require("util");
+  util = require("util");
 
 function rBuildTagBreadCrumb(doc, bc) {
   if (doc && doc.parentNode) {
@@ -28,9 +28,8 @@ function rBuildTagBreadCrumb(doc, bc) {
 }
 
 function isEmpty(obj) {
-  for(var prop in obj) {
-      if(obj.hasOwnProperty(prop))
-          return false;
+  for (var prop in obj) {
+    if (obj.hasOwnProperty(prop)) return false;
   }
 
   return true;
@@ -77,47 +76,48 @@ function getStackTrace(e) {
 }
 
 function selectAttributeValue(item, path) {
-  var attr = xpath.select(path, item);
+  const attr = xpath.select(path, item.getElement());
   return (attr[0] && attr[0].value) || "";
 }
 
 function selectTagValue(item, path) {
-  var doc = xpath.select(path, item.getElement());
+  const doc = xpath.select(path, item.getElement());
   return doc && doc[0] && doc[0].childNodes && doc[0].childNodes[0].nodeValue;
 }
 
-const diagcb = (dbg, label) =>
-    (e, d) => {
-      if (e) {
-        dbg(`${label} message(${e})`);
-        if (e.stack)
-          dbg(e.stack);
-      }
-      //debug(`${label} result: ` + util.format(d));
-      dbg(`${label} done (${d})`);
-    };
+const diagcb = (dbg, label) => (e, d) => {
+  if (e) {
+    dbg(`${label} message(${e})`);
+    if (e.stack) dbg(e.stack);
+  }
+  //debug(`${label} result: ` + util.format(d));
+  dbg(`${label} done (${d})`);
+};
 
 // return a curried function with the left-most argument filled
-const curry = (fn, arg1) =>
-   (...arguments) => fn.apply(this,[arg1].concat(arguments));
+const curry =
+  (fn, arg1) =>
+  (...arguments) =>
+    fn.apply(this, [arg1].concat(arguments));
 
-const re1 = new RegExp('^.+\\((.+)\\)$');
-const reLinux = new RegExp('^/.+/([A-Z]{2}[0-9]{3})-(.+)$');
-const reWindows = new RegExp('^\.+\([A-Z]{2}[0-9]{3})-(.+)$');
+const re1 = new RegExp("^.+\\((.+)\\)$");
+const reLinux = new RegExp("^/.+/([A-Z]{2}[0-9]{3})-(.+)$");
+const reWindows = new RegExp("^.+([A-Z]{2}[0-9]{3})-(.+)$");
 const getRuleId = () => {
-        try {
-          let e = new Error();
-          let frame = e.stack.split("\n")[2];
-          let arr = re1.exec(frame)[1].split(':');
-          var matches, filename;
-          if( arr[0].length == 1 ) { // Assume Windows with frame like: (C:\path\BN001-filename.js:NN:NN)
-            filename = arr[1];
-            matches = reWindows.exec(filename);
-          } else {
-            filename = arr[0];
-            matches = reLinux.exec(filename);
-          }
-          /*
+  try {
+    let e = new Error();
+    let frame = e.stack.split("\n")[2];
+    let arr = re1.exec(frame)[1].split(":");
+    var matches, filename;
+    if (arr[0].length == 1) {
+      // Assume Windows with frame like: (C:\path\BN001-filename.js:NN:NN)
+      filename = arr[1];
+      matches = reWindows.exec(filename);
+    } else {
+      filename = arr[0];
+      matches = reLinux.exec(filename);
+    }
+    /*
           console.log( "frame: " + frame);
           console.log( "filename: " + filename );
           console.log( "matches: " + matches);
@@ -130,17 +130,17 @@ const getRuleId = () => {
           filename: \a\1\s\lib\package\plugins\BN001-checkBundleStructure.js
           matches: \a\1\s\lib\package\plugins\BN001-checkBundleStructure.js,BN001,checkBundleStructure.js
           */
-          if ( ! matches) {
-            console.error(`For plugin file ${filename}, bad plugin filename format`);
-            process.exit(1);
-          }
-          let ruleId = matches[1];
-          return ruleId;
-        }catch (e1) {
-          console.log('error: ' + e1);
-          return "unknown";
-        }
-      };
+    if (!matches) {
+      console.error(`For plugin file ${filename}, bad plugin filename format`);
+      process.exit(1);
+    }
+    let ruleId = matches[1];
+    return ruleId;
+  } catch (e1) {
+    console.log("error: " + e1);
+    return "unknown";
+  }
+};
 
 function effectivePath(root, bundleTypeName) {
   return root;
@@ -157,10 +157,14 @@ const cyrb53 = (str, seed = 0) => {
     h1 = Math.imul(h1 ^ ch, 2654435761);
     h2 = Math.imul(h2 ^ ch, 1597334677);
   }
-  
-  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
-  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
-  
+
+  h1 =
+    Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^
+    Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 =
+    Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^
+    Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+
   return 4294967296 * (2097151 & h2) + (h1 >>> 0);
 };
 

--- a/lib/package/plugins/PO019-serviceCalloutRequestName.js
+++ b/lib/package/plugins/PO019-serviceCalloutRequestName.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2020 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,38 +15,43 @@
 */
 
 const myUtil = require("../myUtil.js"),
-      ruleId = myUtil.getRuleId(),
-      debug = require("debug")("apigeelint:" + ruleId);
+  ruleId = myUtil.getRuleId(),
+  debug = require("debug")("apigeelint:" + ruleId);
 
 const plugin = {
-        ruleId,
-        name: "Check ServiceCallout for Request variable name",
-        message:
-        "Using request for the Request name causes unexepcted side effects.",
-        fatal: false,
-        severity: 2, //error
-        nodeType: "Policy",
-        enabled: true
-      };
+  ruleId,
+  name: "Check ServiceCallout for Request variable name",
+  message: "Using request for the Request name causes unexepcted side effects.",
+  fatal: false,
+  severity: 2, //error
+  nodeType: "Policy",
+  enabled: true
+};
 
-const onPolicy = function(policy, cb) {
-        let hadWarning = false;
-        if (
-          policy.getType() === "ServiceCallout" &&
-            myUtil.selectAttributeValue(policy, "/ServiceCallout/Request/@variable") ===
-            "request"
-        ) {
-          hadWarning = true;
-          policy.addMessage({
-            plugin,
-            message:
-            'Policy has a Request variable named "request", this may lead to unexpected side effects. Rename the Request variable.'
-          });
-        }
-        if (typeof(cb) == 'function') {
-          cb(null, hadWarning);
-        }
-      };
+const onPolicy = function (policy, cb) {
+  let hadWarning = false;
+  try {
+    if (
+      policy.getType() === "ServiceCallout" &&
+      myUtil.selectAttributeValue(
+        policy,
+        "/ServiceCallout/Request/@variable"
+      ) === "request"
+    ) {
+      hadWarning = true;
+      policy.addMessage({
+        plugin,
+        message:
+          'Policy has a Request variable named "request", this may lead to unexpected side effects. Rename the Request variable.'
+      });
+    }
+  } catch (e) {
+    console.log(e);
+  }
+  if (typeof cb == "function") {
+    cb(null, hadWarning);
+  }
+};
 
 module.exports = {
   plugin,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "strip-ansi": "^6.0.1",
         "table": "latest",
         "text-table": "latest",
-        "xpath": "^0.0.34"
+        "xpath": "latest"
       },
       "bin": {
         "apigeelint": "cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "strip-ansi": "^6.0.1",
         "table": "latest",
         "text-table": "latest",
-        "xpath": "^0.0.33"
+        "xpath": "^0.0.34"
       },
       "bin": {
         "apigeelint": "cli.js"
@@ -2709,9 +2709,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.625",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-      "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
+      "version": "1.4.626",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.626.tgz",
+      "integrity": "sha512-f7/be56VjRRQk+Ric6PmIrEtPcIqsn3tElyAu9Sh6egha2VLJ82qwkcOdcnT06W+Pb6RUulV1ckzrGbKzVcTHg==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -6999,9 +6999,9 @@
       }
     },
     "node_modules/xpath": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
-      "integrity": "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+      "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
       "engines": {
         "node": ">=0.6.0"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "strip-ansi": "^6.0.1",
     "table": "latest",
     "text-table": "latest",
-    "xpath": "^0.0.33"
+    "xpath": "latest"
   },
   "devDependencies": {
     "chai": "^4.3.10",


### PR DESCRIPTION
In some cases, the tool called xpath.select() with an object that was not a DOM element. With v0.0.33 of the xpath module, the error was silently ignored. But with v0.0.34 of the xpath module, this caused an error message like so: 

```
Error: Context node does not appear to be a valid DOM node.
    at XPath.evaluate (/Users/dchiesa/dev/apigeelint/node_modules/xpath/xpath.js:1359:19)
    at XPathExpression.evaluate (/Users/dchiesa/dev/apigeelint/node_modules/xpath/xpath.js:4536:33)
    at exports.selectWithResolver (/Users/dchiesa/dev/apigeelint/node_modules/xpath/xpath.js:4989:33)
    at exports.select (/Users/dchiesa/dev/apigeelint/node_modules/xpath/xpath.js:4969:24)
    at FlowPhase.getSteps (/Users/dchiesa/dev/apigeelint/lib/package/FlowPhase.js:50:21)
    at /Users/dchiesa/dev/apigeelint/lib/package/Endpoint.js:306:35
    at Array.forEach (<anonymous>)
    at /Users/dchiesa/dev/apigeelint/lib/package/Endpoint.js:304:17
    at Array.forEach (<anonymous>)
    at Endpoint.getSteps (/Users/dchiesa/dev/apigeelint/lib/package/Endpoint.js:299:8)
```

The primary cause was sloppy initialization of child fields in Endpoint.js. 

The problem was exacerbated by
1.  a bug in the Flow.js module that treated all flows as sharedflows
2.  ignoring exceptions in some plugins