### PR TITLE
fix: PO012 (AssignTo hygiene) now handles missing attributes

### DIFF
--- a/lib/package/Policy.js
+++ b/lib/package/Policy.js
@@ -39,7 +39,7 @@ function Policy(path, fn, parent, doc) {
 
 Policy.prototype.getName = function () {
   if (!this.name) {
-    var attr = xpath.select("//@name", this.getElement());
+    let attr = xpath.select("//@name", this.getElement());
     this.name = (attr[0] && attr[0].value) || "";
   }
   return this.name;
@@ -47,7 +47,6 @@ Policy.prototype.getName = function () {
 
 Policy.prototype.getLines = function (start, stop) {
   //actually parse the source into lines if we haven't already and return the requested subset
-  var result = "";
   if (!this.lines) {
     this.lines = fs.readFileSync(this.filePath).toString().split("\n");
   }
@@ -68,16 +67,12 @@ Policy.prototype.getLines = function (start, stop) {
     start = stop;
   }
 
-  for (var i = start; i <= stop; i++) {
-    result += this.lines[i] + "\n";
-  }
-
-  return result;
+  return this.lines.join("\n");
 };
 
 Policy.prototype.getSource = function () {
   if (!this.source) {
-    var start = this.getElement().lineNumber - 1,
+    const start = this.getElement().lineNumber - 1,
       stop = Number.MAX_SAFE_INTEGER;
     if (
       this.getElement().nextSibling &&
@@ -93,7 +88,7 @@ Policy.prototype.getSource = function () {
 Policy.prototype.getDisplayName = function () {
   if (typeof this.displayName === "undefined") {
     this.getName();
-    let nodes = xpath.select("//DisplayName", this.getElement());
+    const nodes = xpath.select("//DisplayName", this.getElement());
     if (nodes && nodes[0]) {
       if (nodes[0].childNodes && nodes[0].childNodes[0]) {
         this.displayName = nodes[0].childNodes[0].nodeValue;
@@ -117,11 +112,10 @@ Policy.prototype.select = function (xs) {
 };
 
 Policy.prototype.getElement = function () {
-  //read the contents of the file and return it raw
   if (!this.element) {
     this.element = new Dom().parseFromString(
       fs.readFileSync(this.filePath).toString()
-    );
+    ).documentElement;
   }
   return this.element;
 };
@@ -132,13 +126,14 @@ Policy.prototype.getFileName = function () {
 
 Policy.prototype.getType = function () {
   if (!this.type) {
-    var doc = xpath.select("/", this.getElement());
+    const root = xpath.select("/", this.getElement());
     this.type =
-      (doc &&
-        doc[0] &&
-        doc[0].documentElement &&
-        doc[0].documentElement.tagName) ||
+      (root &&
+        root[0] &&
+        root[0].documentElement &&
+        root[0].documentElement.tagName) ||
       "";
+    debug(`getType() policyType: ${this.type}`);
     if (this.type === "DisplayName") {
       this.type = "";
     }

--- a/lib/package/plugins/PO012-assignMessageAssignTo.js
+++ b/lib/package/plugins/PO012-assignMessageAssignTo.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2020 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,69 +15,104 @@
 */
 
 const xpath = require("xpath"),
-      util = require('util'),
-      ruleId = require("../myUtil.js").getRuleId(),
-      debug = require("debug")("apigeelint:" + ruleId);
+  util = require("util"),
+  ruleId = require("../myUtil.js").getRuleId(),
+  debug = require("debug")("apigeelint:" + ruleId);
 
 const plugin = {
-        ruleId,
-        name: "AssignTo",
-        fatal: false,
-        severity: 1, // warning
-        nodeType: "AssignMessage",
-        enabled: true
-      };
+  ruleId,
+  name: "AssignTo",
+  fatal: false,
+  severity: 1, // warning
+  nodeType: "AssignMessage",
+  enabled: true
+};
 
-const onPolicy = function(policy, cb) {
-        let flagged = false;
-        const addMessage = (line, column, message) => {
-                policy.addMessage({plugin, message, line, column});
-                flagged = true;
-              };
-        try {
-          if (policy.getType() === "AssignMessage") {
-            const atNodes = xpath.select("/AssignMessage/AssignTo", policy.getElement());
-            if (atNodes && atNodes.length>0) {
-              debug(`${policy.fileName} found ${atNodes.length} AssignTo elements`);
-              if (atNodes.length>1) {
-                atNodes.slice(1).forEach( (node, ix) =>
-                                          addMessage(node.lineNumber, node.columnNumber, "extraneous AssignTo element"));
-              }
-              else {
-                const node = atNodes[0];
-                debug(`node: ` + util.format(node));
-                const textNodes = xpath.select('text()', node);
-                const text = textNodes[0] && textNodes[0].data;
-                debug(`text: ` + text);
-                const attrs = ['transport', 'createNew', 'type']
-                  .reduce((map, item) => {
-                    map[item] = xpath.select1('@' + item, node).value;
-                    return map;
-                  }, {});
-                debug(`attrs: ` + JSON.stringify(attrs));
-                if (attrs.transport && attrs.transport != 'http') {
-                  addMessage(node.lineNumber, node.columnNumber, "unsupported transport attribute in AssignTo element");
-                }
-                if (attrs.createNew && attrs.createNew == 'false' && !text) {
-                  addMessage(node.lineNumber, node.columnNumber, "unnecessary AssignTo with no named message");
-                }
-                if (attrs.type && attrs.type != 'request' && attrs.type != 'response') {
-                  addMessage(node.lineNumber, node.columnNumber, "unrecognized type attribute in AssignTo");
-                }
-              }
-            }
-            else {
-              debug(`${policy.fileName} found no AssignTo elements`);
-            }
+const onPolicy = function (policy, cb) {
+  let flagged = false;
+  const addMessage = (line, column, message) => {
+    policy.addMessage({ plugin, message, line, column });
+    flagged = true;
+  };
+  try {
+    if (policy.getType() === "AssignMessage") {
+      const atNodes = xpath.select(
+        "/AssignMessage/AssignTo",
+        policy.getElement()
+      );
+      const formatAttrs = (node) =>
+        node.attributes && node.attributes.length
+          ? `(attrs: ${Array.prototype.map
+              .call(node.attributes, (at) => at.localName)
+              .join(", ")})`
+          : "(no attributes)";
+
+      debug(`policy ${policy.fileName} parent ${policy.parent.root}`);
+      debug(`${policy.fileName} atNodes ${util.format(atNodes)}`);
+      if (atNodes && atNodes.length > 0) {
+        debug(`${policy.fileName} found ${atNodes.length} AssignTo elements`);
+        if (atNodes.length > 1) {
+          atNodes
+            .slice(1)
+            .forEach((node, _ix) =>
+              addMessage(
+                node.lineNumber,
+                node.columnNumber,
+                "extraneous AssignTo element"
+              )
+            );
+        } else {
+          const node = atNodes[0];
+          debug(`node: ${node.tagName} ${formatAttrs(node)}`);
+          const textNodes = xpath.select("text()", node);
+          const text = textNodes[0] && textNodes[0].data;
+          debug(`text: ` + text);
+          const attrs = ["transport", "createNew", "type"].reduce(
+            (map, item) => {
+              const attr = xpath.select1("@" + item, node);
+              map[item] = attr ? attr.value : null;
+              return map;
+            },
+            {}
+          );
+          debug(`attrs: ` + JSON.stringify(attrs));
+          if (attrs.transport && attrs.transport != "http") {
+            addMessage(
+              node.lineNumber,
+              node.columnNumber,
+              "unsupported transport attribute in AssignTo element"
+            );
           }
-          if (typeof(cb) == 'function') {
-            cb(null, flagged);
+          if (attrs.createNew && attrs.createNew == "false" && !text) {
+            addMessage(
+              node.lineNumber,
+              node.columnNumber,
+              "unnecessary AssignTo with no named message"
+            );
+          }
+          if (
+            attrs.type &&
+            attrs.type != "request" &&
+            attrs.type != "response"
+          ) {
+            addMessage(
+              node.lineNumber,
+              node.columnNumber,
+              "unrecognized type attribute in AssignTo"
+            );
           }
         }
-        catch(e) {
-          debug(util.format(e));
-        }
-      };
+      } else {
+        debug(`${policy.fileName} found no AssignTo elements`);
+      }
+    }
+    if (typeof cb == "function") {
+      cb(null, flagged);
+    }
+  } catch (e) {
+    debug(util.format(e));
+  }
+};
 
 module.exports = {
   plugin,

--- a/lib/package/plugins/PO034-am-hygiene.js
+++ b/lib/package/plugins/PO034-am-hygiene.js
@@ -126,7 +126,7 @@ const onPolicy = function (policy, cb) {
         "AssignVariable"
       ].reduce(
         (a, action, _ix) =>
-          a + xpath.select(`AssignMessage/${action}`, policyRoot).length,
+          a + xpath.select(`/AssignMessage/${action}`, policyRoot).length,
         0
       );
 
@@ -141,7 +141,10 @@ const onPolicy = function (policy, cb) {
       }
 
       // check for unknown/unsupported elements at the top level
-      const foundTopLevelChildren = xpath.select("AssignMessage/*", policyRoot);
+      const foundTopLevelChildren = xpath.select(
+        "/AssignMessage/*",
+        policyRoot
+      );
       debug(`found ${foundTopLevelChildren.length} toplevel children...`);
       foundTopLevelChildren.forEach((child) => {
         debug(`toplevel child: ${child.tagName}...`);

--- a/test/fixtures/resources/PO012-assignToHygiene/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
+++ b/test/fixtures/resources/PO012-assignToHygiene/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
@@ -1,0 +1,8 @@
+<AssignMessage name='AM-Inject-Proxy-Revision-Header'>
+  <Set>
+    <Headers>
+      <Header name='APIProxy'>{apiproxy.name} r{apiproxy.revision}</Header>
+    </Headers>
+  </Set>
+  <AssignTo createNew='false' type='request'/>
+</AssignMessage>

--- a/test/fixtures/resources/PO012-assignToHygiene/apiproxy/policies/AM-Modify-Request-Remove-ApiKey.xml
+++ b/test/fixtures/resources/PO012-assignToHygiene/apiproxy/policies/AM-Modify-Request-Remove-ApiKey.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<AssignMessage async="false" continueOnError="false" enabled="true" name="AM-ModifyRequestRemoveApiKey">
+<AssignMessage async="false" continueOnError="false" enabled="true" name="AM-Modify-Request-Remove-ApiKey">
     <!--
        here you can use this policy to remove, add, set request parameters before sending the request
        to backend. Here we are just removing x-api-key as it is not needed by backend.
     -->
-    <DisplayName>AM-ModifyRequestRemoveApiKey</DisplayName>
-    <Properties/>
+    <DisplayName>AM-Modify-Request-Remove-ApiKey</DisplayName>
     <Remove>
         <Headers>
             <Header name="x-api-key"/>

--- a/test/fixtures/resources/PO012-assignToHygiene/apiproxy/proxies/default.xml
+++ b/test/fixtures/resources/PO012-assignToHygiene/apiproxy/proxies/default.xml
@@ -4,15 +4,15 @@
 ProxyEndpoint
 =============
 
-The ProxyEndpoint configuration defines the inbound (client-facing) interface for an API proxy. 
+The ProxyEndpoint configuration defines the inbound (client-facing) interface for an API proxy.
 When you configure a ProxyEndpoint, you are setting up a network configuration that defines how client applications ('apps') should invoke the proxied API.
 While you can configure multiple ProxyEndpoints in a single API proxy, it is antipattern and should be avoided as it makes the proxy difficult to read and troubleshoot.
 
 ProxyEndpoint Pipeline can be summarized in the below graph:
 
 Front-End App ===> apigee (PreFlow  (Request)  ==> Flows (Request)  ==> Target-Endpoint(Request))  ==> Backend APIs
-              <=== apigee (PostFlow (Response) <== Flows (Response) <== Target-Endpoint(Response)) <==   
-              
+              <=== apigee (PostFlow (Response) <== Flows (Response) <== Target-Endpoint(Response)) <==
+
 ProxyEndpoint has the following elements to be configured:
     - PreFlow: Defines the policies in the PreFlow flow of a request or response.
     - Flows: Defines the policies in the conditional flows of a request or response.
@@ -20,9 +20,9 @@ ProxyEndpoint has the following elements to be configured:
     - DefaultFaultRule: Handles all errors raised by apigee or backend
     - HTTPProxyConnection: Defines the network address and URI path associated with the API proxy
         - BasePath: A required string that uniquely identifies the URI path used by Apigee Edge to route incoming messages to the proper API proxy.
-        - VirtualHost: defines which apigee virtual host would be used for this proxy. 
-    - RouteRule: Defines the destination of inbound request messages after processing by the ProxyEndpoint request pipeline. 
-    
+        - VirtualHost: defines which apigee virtual host would be used for this proxy.
+    - RouteRule: Defines the destination of inbound request messages after processing by the ProxyEndpoint request pipeline.
+
 -->
 <ProxyEndpoint name="default">
     <PreFlow name="PreFlow">
@@ -77,7 +77,7 @@ ProxyEndpoint has the following elements to be configured:
                     <Name>JS-ValidateAndSanitizeRequest</Name>
                 </Step>
                 <Step>
-                    <Name>AM-ModifyRequestRemoveApiKey</Name>
+                    <Name>AM-Modify-Request-Remove-ApiKey</Name>
                 </Step>
             </Request>
             <Response/>
@@ -109,6 +109,9 @@ ProxyEndpoint has the following elements to be configured:
         </Response>
     </PostFlow>
     <DefaultFaultRule name="default-fault">
+        <Step>
+            <Name>AM-Inject-Proxy-Revision-Header</Name>
+        </Step>
         <Step>
             <Name>AM-AddCORS</Name>
         </Step>

--- a/test/specs/PO012-assignToHygiene.js
+++ b/test/specs/PO012-assignToHygiene.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,77 +17,103 @@
 /* global describe, it */
 
 const assert = require("assert"),
-      path = require("path"),
-      bl = require("../../lib/package/bundleLinter.js");
+  path = require("path"),
+  util = require("util"),
+  ruleId = "PO012",
+  debug = require("debug")("apigeelint:" + ruleId),
+  bl = require("../../lib/package/bundleLinter.js");
 
 describe(`PO012 - AssignToHygiene`, () => {
-  it('should generate the expected errors', () => {
-    let configuration = {
-          debug: true,
-          source: {
-            type: "filesystem",
-            path: path.resolve(__dirname, '../fixtures/resources/PO012-assignToHygiene/apiproxy'),
-            bundleType: "apiproxy"
-          },
-          excluded: {},
-          setExitCode: false,
-          output: () => {} // suppress output
-        };
+  it("should generate the expected errors", () => {
+    const configuration = {
+      debug: true,
+      source: {
+        type: "filesystem",
+        path: path.resolve(
+          __dirname,
+          "../fixtures/resources/PO012-assignToHygiene/apiproxy"
+        ),
+        bundleType: "apiproxy"
+      },
+      excluded: {},
+      setExitCode: false,
+      output: () => {} // suppress output
+    };
 
+    debug(`PO012 configuration: ${util.format(configuration)}`);
     bl.lint(configuration, (bundle) => {
-      let items = bundle.getReport();
+      const items = bundle.getReport();
       assert.ok(items);
       assert.ok(items.length);
 
-      let expected = {
-            'AM-ModifyRequestRemoveApiKey.xml' : [
-              {
-                message: "unnecessary AssignTo with no named message",
-                line: 20,
-                column: 5
-              }
-            ],
-            'AM-SetCorsSecurityHeaders.xml' : [
-              {
-                message: "unnecessary AssignTo with no named message",
-                line: 28,
-                column: 5
-              }
-            ],
-            'AM-AssignProxyFlowName.xml' : [
-              {
-                message: "unnecessary AssignTo with no named message",
-                line: 12,
-                column: 5
-              }
-            ],
-            'AM-AddCORS.xml' : [
-              {
-                message: "unnecessary AssignTo with no named message",
-                line: 16,
-                column: 5
-              }
-            ]
-          };
+      const expected = {
+        "AM-Inject-Proxy-Revision-Header.xml": [
+          {
+            message: "unnecessary AssignTo with no named message",
+            line: 7,
+            column: 3
+          }
+        ],
+        "AM-Modify-Request-Remove-ApiKey.xml": [
+          {
+            message: "unnecessary AssignTo with no named message",
+            line: 19,
+            column: 5
+          }
+        ],
+        "AM-SetCorsSecurityHeaders.xml": [
+          {
+            message: "unnecessary AssignTo with no named message",
+            line: 28,
+            column: 5
+          }
+        ],
+        "AM-AssignProxyFlowName.xml": [
+          {
+            message: "unnecessary AssignTo with no named message",
+            line: 12,
+            column: 5
+          }
+        ],
+        "AM-AddCORS.xml": [
+          {
+            message: "unnecessary AssignTo with no named message",
+            line: 16,
+            column: 5
+          }
+        ]
+      };
 
-      let po012Items = items.filter( item => item.messages.some( m => m.ruleId == 'PO012'));
+      const po012Items = items.filter((item) =>
+        item.messages.some((m) => m.ruleId == "PO012")
+      );
+      debug(`po012Items: ${util.format(po012Items.map((i) => i.filePath))}`);
       assert.equal(po012Items.length, Object.keys(expected).length);
 
-      Object.keys(expected).forEach( (policyName, caseNum)  => {
-        let policyItems = items.filter( item => item.filePath.endsWith(policyName));
-        assert.equal(policyItems.length, 1);
-        let po012Messages = policyItems[0].messages.filter( m => m.ruleId == 'PO012');
-        assert.equal(po012Messages.length, expected[policyName].length);
-        po012Messages.forEach( (m, ix) => assert.equal(m.severity, 1));
+      Object.keys(expected).forEach((policyName, caseNum) => {
+        debug(`policyName: ${policyName}`);
+        const policyItems = po012Items.filter((item) =>
+          item.filePath.endsWith(policyName)
+        );
+        debug(`policyItems: ${util.format(policyItems)}`);
 
-        expected[policyName].forEach( (item, ix) => {
-          Object.keys(item).forEach( key => {
-            assert.equal(po012Messages[ix][key], item[key], `case(${caseNum}) message(${ix}) key(${key})`);
+        assert.equal(policyItems.length, 1);
+        let po012Messages = policyItems[0].messages.filter(
+          (m) => m.ruleId == "PO012"
+        );
+        assert.equal(po012Messages.length, expected[policyName].length);
+        po012Messages.forEach((m, ix) => assert.equal(m.severity, 1));
+
+        expected[policyName].forEach((item, ix) => {
+          Object.keys(item).forEach((key) => {
+            assert.equal(
+              po012Messages[ix][key],
+              item[key],
+              `${policyName} case(${caseNum}) message(${ix}) key(${key})`
+            );
           });
         });
       });
-
     });
   });
-
 });


### PR DESCRIPTION
The PO012 plugin previously would silently choke when some of the attributes on the AssignTo element were missing. 
This change fixes that.  And adds some new tests to support that.

