### PR TITLE
feat: BN012 plugin to find unreferenced targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ This is the current list:
 | &nbsp; |:white_check_mark:| BN009 | Statistics Collector - duplicate policies |  Warn on duplicate policies when no conditions are present or conditions are duplicates. |
 | &nbsp; |:white_check_mark:| BN010 | Missing policies | Issue an error if a referenced policy is not present in the bundle. |
 | &nbsp; |:white_check_mark:| BN011 | Check each XML file for well-formedness.|
+| &nbsp; |:white_check_mark:| BN012 | unreferrenced Target Endpoints | Check that each TargetEndpoint can be reached. |
 | Proxy Definition | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| PD001 | RouteRules to Targets | RouteRules should map to defined Targets. |
 | &nbsp; |:white_check_mark:| PD002 | Unreachable Route Rules - defaults |  Only one RouteRule should be present without a condition. |

--- a/lib/package/plugins/BN012-unreferencedTargets.js
+++ b/lib/package/plugins/BN012-unreferencedTargets.js
@@ -1,0 +1,77 @@
+/*
+  Copyright 2019-2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const ruleId = require("../myUtil.js").getRuleId(),
+  util = require("util"),
+  debug = require("debug")("apigeelint:" + ruleId);
+
+const plugin = {
+  ruleId,
+  name: "Check for unreferenced targets",
+  message:
+    "Unreferenced targets are dead code; should be removed from bundles.",
+  fatal: false,
+  severity: 1, //1=warn, 2=error
+  nodeType: "Bundle",
+  enabled: true
+};
+
+const onBundle = function (bundle, cb) {
+  const proxies = bundle.getProxyEndpoints(),
+    targets = bundle
+      .getTargetEndpoints()
+      .reduce((a, c) => ((a[c.getName()] = { count: 0, ep: c }), a), {});
+  debug(`targetmap: ${util.format(targets)}`);
+  let flagged = false;
+  if (Object.keys(targets).length) {
+    proxies.forEach((proxyEndpoint, _pix) => {
+      const routeRules = proxyEndpoint.getRouteRules();
+      routeRules.forEach((rr, rrix) => {
+        const targetName = rr.getTargetEndpoint();
+        debug(`rr${rrix} = "${targetName}"`);
+        if (targetName) {
+          if (targets[targetName]) {
+            targets[targetName].count++;
+          } else {
+            // unknown target - caught by a different plugin
+          }
+        }
+      });
+    });
+    const unreferenced = Object.keys(targets).filter(
+      (key) => targets[key].count == 0
+    );
+    if (unreferenced.length) {
+      flagged = true;
+      unreferenced.forEach((tepname) => {
+        debug(`unreferenced: ${tepname}`);
+        bundle.addMessage({
+          plugin,
+          entity: targets[tepname].ep,
+          message: `Unreferenced TargetEndpoint ${tepname}. There are no RouteRules that reference this TargetEndpoint.`
+        });
+      });
+    }
+  }
+  if (typeof cb == "function") {
+    cb(null, flagged);
+  }
+};
+
+module.exports = {
+  plugin,
+  onBundle
+};

--- a/test/fixtures/resources/BN012-unreferenced-target/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
+++ b/test/fixtures/resources/BN012-unreferenced-target/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='AM-Inject-Proxy-Revision-Header'>
+  <Set>
+    <Headers>
+      <Header name='APIProxy'>{apiproxy.name} r{apiproxy.revision}</Header>
+    </Headers>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/BN012-unreferenced-target/apiproxy/policies/RF-Unknown-Request.xml
+++ b/test/fixtures/resources/BN012-unreferenced-target/apiproxy/policies/RF-Unknown-Request.xml
@@ -1,0 +1,16 @@
+<RaiseFault name='RF-Unknown-Request'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <FaultResponse>
+    <Set>
+      <Payload contentType='application/json'>{
+  "error" : {
+    "code" : 404.01,
+    "message" : "that request was unknown; try a different request."
+  }
+}
+</Payload>
+      <StatusCode>404</StatusCode>
+      <ReasonPhrase>Not Found</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+</RaiseFault>

--- a/test/fixtures/resources/BN012-unreferenced-target/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/BN012-unreferenced-target/apiproxy/proxies/endpoint1.xml
@@ -1,0 +1,70 @@
+<ProxyEndpoint name="endpoint1">
+
+  <HTTPProxyConnection>
+    <BasePath>/unreferenced-target</BasePath>
+    <Properties/>
+    <VirtualHost>secure</VirtualHost>
+  </HTTPProxyConnection>
+
+  <FaultRules/>
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Revision-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <PreFlow name="PreFlow">
+    <Request/>
+    <Response/>
+  </PreFlow>
+
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response>
+      <Step>
+        <Name>AM-Inject-Proxy-Revision-Header</Name>
+      </Step>
+    </Response>
+  </PostFlow>
+
+  <PostClientFlow name="PostClientFlow">
+    <Request/>
+    <Response>
+    </Response>
+  </PostClientFlow>
+
+  <Flows>
+    <Flow name="t1">
+      <Request>
+      </Request>
+      <Response>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/t1" and request.verb = "GET"</Condition>
+    </Flow>
+
+    <Flow name="t2">
+      <Request>
+      </Request>
+      <Response>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/t2" and request.verb = "POST"</Condition>
+    </Flow>
+
+    <Flow name="unknown request">
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+    </Flow>
+
+  </Flows>
+
+  <RouteRule name="default">
+    <TargetEndpoint>target-1</TargetEndpoint>
+  </RouteRule>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/BN012-unreferenced-target/apiproxy/proxies/endpoint2.xml
+++ b/test/fixtures/resources/BN012-unreferenced-target/apiproxy/proxies/endpoint2.xml
@@ -1,0 +1,70 @@
+<ProxyEndpoint name="endpoint2">
+
+  <HTTPProxyConnection>
+    <BasePath>/unreferenced-target/2</BasePath>
+    <Properties/>
+    <VirtualHost>secure</VirtualHost>
+  </HTTPProxyConnection>
+
+  <FaultRules/>
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Revision-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <PreFlow name="PreFlow">
+    <Request/>
+    <Response/>
+  </PreFlow>
+
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response>
+      <Step>
+        <Name>AM-Inject-Proxy-Revision-Header</Name>
+      </Step>
+    </Response>
+  </PostFlow>
+
+  <PostClientFlow name="PostClientFlow">
+    <Request/>
+    <Response>
+    </Response>
+  </PostClientFlow>
+
+  <Flows>
+    <Flow name="t1">
+      <Request>
+      </Request>
+      <Response>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/t1" and request.verb = "GET"</Condition>
+    </Flow>
+
+    <Flow name="t2">
+      <Request>
+      </Request>
+      <Response>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/t2" and request.verb = "POST"</Condition>
+    </Flow>
+
+    <Flow name="unknown request">
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+    </Flow>
+
+  </Flows>
+
+  <RouteRule name="default">
+    <TargetEndpoint>target-2</TargetEndpoint>
+  </RouteRule>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/BN012-unreferenced-target/apiproxy/targets/target-1.xml
+++ b/test/fixtures/resources/BN012-unreferenced-target/apiproxy/targets/target-1.xml
@@ -1,0 +1,26 @@
+<TargetEndpoint name="target-1">
+  <Description/>
+  <FaultRules/>
+  <PreFlow name="PreFlow">
+    <Request/>
+    <Response/>
+  </PreFlow>
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response/>
+  </PostFlow>
+  <Flows/>
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+    </SSLInfo>
+    <Properties>
+      <Property name="success.codes">1xx,2xx,3xx</Property>
+      <Property name="request.retain.headers">User-Agent,Referer,Accept-Language</Property>
+      <Property name="retain.queryparams">apikey</Property>
+    </Properties>
+
+    <URL>https://target-1.demo.altostrat.com</URL>
+  </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/BN012-unreferenced-target/apiproxy/targets/target-2.xml
+++ b/test/fixtures/resources/BN012-unreferenced-target/apiproxy/targets/target-2.xml
@@ -1,0 +1,26 @@
+<TargetEndpoint name="target-2">
+  <Description/>
+  <FaultRules/>
+  <PreFlow name="PreFlow">
+    <Request/>
+    <Response/>
+  </PreFlow>
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response/>
+  </PostFlow>
+  <Flows/>
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+    </SSLInfo>
+    <Properties>
+      <Property name="success.codes">1xx,2xx,3xx</Property>
+      <Property name="request.retain.headers">User-Agent,Referer,Accept-Language</Property>
+      <Property name="retain.queryparams">apikey</Property>
+    </Properties>
+
+    <URL>https://target-2.demo.altostrat.com</URL>
+  </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/BN012-unreferenced-target/apiproxy/targets/target-3.xml
+++ b/test/fixtures/resources/BN012-unreferenced-target/apiproxy/targets/target-3.xml
@@ -1,0 +1,26 @@
+<TargetEndpoint name="target-3">
+  <Description/>
+  <FaultRules/>
+  <PreFlow name="PreFlow">
+    <Request/>
+    <Response/>
+  </PreFlow>
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response/>
+  </PostFlow>
+  <Flows/>
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+    </SSLInfo>
+    <Properties>
+      <Property name="success.codes">1xx,2xx,3xx</Property>
+      <Property name="request.retain.headers">User-Agent,Referer,Accept-Language</Property>
+      <Property name="retain.queryparams">apikey</Property>
+    </Properties>
+
+    <URL>https://target-3.demo.altostrat.com</URL>
+  </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/BN012-unreferenced-target/apiproxy/unreferenced-target.xml
+++ b/test/fixtures/resources/BN012-unreferenced-target/apiproxy/unreferenced-target.xml
@@ -1,0 +1,18 @@
+<APIProxy name="unused-target">
+  <ConfigurationVersion majorVersion="4" minorVersion="0"/>
+  <CreatedAt>1491498008040</CreatedAt>
+  <Description/>
+  <DisplayName>unused-target</DisplayName>
+  <LastModifiedAt>1491517153495</LastModifiedAt>
+  <Policies/>
+  <ProxyEndpoints>
+    <ProxyEndpoint>default</ProxyEndpoint>
+  </ProxyEndpoints>
+  <Resources/>
+  <Spec/>
+  <TargetServers/>
+  <TargetEndpoints>
+    <TargetEndpoint>default</TargetEndpoint>
+  </TargetEndpoints>
+  <validate>false</validate>
+</APIProxy>

--- a/test/specs/BN012-unreferenced-targets.js
+++ b/test/specs/BN012-unreferenced-targets.js
@@ -1,0 +1,69 @@
+/*
+  Copyright 2019-2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+/* global configuration, describe, it */
+const assert = require("assert"),
+  path = require("path"),
+  util = require("util"),
+  testID = "BN012",
+  debug = require("debug")("apigeelint:" + testID),
+  //Bundle = require("../../lib/package/Bundle.js"),
+  bl = require("../../lib/package/bundleLinter.js");
+
+describe("BN012 - Check for unreferenced targets", function () {
+  it("should flag unused targets in the test bundle", () => {
+    const configuration = {
+      debug: true,
+      source: {
+        type: "filesystem",
+        path: path.resolve(
+          __dirname,
+          "../fixtures/resources/BN012-unreferenced-target/apiproxy"
+        ),
+        bundleType: "apiproxy"
+      },
+      //profile: 'apigeex',
+      excluded: {},
+      setExitCode: false,
+      output: () => {} // suppress output
+    };
+
+    debug("test configuration: " + JSON.stringify(configuration));
+    bl.lint(configuration, (bundle) => {
+      const items = bundle.getReport();
+      assert.ok(items);
+      assert.ok(items.length);
+      const actualErrors = items.filter(
+        (item) => item.messages && item.messages.length
+      );
+      assert.ok(actualErrors.length);
+      debug(util.format(actualErrors));
+
+      const bn012Items = actualErrors.filter((e) =>
+        e.messages.find((m) => m.ruleId == "BN012")
+      );
+
+      debug(util.format(bn012Items));
+      assert.equal(bn012Items.length, 1);
+      debug(util.format(bn012Items[0]));
+      assert.ok(bn012Items[0].messages);
+      assert.equal(bn012Items[0].messages.length, 1);
+      assert.equal(
+        bn012Items[0].messages[0].message,
+        "Unreferenced TargetEndpoint target-3. There are no RouteRules that reference this TargetEndpoint."
+      );
+    });
+  });
+});


### PR DESCRIPTION
I was surprised to see that apigeelint did not flag unreferenced TargetEndpoints. 
This new plugin fills that gap. 