### PR TITLE
[DevOps] Add CodeClimate style fomatter to use apigee-lint into GitLab CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ apigeelint -s sampleProxy/apiproxy -f table.js
 
 Where `-s` points to the apiProxy source directory and `-f` is the output formatter desired.
 
-Possible formatters are: "json.js" (the default), "stylish.js", "compact.js", "codeframe.js", "html.js", "table.js", "unix.js", "visualstudio.js", "checkstyle.js", "jslint-xml.js", "junit.js" and "tap.js".
+Possible formatters are: "json.js" (the default), "stylish.js", "compact.js", "codeframe.js", "codeclimate.js", "html.js", "table.js", "unix.js", "visualstudio.js", "checkstyle.js", "jslint-xml.js", "junit.js" and "tap.js".
 
 ### More Examples
 
@@ -162,6 +162,29 @@ The selection of a profile affects other checks, too. For example, [the Google
 Authentication feature](https://cloud.google.com/apigee/docs/api-platform/security/google-auth/overview)
 is available only in X/hybrid.
 
+#### Pipeline lint job integration
+
+##### GitLab CI/CD
+
+On GitLab CI/CD, on your `.gitlab-ci.yml` you can use codequality report artifact to get
+a report supported by GitLab. Once the CI/CD has been completed, a new tab appears in your
+Pipeline named "[Code Quality](https://docs.gitlab.com/ee/ci/testing/code_quality.html)".
+This new tab lets you easily view the information from the apigeelint job, with the associated
+severity level and lines affected. A widget with the same information appears during merge requests.
+
+```yml
+apigeelint:
+  stage: lint
+  image: node:12-alpine
+  before_script:
+    - npm install -g apigeelint
+  script:
+    - apigeelint -f codeclimate.js > apigeelint-results.json
+  artifacts:
+    reports:
+      codequality:
+        - "${CI_PROJECT_DIR}/apigeelint-results.json"
+```
 
 ## Does this tool just lint or does it also check style?
 

--- a/lib/package/third_party/formatters/codeclimate.js
+++ b/lib/package/third_party/formatters/codeclimate.js
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview CodeClimate Reporter
+ * @author ipierre1
+ */
+"use strict";
+const crypto = require('crypto');
+
+/**
+ * Returns the severity of warning or error
+ * @param {Object} message message object to examine
+ * @returns {string} severity level
+ * @private
+ */
+function getMessageType(message) {
+    if (message.fatal || message.severity === 2) {
+        return "major";
+    } else if (message.severity === 1) {
+        return "minor";
+    } else {
+        return "info";
+    }
+}
+
+/**
+ * Generates a fingerprint for the issue based on its properties
+ * @param {Object} issue issue object
+ * @returns {string} fingerprint
+ * @private
+ */
+function generateFingerprint(issue) {
+    const data = `${issue.check_name}-${issue.location.path}-${issue.location.lines.begin}`;
+    return crypto.createHash('md5').update(data).digest('hex');
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+module.exports = function(results) {
+
+    let output = [];
+
+    results.forEach(result => {
+
+        const messages = result.messages;
+
+        messages.forEach(message => {
+            const type = getMessageType(message);
+
+            const issue = {
+                "type": "issue",
+                "check_name": message.ruleId || "unknown_rule",
+                "description": message.message || "",
+                "categories": ["lint"],
+                "location": {
+                    "path": result.filePath,
+                    "lines": {
+                        "begin": message.line || 0
+                    }
+                },
+                "fingerprint": generateFingerprint({
+                    "check_name": message.ruleId || "unknown_rule",
+                    "location": {
+                        "path": result.filePath,
+                        "lines": {
+                            "begin": message.line || 0
+                        }
+                    }
+                }),
+                "severity": type
+            };
+
+            output.push(issue);
+        });
+
+    });
+
+    return JSON.stringify(output, null, 2);
+};


### PR DESCRIPTION
Linked to issue : https://github.com/apigee/apigeelint/issues/427

To use full functionnalities on GitLab CI/CD, it would be nice to implement codeclimate formatter to use codequality reports artifact into pipeline job artifacts as bellow: 

```yml
apigeelint:
  stage: lint
  image: node:12-alpine
  before_script:
    - npm install -g apigeelint
  script:
    - apigeelint -f codeclimate.js > apigeelint-results.json
  artifacts:
    reports:
      codequality:
        - "${CI_PROJECT_DIR}/apigeelint-results.json"
```

Code Quality of GitLab use CodeClimate json format, with enforcement on fingerprint which is not optional for GitLab CI/CD.

Codequality : https://docs.gitlab.com/ee/ci/testing/code_quality.html
Codeclimate specification : https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
