### PR TITLE
feat: .apigeelintrc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can install apigeellint using npm. But, there is a minimum version of `npm` 
    npm install -g apigeelint
    ```
 
-## Usage
+## Basic Usage
 
 Help
 ```
@@ -63,6 +63,7 @@ Options:
   --list                                  do not execute, instead list the available plugins and formatters
   --maxWarnings [value]                   Number of warnings to trigger nonzero exit code (default: -1)
   --profile [value]                       Either apigee or apigeex (default: apigee)
+  --norc                                  do not search for and use the .apigeelintrc file for settings
   -h, --help                              output usage information
 ```
 Example:
@@ -74,9 +75,9 @@ Where `-s` points to the apiProxy source directory and `-f` is the output format
 
 Possible formatters are: "json.js" (the default), "stylish.js", "compact.js", "codeframe.js", "codeclimate.js", "html.js", "table.js", "unix.js", "visualstudio.js", "checkstyle.js", "jslint-xml.js", "junit.js" and "tap.js".
 
-### More Examples
+## Examples
 
-#### Using External Plugins:
+### Using External Plugins:
 ```
 apigeelint -x ./externalPlugins -s path/to/your/apiproxy -f table.js
 ```
@@ -93,7 +94,7 @@ apigeelint -x ./externalPlugins -e PO007 -s path/to/your/apiproxy -f table.js
 This would effectively override the built-in naming conventions that apigeelint checks.
 
 
-#### Excluding plugins
+### Excluding plugins
 
 You can, of course, exclude plugins without providing a replacement implementation:
 
@@ -106,7 +107,7 @@ also not check for conditions on an ExtractVariables with a JSONPayload
 (`ST003`), if for some reason you wanted to do that.
 
 
-#### Writing output to a file
+### Writing output to a file
 ```
 apigeelint -s sampleProxy/apiproxy -f table.js -w existing-outputdir --quiet
 ```
@@ -120,20 +121,7 @@ is written there.
 If you do not also specify `--quiet` the report will go to both stdout and to
 the specified filesystem destination.
 
-#### Listing plugins
-
-List plugins and formatters, with or without --externalPluginsDirectory.
-```sh
-apigeelint --list
-apigeelint --list -x ./externalPlugins
-
-# or
-
-apigeelint --list --externalPluginsDirectory ./externalPlugins
-
-```
-
-#### Selecting a profile
+### Selecting a profile
 
 Apigee X/hybrid is very similar to Apigee Edge, but there are differences in the
 supported policy types, and some of the supported configuration options. For
@@ -162,9 +150,50 @@ The selection of a profile affects other checks, too. For example, [the Google
 Authentication feature](https://cloud.google.com/apigee/docs/api-platform/security/google-auth/overview)
 is available only in X/hybrid.
 
-#### Pipeline lint job integration
+### Using the .apigeelintrc file
 
-##### GitLab CI/CD
+Starting with release v2.53.0, apigeelint will look for an .apigeelintrc file, with
+settings that you want apigeelint to always use, unless overridden on the
+command line. If you want to avoid this, use the `--norc` option.
+
+
+If you DO want apigeelint to use an `.apigeelintrc` file, format the file like this:
+
+```
+# settings for apigeelint
+# Comment lines begin with octothorpe.
+
+## specify a profile
+--profile apigeex
+
+## always exclude these plugins
+--excluded TD002,TD004
+
+## use this formatter unless overridden
+--formatter table.js
+
+```
+
+Each non-blank line should have a single "option" as supported by the command-line interface.
+
+apigeelint will look for an .apigeelintrc file in these locations, in order of precedence:
+* the parent directory of the apiproxy or sharedflowbundle directory specified in the "path" argument
+* the current working directory where apigeelint is running
+* the "home" directory for the current user
+
+apigeelint stops looking for an rc file as soon as it finds one. apigeelint does
+not combine rc files from these locations.
+
+These command-line options have no effect when they appear in the rc file:
+* --path
+* --list
+* --version
+* --help
+* --norc
+
+## Pipeline lint job integration
+
+### GitLab CI/CD
 
 On GitLab CI/CD, on your `.gitlab-ci.yml` you can use codequality report artifact to get
 a report supported by GitLab. Once the CI/CD has been completed, a new tab appears in your
@@ -191,7 +220,7 @@ apigeelint:
 This tool does both traditional linting (looking for problematic patterns) and
 style checking (enforcement of conventions). You can use it for both.
 
-## Tests
+## Tests to validate the installation
 
 The `test` directory includes scripts to exercise a subset of rules. Overall linting can be tested with:
 
@@ -217,14 +246,13 @@ Run the unit tests like this:
 npm run test
 ```
 
-or, run a subset of tests like this:
+or, run the tests just for one plugin, like this:
 
 ```
-./node_modules/mocha/bin/mocha --grep PO033
+./node_modules/mocha/bin/mocha --grep "^PO033"
 ```
 
-
-You can also contribute by reporting issues, asking for new features.
+You can also contribute by reporting issues, or requesting new features.
 
 ## Rules
 

--- a/cli.js
+++ b/cli.js
@@ -16,51 +16,84 @@
   limitations under the License.
 */
 
-const program    = require("commander"),
-      fs         = require("fs"),
-      path       = require("path"),
-      bl         = require("./lib/package/bundleLinter.js"),
-      pkj        = require('./package.json'),
-      bundleType = require('./lib/package/BundleTypes.js');
+const program = require("commander"),
+  fs = require("fs"),
+  path = require("path"),
+  bl = require("./lib/package/bundleLinter.js"),
+  rc = require("./lib/package/apigeelintrc.js"),
+  pkj = require("./package.json"),
+  bundleType = require("./lib/package/BundleTypes.js");
 
 const findBundle = (p) => {
-        if (p.endsWith("/")) {
-          p = p.slice(0,-1);
-        }
-        const subdirnames = [bundleType.BundleType.SHAREDFLOW, bundleType.BundleType.APIPROXY];
-        if (subdirnames.find(n => p.endsWith(n)) && fs.statSync(p).isDirectory()) {
-          return p;
-        }
-        const subdirs = subdirnames.map(d => path.join(p, d));
+  if (p.endsWith("/")) {
+    p = p.slice(0, -1);
+  }
+  const subdirnames = [
+    bundleType.BundleType.SHAREDFLOW,
+    bundleType.BundleType.APIPROXY
+  ];
+  if (subdirnames.find((n) => p.endsWith(n)) && fs.statSync(p).isDirectory()) {
+    return p;
+  }
+  const subdirs = subdirnames.map((d) => path.join(p, d));
 
-        for (let i = 0; i<subdirs.length; i++) {
-          if (fs.existsSync(subdirs[i]) && fs.statSync(subdirs[i]).isDirectory()) {
-            if (!fs.existsSync(subdirs[1 - i]) || !fs.statSync(subdirs[1 - i]).isDirectory()) {
-              return subdirs[i];
-            }
-            throw new Error("that path appears to contain both an apiproxy and a sharedflowbundle");
-          }
-        }
-        throw new Error("that path does not appear to contain an apiproxy or sharedflowbundle");
-      };
+  for (let i = 0; i < subdirs.length; i++) {
+    if (fs.existsSync(subdirs[i]) && fs.statSync(subdirs[i]).isDirectory()) {
+      if (
+        !fs.existsSync(subdirs[1 - i]) ||
+        !fs.statSync(subdirs[1 - i]).isDirectory()
+      ) {
+        return subdirs[i];
+      }
+      throw new Error(
+        "that path appears to contain both an apiproxy and a sharedflowbundle"
+      );
+    }
+  }
+  throw new Error(
+    "that path does not appear to contain an apiproxy or sharedflowbundle"
+  );
+};
 
 program
   .version(pkj.version)
-  .option("-s, --path <path>", "Path of the exploded apiproxy or sharedflowbundle directory")
-  .option("-f, --formatter [value]", "Specify formatters (default json.js)")
+  .option(
+    "-s, --path <path>",
+    "Path of the exploded apiproxy or sharedflowbundle directory"
+  )
+  .option("-f, --formatter [value]", "Specify formatters (default: json.js)")
   .option("-w, --write [value]", "file path to write results")
-  .option("-e, --excluded [value]", "The comma separated list of tests to exclude (default: none)")
+  .option(
+    "-e, --excluded [value]",
+    "The comma separated list of tests to exclude (default: none)"
+  )
   // .option("-M, --mgmtserver [value]", "Apigee management server")
   // .option("-u, --user [value]", "Apigee user account")
   // .option("-p, --password [value]", "Apigee password")
   // .option("-o, --organization [value]", "Apigee organization")
-  .option("-x, --externalPluginsDirectory [value]", "Relative or full path to an external plugins directory")
-  .option("-q, --quiet", "do not emit the report to stdout. (can use --write option to write to file)")
-  .option("--list", "do not execute, instead list the available plugins and formatters")
-  .option("--maxWarnings [value]", "Number of warnings to trigger nonzero exit code (default: -1)")
-  .option("--profile [value]", "Either apigee or apigeex (default: apigee)");
+  .option(
+    "-x, --externalPluginsDirectory [value]",
+    "Relative or full path to an external plugins directory"
+  )
+  .option(
+    "-q, --quiet",
+    "do not emit the report to stdout. (can use --write option to write to file)"
+  )
+  .option(
+    "--list",
+    "do not execute, instead list the available plugins and formatters"
+  )
+  .option(
+    "--maxWarnings [value]",
+    "Number of warnings to trigger nonzero exit code (default: -1)"
+  )
+  .option("--profile [value]", "Either apigee or apigeex (default: apigee)")
+  .option(
+    "--norc",
+    "do not search for and use the .apigeelintrc file for settings"
+  );
 
-program.on("--help", function() {
+program.on("--help", function () {
   console.log("\nExample: apigeelint -f table.js -s sampleProxy/apiproxy");
   console.log("");
 });
@@ -68,27 +101,46 @@ program.on("--help", function() {
 program.parse(process.argv);
 
 if (program.list) {
-  console.log('available plugins: ' + bl.listRuleIds().join(', ') + '\n');
-  console.log('available formatters: ' + bl.listFormatters().join(', '));
-  if(fs.existsSync(program.externalPluginsDirectory)){
-    console.log('\n'+'available external plugins: ' + bl.listExternalRuleIds(program.externalPluginsDirectory).join(', ') + '\n');
+  console.log("available plugins: " + bl.listRuleIds().join(", ") + "\n");
+  console.log("available formatters: " + bl.listFormatters().join(", "));
+  if (fs.existsSync(program.externalPluginsDirectory)) {
+    console.log(
+      "\n" +
+        "available external plugins: " +
+        bl.listExternalRuleIds(program.externalPluginsDirectory).join(", ") +
+        "\n"
+    );
   }
   process.exit(0);
 }
 
-if ( ! program.path) {
-  console.log('you must specify the -s option, or the long form of that: --path ');
+if (!program.path) {
+  console.log(
+    "you must specify the -s option, or the long form of that: --path "
+  );
   process.exit(1);
 }
 
 program.path = findBundle(program.path);
+
+// apply RC file
+if (!program.norc) {
+  const rcSettings = rc.readRc([".apigeelintrc"], program.path);
+  if (rcSettings) {
+    Object.keys(rcSettings)
+      .filter((key) => key != "path" && key != "list" && !program[key])
+      .forEach((key) => (program[key] = rcSettings[key]));
+  }
+}
 
 const configuration = {
   debug: true,
   source: {
     type: "filesystem",
     path: program.path,
-    bundleType: program.path.includes(bundleType.BundleType.SHAREDFLOW) ? bundleType.BundleType.SHAREDFLOW : bundleType.BundleType.APIPROXY
+    bundleType: program.path.includes(bundleType.BundleType.SHAREDFLOW)
+      ? bundleType.BundleType.SHAREDFLOW
+      : bundleType.BundleType.APIPROXY
   },
   externalPluginsDirectory: program.externalPluginsDirectory,
   excluded: {},
@@ -96,7 +148,7 @@ const configuration = {
   profile: "apigee"
 };
 
-if(!isNaN(program.maxWarnings)){
+if (!isNaN(program.maxWarnings)) {
   configuration.maxWarnings = Number.parseInt(program.maxWarnings);
 }
 
@@ -105,15 +157,14 @@ if (program.formatter) {
 }
 
 if (program.quiet) {
-  configuration.output = 'none';
+  configuration.output = "none";
 }
 
-if (program.excluded && typeof(program.excluded) === "string") {
-  configuration.excluded = program
-    .excluded
-    .split(',')
-    .map(s => s.trim())
-    .reduce( (acc, item) => (acc[item] = true, acc), {});
+if (program.excluded && typeof program.excluded === "string") {
+  configuration.excluded = program.excluded
+    .split(",")
+    .map((s) => s.trim())
+    .reduce((acc, item) => ((acc[item] = true), acc), {});
 }
 
 if (program.write) {

--- a/lib/package/apigeelintrc.js
+++ b/lib/package/apigeelintrc.js
@@ -1,0 +1,59 @@
+// apigeelintrc.js
+// ------------------------------------------------------------------
+//
+// created: Mon Apr 15 18:14:54 2024
+// last saved: <2024-April-16 13:54:37>
+
+/* jshint esversion:9, node:true, strict:implied */
+/* global process, console, Buffer */
+
+const os = require("os");
+const fs = require("fs");
+const path = require("path");
+const bundleType = require("./BundleTypes.js");
+
+const locations = ["./", "~/"];
+
+const untildify = (() => {
+  const homedir = os.homedir();
+  return (pathToResolve) =>
+    homedir ? pathToResolve.replace(/^~(?=$|\/|\\)/, homedir) : pathToResolve;
+})();
+
+const findRc = (settingsfiles, sourcedir) => {
+  const combine = (a, b) =>
+    a.flatMap((ax) => b.map((bx) => untildify(path.join(ax, bx))));
+  if (
+    sourcedir.endsWith(bundleType.BundleType.SHAREDFLOW) ||
+    sourcedir.endsWith(bundleType.BundleType.APIPROXY)
+  ) {
+    sourcedir = path.dirname(sourcedir);
+  }
+
+  return combine([sourcedir, ...locations], settingsfiles).find(
+    (candidate) => fs.existsSync(candidate) && fs.statSync(candidate).isFile()
+  );
+};
+
+const readRc = (settingsfiles, sourcedir) => {
+  const rcFile = findRc(settingsfiles, sourcedir);
+  if (rcFile) {
+    const lines = fs
+      .readFileSync(rcFile, "utf-8")
+      .split("\n")
+      .map((s) => s.trim())
+      .filter((s) => s && !s.startsWith("#"));
+    return lines.reduce((a, line) => {
+      if (line.startsWith("--")) {
+        const [setting, value] = line.slice(2).split(" ", 2);
+        a[setting] = value;
+      }
+      return a;
+    }, {});
+  }
+};
+
+module.exports = {
+  readRc,
+  findRc
+};


### PR DESCRIPTION
This change adds support for reading program options from an .apigeelintrc file. 
And, there is a new option, `--norc` , which tells apigee to not look for an `.apigeelintrc` file. 

Beyond that, no functional changes. 

Also updated the README. 

Please review before merge! 