### PR TITLE
fix: correct PD003 error message

### DIFF
--- a/lib/package/plugins/PD003-emptyRouteRuleLast.js
+++ b/lib/package/plugins/PD003-emptyRouteRuleLast.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,69 +15,53 @@
 */
 
 const ruleId = require("../myUtil.js").getRuleId(),
-      debug = require("debug")("apigeelint:" + ruleId);
+  debug = require("debug")("apigeelint:" + ruleId);
 
 const plugin = {
-        ruleId,
-        name: "Unreachable Route Rules - empty conditions go last",
-        message:
-        "Check RouteRules in a ProxyEndpoint to ensure that empty condition is last.",
-        fatal: false,
-        severity: 2, //error
-        nodeType: "RouteRule",
-        enabled: true
-      };
+  ruleId,
+  name: "Unreachable Route Rules - empty conditions go last",
+  message:
+    "Check RouteRules in a ProxyEndpoint to ensure that empty condition is last.",
+  fatal: false,
+  severity: 2, // 2=error
+  nodeType: "RouteRule",
+  enabled: true
+};
 
-const processRouteRules =
-  function(endpoint) {
-    let rr = endpoint.getRouteRules();
-    debug(`found ${rr.length} RouteRules`);
-    let flagged = false;
-    let unconditionalRoutes =
-      rr.filter( r => (!r.getCondition() ||
-                       r.getCondition().getExpression() === "") );
-    let lastUncRoute = unconditionalRoutes[unconditionalRoutes.length - 1];
+const processRouteRules = function (endpoint) {
+  const rr = endpoint.getRouteRules();
+  debug(`found ${rr.length} RouteRules`);
+  let flagged = false;
+  const unconditionalRoutes = rr.filter(
+    (r) => !r.getCondition() || r.getCondition().getExpression() === ""
+  );
+  const lastUncRoute = unconditionalRoutes[unconditionalRoutes.length - 1];
 
-    if (unconditionalRoutes.length > 0) {
-      // This check is done by PD002.
+  if (unconditionalRoutes.length > 0) {
+    // The check for multiple RRs with no condition, is done by PD002.
 
-      // debug(`found ${unconditionalRoutes.length} RouteRules with no Condition`);
-      // if (unconditionalRoutes.length > 1) {
-      //   flagged = true;
-      //   endpoint.addMessage({
-      //     source: lastUncRoute.getSource(),
-      //     line: lastUncRoute.getElement().lineNumber,
-      //     column: lastUncRoute.getElement().columnNumber,
-      //     plugin,
-      //     message:
-      //     `Endpoint has too many unconditional RouteRules (${unconditionalRoutes.length}). Only the last will apply.`
-      //   });
-      // }
-
-      // check if unconditional is not final route
-      let lastRoute = rr[rr.length - 1];
-      if (lastRoute != lastUncRoute) {
-        flagged = true;
-        endpoint.addMessage({
-          source: lastUncRoute.getSource(),
-          line: lastUncRoute.getElement().lineNumber,
-          column: lastUncRoute.getElement().columnNumber,
-          plugin,
-          message:
-          `Endpoint has an unconditional RouteRule that is not the final RouteRule. It will be ignored.`
-        });
-      }
+    // check if unconditional is not final route
+    const lastRoute = rr[rr.length - 1];
+    if (lastRoute != lastUncRoute) {
+      flagged = true;
+      endpoint.addMessage({
+        source: lastUncRoute.getSource(),
+        line: lastUncRoute.getElement().lineNumber,
+        column: lastUncRoute.getElement().columnNumber,
+        plugin,
+        message: `Endpoint has an unconditional RouteRule that is not the final RouteRule.`
+      });
     }
-    return flagged;
-  };
+  }
+  return flagged;
+};
 
-const onProxyEndpoint =
-  function(ep, cb) {
-    let flagged = processRouteRules(ep);
-    if (typeof cb == "function") {
-      cb(null, flagged);
-    }
-  };
+const onProxyEndpoint = function (ep, cb) {
+  const flagged = processRouteRules(ep);
+  if (typeof cb == "function") {
+    cb(null, flagged);
+  }
+};
 
 module.exports = {
   plugin,

--- a/test/specs/PD003-conditions-on-RouteRules.js
+++ b/test/specs/PD003-conditions-on-RouteRules.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -16,45 +16,50 @@
 
 /* global describe, it */
 
-const ruleId = 'PD003',
-      assert = require("assert"),
-      path = require("path"),
-      util = require("util"),
-      debug = require("debug")(`apigeelint:${ruleId}`),
-      bl = require("../../lib/package/bundleLinter.js");
+const ruleId = "PD003",
+  assert = require("assert"),
+  path = require("path"),
+  util = require("util"),
+  debug = require("debug")(`apigeelint:${ruleId}`),
+  bl = require("../../lib/package/bundleLinter.js");
 
 describe(`${ruleId} - bundle with unconditional routes`, () => {
-  it('should generate the expected errors', () => {
-    let configuration = {
-          debug: true,
-          source: {
-            type: "filesystem",
-            path: path.resolve(__dirname, '../fixtures/resources/PD003/apiproxy'),
-            bundleType: "apiproxy"
-          },
-          profile: 'apigeex',
-          excluded: {},
-          setExitCode: false,
-          output: () => {} // suppress output
-        };
+  it("should generate the expected errors", () => {
+    const configuration = {
+      debug: true,
+      source: {
+        type: "filesystem",
+        path: path.resolve(__dirname, "../fixtures/resources/PD003/apiproxy"),
+        bundleType: "apiproxy"
+      },
+      profile: "apigeex",
+      excluded: {},
+      setExitCode: false,
+      output: () => {} // suppress output
+    };
 
     bl.lint(configuration, (bundle) => {
-      let items = bundle.getReport();
+      const items = bundle.getReport();
       assert.ok(items);
       assert.ok(items.length);
-      let actualErrors = items.filter(item => item.messages && item.messages.length);
+      const actualErrors = items.filter(
+        (item) => item.messages && item.messages.length
+      );
       assert.ok(actualErrors.length);
       debug(util.format(actualErrors));
 
-      let ep2 = actualErrors.find(e => e.filePath.endsWith('endpoint2.xml'));
+      const ep2 = actualErrors.find((e) =>
+        e.filePath.endsWith("endpoint2.xml")
+      );
       assert.ok(ep2);
       debug(util.format(ep2.messages));
-      let pd003Messages = ep2.messages.filter(m => m.ruleId == 'PD003');
+      const pd003Messages = ep2.messages.filter((m) => m.ruleId == "PD003");
       assert.equal(pd003Messages.length, 1);
       assert.ok(pd003Messages[0].message);
-      assert.equal(pd003Messages[0].message, 'Endpoint has an unconditional RouteRule that is not the final RouteRule. It will be ignored.');
-
+      assert.equal(
+        pd003Messages[0].message,
+        "Endpoint has an unconditional RouteRule that is not the final RouteRule."
+      );
     });
   });
-
 });


### PR DESCRIPTION
The error message for PD003 is unclear and confusing. Before this change, it reads: 
```
Endpoint has an unconditional RouteRule that is not the final RouteRule. It will be ignored.
```
It is not clear what "It" refers to, in "It will be ignored."  By convention in English, "It" to begin a sentence normally refers to the subject of the prior sentence. But here, "It" refers to the final RouteRule. So that's confusing. 

The message is clearer when stated more simply: 
```
Endpoint has an unconditional RouteRule that is not the final RouteRule.
```

Accompanying this change, there's some cleanup of commented blocks of code, and formatting changes via `prettier` . 