### PR TITLE
fix: re-order checks for Is and IsNot

### DIFF
--- a/build/ConditionParser.js
+++ b/build/ConditionParser.js
@@ -321,8 +321,8 @@ function peg$parse(input, options) {
   var peg$f11 = function() {return "OR"; };
   var peg$f12 = function() { return "EqualsCaseInsensitive"; };
   var peg$f13 = function() {return "StartsWith";};
-  var peg$f14 = function() { return "Equals"; };
-  var peg$f15 = function() { return "NotEquals"; };
+  var peg$f14 = function() { return "NotEquals"; };
+  var peg$f15 = function() { return "Equals"; };
   var peg$f16 = function() {return "GreaterThanOrEquals";};
   var peg$f17 = function() {return "GreaterThan";};
   var peg$f18 = function() {return "LesserThanOrEquals";};
@@ -331,8 +331,8 @@ function peg$parse(input, options) {
   var peg$f21 = function() {return "MatchesPath";};
   var peg$f22 = function() {return "Matches";};
   var peg$f23 = function() {return "StartsWith";};
-  var peg$f24 = function() { return "Equals"; };
-  var peg$f25 = function() { return "NotEquals"; };
+  var peg$f24 = function() { return "NotEquals"; };
+  var peg$f25 = function() { return "Equals"; };
   var peg$f26 = function() {return "GreaterThanOrEquals";};
   var peg$f27 = function() {return "GreaterThan";};
   var peg$f28 = function() {return "LesserThanOrEquals";};
@@ -1154,7 +1154,7 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parseop_equals();
+        s1 = peg$parseop_notequals();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$f14();
@@ -1162,7 +1162,7 @@ function peg$parse(input, options) {
         s0 = s1;
         if (s0 === peg$FAILED) {
           s0 = peg$currPos;
-          s1 = peg$parseop_notequals();
+          s1 = peg$parseop_equals();
           if (s1 !== peg$FAILED) {
             peg$savedPos = s0;
             s1 = peg$f15();
@@ -1250,7 +1250,7 @@ function peg$parse(input, options) {
     s0 = s1;
     if (s0 === peg$FAILED) {
       s0 = peg$currPos;
-      s1 = peg$parseop_equals();
+      s1 = peg$parseop_notequals();
       if (s1 !== peg$FAILED) {
         peg$savedPos = s0;
         s1 = peg$f24();
@@ -1258,7 +1258,7 @@ function peg$parse(input, options) {
       s0 = s1;
       if (s0 === peg$FAILED) {
         s0 = peg$currPos;
-        s1 = peg$parseop_notequals();
+        s1 = peg$parseop_equals();
         if (s1 !== peg$FAILED) {
           peg$savedPos = s0;
           s1 = peg$f25();

--- a/lib/peggy/Apigee-Condition.pegjs
+++ b/lib/peggy/Apigee-Condition.pegjs
@@ -110,8 +110,8 @@ op_or = "or"i / "||"
 op_accepts_literal
   = op_equalsnocase { return "EqualsCaseInsensitive"; }
   / op_startswith {return "StartsWith";}
-  / op_equals { return "Equals"; }
   / op_notequals { return "NotEquals"; }
+  / op_equals { return "Equals"; }
   / op_greatereq {return "GreaterThanOrEquals";}
   / op_greater {return "GreaterThan";}
   / op_lessereq {return "LesserThanOrEquals";}
@@ -122,8 +122,8 @@ op_accepts_literal
 
 op_accepts_variable
   = op_startswith {return "StartsWith";}
-  / op_equals { return "Equals"; }
   / op_notequals { return "NotEquals"; }
+  / op_equals { return "Equals"; }
   / op_greatereq {return "GreaterThanOrEquals";}
   / op_greater {return "GreaterThan";}
   / op_lessereq {return "LesserThanOrEquals";}

--- a/test/specs/ConditionParserTest.js
+++ b/test/specs/ConditionParserTest.js
@@ -204,11 +204,22 @@ describe("ConditionParser", function () {
       }
     });
 
-    const validOperators = ["equals", "notquals", "isnot", "is"];
+    const validOperators = ["equals", "notequals", "isnot", "is"];
     validOperators.forEach((goodOp) => {
-      const badOp = goodOp + "a";
+      const expr = (op) =>
+        `request.formparam.grant_type ${op} "authorization_code"`;
+      it(`accepts ${goodOp} as an operator`, function () {
+        const c1 = expr(goodOp);
+        try {
+          parser.parse(c1);
+          expect(true);
+        } catch (_e) {
+          expect.fail();
+        }
+      });
+      const badOp = `${goodOp}a`;
       it(`rejects ${badOp} as an operator`, function () {
-        const c1 = `request.formparam.grant_type ${badOp} "authorization_code"`;
+        const c1 = expr(badOp);
         try {
           parser.parse(c1);
           expect.fail();


### PR DESCRIPTION
The checks for Is and IsNot were in the incorrect order. This change corrects that. 
And adds tests for same. This addresses #422 . 