### PR TITLE
feat: PO035 hygiene check for Quota policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ This is the current list:
 | &nbsp; |:white_check_mark:| PO032 | CORS policy hygiene | In a CORS policy, wildcard origins should generate a warning. And other hygiene checks.|
 | &nbsp; |:white_check_mark:| PO033 | ExtractVariables policy hygiene | In an ExtractVariables policy, check variable types and other hygiene. |
 | &nbsp; |:white_check_mark:| PO034 | AssignMessage policy hygiene | In an AssignMessage policy, check element placement and other hygiene. |
+| &nbsp; |:white_check_mark:| PO035 | Quota policy hygiene | In a Quota policy, check element placement and other hygiene. |
 | FaultRules | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| FR001 | No Condition on FaultRule | Use Condition elements on FaultRules, unless it is the fallback rule. |
 | &nbsp; |:white_check_mark:| FR002 | DefaultFaultRule Structure | DefaultFaultRule should have only supported child elements, at most one AlwaysEnforce element, and at most one Condition element. |

--- a/lib/package/plugins/PO035-quota-hygiene.js
+++ b/lib/package/plugins/PO035-quota-hygiene.js
@@ -1,0 +1,378 @@
+/*
+  Copyright 2019-2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const ruleId = require("../myUtil.js").getRuleId(),
+  debug = require("debug")("apigeelint:" + ruleId),
+  xpath = require("xpath");
+
+const plugin = {
+  ruleId,
+  name: "Check for element placement within Quota",
+  fatal: false,
+  severity: 2, // error
+  nodeType: "Policy",
+  enabled: true
+};
+
+const allowedChildrenApigee = {
+  DisplayName: [],
+  Properties: [],
+  Allow: ["Class"],
+  Interval: [],
+  Distributed: [],
+  Synchronous: [],
+  TimeUnit: [],
+  Identifier: [],
+  MessageWeight: [],
+  StartTime: [],
+  AsynchronousConfiguration: ["SyncIntervalInSeconds", "SyncMessageCount"],
+  UseQuotaConfigInAPIProduct: ["DefaultConfig"],
+  "UseQuotaConfigInAPIProduct/DefaultConfig": ["Allow", "Interval", "TimeUnit"],
+  "UseQuotaConfigInAPIProduct/DefaultConfig/Allow": [],
+  "UseQuotaConfigInAPIProduct/DefaultConfig/Interval": [],
+  "UseQuotaConfigInAPIProduct/DefaultConfig/TimeUnit": [],
+  "AsynchronousConfiguration/SyncIntervalInSeconds": [],
+  "AsynchronousConfiguration/SyncMessageCount": [],
+  "Allow/Class": ["Allow"]
+};
+
+const additionalAllowedChildrenApigeex = {
+  CountOnly: [],
+  EnforceOnly: [],
+  SharedName: []
+};
+
+let bundleProfile = "apigee";
+const onBundle = function (bundle, cb) {
+  if (bundle.profile) {
+    bundleProfile = bundle.profile;
+    debug(`profile ${bundleProfile}...`);
+  }
+  if (typeof cb == "function") {
+    cb(null, false);
+  }
+};
+
+const onPolicy = function (quotaPolicy, cb) {
+  let foundIssue = false;
+  const addIssue = (message, line, column) => {
+    const result = {
+      ruleId: plugin.ruleId,
+      severity: plugin.severity,
+      nodeType: plugin.nodeType,
+      message,
+      line,
+      column
+    };
+    foundIssue = true;
+    quotaPolicy.addMessage(result);
+  };
+
+  const allowedChildren =
+    bundleProfile == "apigee"
+      ? allowedChildrenApigee
+      : { ...allowedChildrenApigee, ...additionalAllowedChildrenApigeex };
+  if (quotaPolicy.getType() === "Quota") {
+    try {
+      debug(`policy ${quotaPolicy.filePath}...`);
+      debug(`profile ${bundleProfile}...`);
+      const policyRoot = quotaPolicy.getElement();
+      debug(`root ${policyRoot}...`);
+      const allowedTopLevelElements = Object.keys(allowedChildren).filter(
+        (key) => !key.includes("/")
+      );
+      debug(
+        `allowed toplevel elts: ${JSON.stringify(allowedTopLevelElements)}...`
+      );
+
+      // 1. check for unknown/unsupported elements at the top level
+      const foundTopLevelChildren = xpath.select("/Quota/*", policyRoot);
+      debug(`found ${foundTopLevelChildren.length} toplevel children...`);
+      foundTopLevelChildren.forEach((child) => {
+        debug(`toplevel child: ${child.tagName}...`);
+
+        if (!allowedTopLevelElements.includes(child.tagName)) {
+          addIssue(
+            `element <${child.tagName}> is not allowed here.`,
+            child.lineNumber,
+            child.columnNumber
+          );
+        }
+      });
+
+      // 2. For 1st level children, there should be at most one.
+      allowedTopLevelElements.forEach((elementName) => {
+        const elements = xpath.select(`${elementName}`, policyRoot);
+        if (elements.length != 0 && elements.length != 1) {
+          elements
+            .slice(1)
+            .forEach((element) =>
+              addIssue(
+                `extra <${elementName}> element.`,
+                element.lineNumber,
+                element.columnNumber
+              )
+            );
+        }
+      });
+
+      // 3. There must be all of {Interval, TimeUnit, Allow}, or
+      // UseQuotaConfigInAPIProduct, but not both.
+      const useApiProductElement = xpath.select1(
+        "UseQuotaConfigInAPIProduct",
+        policyRoot
+      );
+      if (useApiProductElement) {
+        ["Interval", "TimeUnit", "Allow"].forEach((elementName) => {
+          const elements = xpath.select(`Quota/${elementName}`, policyRoot);
+          if (elements.length > 0) {
+            addIssue(
+              `element <${elementName}> conflicts with <UseQuotaConfigInAPIProduct>.`
+            );
+          }
+        });
+
+        // the stepName referenced should exist
+        const elt = useApiProductElement;
+        const stepNameAttr = xpath.select1("//@stepName", elt);
+        if (!stepNameAttr) {
+          addIssue(
+            `missing stepName attribute.`,
+            elt.lineNumer,
+            elt.columnNumber
+          );
+        } else {
+          try {
+            const referencedCredentialVerificationPolicy = stepNameAttr.value;
+            if (
+              referencedCredentialVerificationPolicy == quotaPolicy.getName()
+            ) {
+              // must not refer to self
+              addIssue(
+                `the stepName attribute refers to the Quota policy itself.`,
+                elt.lineNumer,
+                elt.columnNumber
+              );
+            } else {
+              const bundlePolicies = quotaPolicy.parent.getPolicies();
+              const referredPolicy = bundlePolicies.find(
+                (p) => p.name == referencedCredentialVerificationPolicy
+              );
+              if (!referredPolicy) {
+                addIssue(
+                  `the stepName attribute refers to a policy that does not exist.`,
+                  elt.lineNumer,
+                  elt.columnNumber
+                );
+              } else {
+                // the policy must be of the correct type
+                const referredPtype = referredPolicy.getType();
+
+                if (referredPtype != "VerifyAPIKey") {
+                  if (referredPtype == "OAuthV2") {
+                    const referredPolicyElement = referredPolicy.getElement();
+                    const operation = xpath.select1(
+                      "/OAuthV2/Operation",
+                      referredPolicyElement
+                    );
+                    if (
+                      !operation.startsWith("Verify") ||
+                      !operation.endsWith("Token")
+                    ) {
+                      addIssue(
+                        `the stepName attribute refers to an OAuthV2 policy with the wrong Operation.`,
+                        elt.lineNumer,
+                        elt.columnNumber
+                      );
+                    }
+                  } else {
+                    addIssue(
+                      `the stepName attribute refers to a policy of the wrong type.`,
+                      elt.lineNumer,
+                      elt.columnNumber
+                    );
+                  }
+                }
+              }
+            }
+          } catch (e) {
+            // This error can be thrown during unit testing.
+            if (
+              e.toString() !=
+              "TypeError: quotaPolicy.parent.getPolicies is not a function"
+            ) {
+              addIssue(
+                `could not inspect policies for bundle.` + e.toString(),
+                elt.lineNumer,
+                elt.columnNumber
+              );
+            }
+          }
+        }
+      } else {
+        ["Interval", "TimeUnit", "Allow"].forEach((elementName) => {
+          const elements = xpath.select(`${elementName}`, policyRoot);
+          if (elements.length == 0) {
+            addIssue(`missing <${elementName}> element.`);
+          }
+        });
+      }
+
+      // 4. Some of the elements ought to be boolean only
+      const booleanElements = ["Distributed", "Synchronous"];
+      if (bundleProfile == "apigeex") {
+        booleanElements.push(...["CountOnly", "EnforceOnly"]);
+      }
+      booleanElements.forEach((elementName) => {
+        const element = xpath.select1(`${elementName}`, policyRoot);
+        if (element) {
+          let textValue = xpath.select1("text()", element);
+          textValue = textValue && textValue.data.trim().toLowerCase();
+          if (textValue && !["true", "false"].includes(textValue)) {
+            addIssue(
+              `value for <${elementName}> should be one of [true,false].`,
+              element.lineNumber,
+              element.columnNumber
+            );
+          }
+        }
+      });
+
+      // 5. if using CountOnly/EnforceOnly, there must be a SharedName
+      ["CountOnly", "EnforceOnly"].forEach((elementName) => {
+        const element = xpath.select1(`${elementName}`, policyRoot);
+        if (element) {
+          const requisiteElement = xpath.select1("SharedName", policyRoot);
+          if (!requisiteElement) {
+            addIssue(
+              `missing <SharedName> element when using <${elementName}>`,
+              element.lineNumber,
+              element.columnNumber
+            );
+          }
+        }
+      });
+
+      // 6. For MessageWeight, disallow text(), require @ref
+      const mwElement = xpath.select1(`MessageWeight`, policyRoot);
+      if (mwElement) {
+        const textValue = xpath.select1("text()", mwElement);
+        if (textValue) {
+          addIssue(
+            `element <${mwElement.tagName}> must not have a text value.`,
+            mwElement.lineNumber,
+            mwElement.columnNumber
+          );
+        }
+
+        const ref = xpath.select1("//@ref", mwElement);
+        debug(`checking for ref attr...${ref}`);
+        debug(`!ref attr truthy...${!ref}`);
+        if (!ref) {
+          addIssue(
+            `element <${mwElement.tagName}> must have a ref attribute.`,
+            mwElement.lineNumber,
+            mwElement.columnNumber
+          );
+        }
+      }
+
+      // 7. For AsynchronousConfiguration, only one child
+      const asyncElement = xpath.select1(
+        `AsynchronousConfiguration`,
+        policyRoot
+      );
+      if (asyncElement) {
+        const validChildElements = [
+          "SyncIntervalInSeconds",
+          "SyncMessageCount"
+        ];
+        const condition = validChildElements
+          .map((n) => `self::${n}`)
+          .join(" or ");
+
+        const children = xpath.select(`*[${condition}]`, asyncElement);
+        if (children.length != 1) {
+          addIssue(
+            `element <${
+              asyncElement.tagName
+            }> must have exactly one of {${validChildElements.join(
+              ", "
+            )}} as a child.`,
+            asyncElement.lineNumber,
+            asyncElement.columnNumber
+          );
+        }
+        const child = children[0];
+        const textValue = xpath.select1("text()", child);
+        debug(`asynch textValue (${textValue})...`);
+
+        const intValue = textValue && parseInt(textValue, 10);
+        if (!textValue || !intValue || intValue <= 0) {
+          addIssue(
+            `element <${child.tagName}> must have a text value representing an integer.`,
+            child.lineNumber,
+            child.columnNumber
+          );
+        }
+      }
+
+      // 8. For any valid element, check allowed children.
+      Object.keys(allowedChildren).forEach((elementPath) => {
+        debug(`checking allowedChildren for ${elementPath}...`);
+        const childElements = xpath.select(`${elementPath}/*`, policyRoot);
+        if (elementPath.includes("/")) {
+          debug(`child elements (${childElements})...`);
+        }
+        debug(`examining each child of ${elementPath}...`);
+
+        childElements.forEach((childElement) => {
+          try {
+            const qualifiedPath = `${childElement.parentNode.tagName}/${childElement.tagName}`;
+            debug(`checking(1) ${qualifiedPath}...`);
+            if (!allowedChildren[elementPath].includes(childElement.tagName)) {
+              addIssue(
+                `element <${childElement.tagName}> is not allowed here.`,
+                childElement.lineNumber,
+                childElement.columnNumber
+              );
+            }
+          } catch (e) {
+            addIssue(
+              `logic error: ${e}`,
+              childElement && childElement.lineNumber,
+              childElement && childElement.columnNumber
+            );
+          }
+        });
+      });
+
+      // future: add other checks here.
+    } catch (e) {
+      console.log(e);
+    }
+  }
+
+  if (typeof cb == "function") {
+    cb(null, foundIssue);
+  }
+};
+
+module.exports = {
+  plugin,
+  onBundle,
+  onPolicy
+};

--- a/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/policies/AM-Clean-Request-Headers-From-Response.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/policies/AM-Clean-Request-Headers-From-Response.xml
@@ -1,0 +1,20 @@
+<AssignMessage name='AM-Clean-Request-Headers-From-Response'>
+  <Remove>
+    <Headers>
+      <Header name='Host'/>
+      <Header name='Accept'/>
+      <Header name='Authorization'/>
+      <Header name='user-agent'/>
+      <Header name='X-Request-id'/>
+      <Header name='x-client-data'/>
+      <Header name='x-cloud-trace-context'/>
+      <Header name='X-Powered-By'/>
+      <Header name='X-b3-traceid'/>
+      <Header name='X-b3-spanid'/>
+      <Header name='X-b3-sampled'/>
+      <Header name='X-Forwarded-For'/>
+      <Header name='X-Forwarded-Port'/>
+      <Header name='X-Forwarded-Proto'/>
+    </Headers>
+  </Remove>
+</AssignMessage>

--- a/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='AM-Inject-Proxy-Revision-Header'>
+  <Set>
+    <Headers>
+      <Header name='APIProxy'>{apiproxy.name} r{apiproxy.revision}</Header>
+    </Headers>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/policies/AM-Response.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/policies/AM-Response.xml
@@ -1,0 +1,12 @@
+<AssignMessage name='AM-Response'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <Set>
+    <Payload contentType='application/json'>{
+    "status" : "ok"
+}
+</Payload>
+    <ReasonPhrase>OK</ReasonPhrase>
+    <StatusCode>200</StatusCode>
+  </Set>
+  <AssignTo>response</AssignTo>
+</AssignMessage>

--- a/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/policies/Quota-1.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/policies/Quota-1.xml
@@ -1,0 +1,7 @@
+<Quota name='Quota-1'>
+  <Identifier ref='client_id'/>
+  <!-- this is wrong: refers to a policy that does not exist -->
+  <UseQuotaConfigInAPIProduct stepName="VerifyAPIKey-1"/>
+  <Distributed>true</Distributed>
+  <Synchronous>false</Synchronous>
+</Quota>

--- a/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/policies/RF-Unknown-Request.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/policies/RF-Unknown-Request.xml
@@ -1,0 +1,16 @@
+<RaiseFault name='RF-Unknown-Request'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <FaultResponse>
+    <Set>
+      <Payload contentType='application/json'>{
+  "error" : {
+    "code" : 404.01,
+    "message" : "that request was unknown; try a different request."
+  }
+}
+</Payload>
+      <StatusCode>404</StatusCode>
+      <ReasonPhrase>Not Found</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+</RaiseFault>

--- a/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/policies/VerifyAPIKey.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/policies/VerifyAPIKey.xml
@@ -1,0 +1,3 @@
+<VerifyAPIKey name='VerifyAPIKey'>
+  <APIKey ref='request.header.X-Apikey'/>
+</VerifyAPIKey>

--- a/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/proxies/endpoint1.xml
@@ -1,0 +1,75 @@
+<ProxyEndpoint name="endpoint1">
+  <Description>Proxy Endpoint 1</Description>
+  <HTTPProxyConnection>
+    <BasePath>/test1</BasePath>
+  </HTTPProxyConnection>
+
+  <FaultRules/>
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Revision-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <PreFlow name="PreFlow">
+    <Request>
+      <Step>
+        <Name>VerifyAPIKey</Name>
+      </Step>
+      <Step>
+        <Name>Quota-1</Name>
+      </Step>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Clean-Request-Headers-From-Response</Name>
+      </Step>
+    </Response>
+  </PreFlow>
+
+  <PostFlow name="PostFlow">
+    <Request>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Inject-Proxy-Revision-Header</Name>
+      </Step>
+    </Response>
+  </PostFlow>
+
+  <PostClientFlow name="PostClientFlow">
+    <Request>
+    </Request>
+    <Response>
+    </Response>
+  </PostClientFlow>
+
+  <Flows>
+
+    <Flow name="flow1">
+      <Request>
+      </Request>
+      <Response>
+        <Step>
+          <Name>AM-Response</Name>
+        </Step>
+      </Response>
+      <Condition>(proxy.pathsuffix MatchesPath "/t1") and (request.verb = "GET")</Condition>
+    </Flow>
+
+    <Flow name="unknown request">
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+    </Flow>
+
+  </Flows>
+
+  <RouteRule name="NoRouteRule"/>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/test1.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test1/apiproxy/test1.xml
@@ -1,0 +1,4 @@
+<APIProxy revision="1" name="test1">
+  <ConfigurationVersion minorVersion="0" majorVersion="4"/>
+  <DisplayName>test1</DisplayName>
+</APIProxy>

--- a/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/policies/AM-Clean-Request-Headers-From-Response.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/policies/AM-Clean-Request-Headers-From-Response.xml
@@ -1,0 +1,20 @@
+<AssignMessage name='AM-Clean-Request-Headers-From-Response'>
+  <Remove>
+    <Headers>
+      <Header name='Host'/>
+      <Header name='Accept'/>
+      <Header name='Authorization'/>
+      <Header name='user-agent'/>
+      <Header name='X-Request-id'/>
+      <Header name='x-client-data'/>
+      <Header name='x-cloud-trace-context'/>
+      <Header name='X-Powered-By'/>
+      <Header name='X-b3-traceid'/>
+      <Header name='X-b3-spanid'/>
+      <Header name='X-b3-sampled'/>
+      <Header name='X-Forwarded-For'/>
+      <Header name='X-Forwarded-Port'/>
+      <Header name='X-Forwarded-Proto'/>
+    </Headers>
+  </Remove>
+</AssignMessage>

--- a/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='AM-Inject-Proxy-Revision-Header'>
+  <Set>
+    <Headers>
+      <Header name='APIProxy'>{apiproxy.name} r{apiproxy.revision}</Header>
+    </Headers>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/policies/AM-Response.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/policies/AM-Response.xml
@@ -1,0 +1,12 @@
+<AssignMessage name='AM-Response'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <Set>
+    <Payload contentType='application/json'>{
+    "status" : "ok"
+}
+</Payload>
+    <ReasonPhrase>OK</ReasonPhrase>
+    <StatusCode>200</StatusCode>
+  </Set>
+  <AssignTo>response</AssignTo>
+</AssignMessage>

--- a/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/policies/Quota-1.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/policies/Quota-1.xml
@@ -1,0 +1,7 @@
+<Quota name='Quota-1'>
+  <Identifier ref='client_id'/>
+  <!-- this is wrong: refers to self -->
+  <UseQuotaConfigInAPIProduct stepName="Quota-1"/>
+  <Distributed>true</Distributed>
+  <Synchronous>false</Synchronous>
+</Quota>

--- a/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/policies/RF-Unknown-Request.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/policies/RF-Unknown-Request.xml
@@ -1,0 +1,16 @@
+<RaiseFault name='RF-Unknown-Request'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <FaultResponse>
+    <Set>
+      <Payload contentType='application/json'>{
+  "error" : {
+    "code" : 404.01,
+    "message" : "that request was unknown; try a different request."
+  }
+}
+</Payload>
+      <StatusCode>404</StatusCode>
+      <ReasonPhrase>Not Found</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+</RaiseFault>

--- a/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/policies/VerifyAPIKey.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/policies/VerifyAPIKey.xml
@@ -1,0 +1,3 @@
+<VerifyAPIKey name='VerifyAPIKey'>
+  <APIKey ref='request.header.X-Apikey'/>
+</VerifyAPIKey>

--- a/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/proxies/endpoint1.xml
@@ -1,0 +1,75 @@
+<ProxyEndpoint name="endpoint1">
+  <Description>Proxy Endpoint 1</Description>
+  <HTTPProxyConnection>
+    <BasePath>/test2</BasePath>
+  </HTTPProxyConnection>
+
+  <FaultRules/>
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Revision-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <PreFlow name="PreFlow">
+    <Request>
+      <Step>
+        <Name>VerifyAPIKey</Name>
+      </Step>
+      <Step>
+        <Name>Quota-1</Name>
+      </Step>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Clean-Request-Headers-From-Response</Name>
+      </Step>
+    </Response>
+  </PreFlow>
+
+  <PostFlow name="PostFlow">
+    <Request>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Inject-Proxy-Revision-Header</Name>
+      </Step>
+    </Response>
+  </PostFlow>
+
+  <PostClientFlow name="PostClientFlow">
+    <Request>
+    </Request>
+    <Response>
+    </Response>
+  </PostClientFlow>
+
+  <Flows>
+
+    <Flow name="flow1">
+      <Request>
+      </Request>
+      <Response>
+        <Step>
+          <Name>AM-Response</Name>
+        </Step>
+      </Response>
+      <Condition>(proxy.pathsuffix MatchesPath "/t1") and (request.verb = "GET")</Condition>
+    </Flow>
+
+    <Flow name="unknown request">
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+    </Flow>
+
+  </Flows>
+
+  <RouteRule name="NoRouteRule"/>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/test2.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test2/apiproxy/test2.xml
@@ -1,0 +1,4 @@
+<APIProxy revision="1" name="test2">
+  <ConfigurationVersion minorVersion="0" majorVersion="4"/>
+  <DisplayName>test2</DisplayName>
+</APIProxy>

--- a/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/policies/AM-Clean-Request-Headers-From-Response.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/policies/AM-Clean-Request-Headers-From-Response.xml
@@ -1,0 +1,20 @@
+<AssignMessage name='AM-Clean-Request-Headers-From-Response'>
+  <Remove>
+    <Headers>
+      <Header name='Host'/>
+      <Header name='Accept'/>
+      <Header name='Authorization'/>
+      <Header name='user-agent'/>
+      <Header name='X-Request-id'/>
+      <Header name='x-client-data'/>
+      <Header name='x-cloud-trace-context'/>
+      <Header name='X-Powered-By'/>
+      <Header name='X-b3-traceid'/>
+      <Header name='X-b3-spanid'/>
+      <Header name='X-b3-sampled'/>
+      <Header name='X-Forwarded-For'/>
+      <Header name='X-Forwarded-Port'/>
+      <Header name='X-Forwarded-Proto'/>
+    </Headers>
+  </Remove>
+</AssignMessage>

--- a/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='AM-Inject-Proxy-Revision-Header'>
+  <Set>
+    <Headers>
+      <Header name='APIProxy'>{apiproxy.name} r{apiproxy.revision}</Header>
+    </Headers>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/policies/AM-Response.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/policies/AM-Response.xml
@@ -1,0 +1,12 @@
+<AssignMessage name='AM-Response'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <Set>
+    <Payload contentType='application/json'>{
+    "status" : "ok"
+}
+</Payload>
+    <ReasonPhrase>OK</ReasonPhrase>
+    <StatusCode>200</StatusCode>
+  </Set>
+  <AssignTo>response</AssignTo>
+</AssignMessage>

--- a/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/policies/Quota-1.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/policies/Quota-1.xml
@@ -1,0 +1,7 @@
+<Quota name='Quota-1'>
+  <Identifier ref='client_id'/>
+  <!-- this is wrong: refers to a policy that exists, but is of the wrong type -->
+  <UseQuotaConfigInAPIProduct stepName="AM-Response"/>
+  <Distributed>true</Distributed>
+  <Synchronous>false</Synchronous>
+</Quota>

--- a/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/policies/RF-Unknown-Request.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/policies/RF-Unknown-Request.xml
@@ -1,0 +1,16 @@
+<RaiseFault name='RF-Unknown-Request'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <FaultResponse>
+    <Set>
+      <Payload contentType='application/json'>{
+  "error" : {
+    "code" : 404.01,
+    "message" : "that request was unknown; try a different request."
+  }
+}
+</Payload>
+      <StatusCode>404</StatusCode>
+      <ReasonPhrase>Not Found</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+</RaiseFault>

--- a/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/policies/VerifyAPIKey.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/policies/VerifyAPIKey.xml
@@ -1,0 +1,3 @@
+<VerifyAPIKey name='VerifyAPIKey'>
+  <APIKey ref='request.header.X-Apikey'/>
+</VerifyAPIKey>

--- a/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/proxies/endpoint1.xml
@@ -1,0 +1,75 @@
+<ProxyEndpoint name="endpoint1">
+  <Description>Proxy Endpoint 1</Description>
+  <HTTPProxyConnection>
+    <BasePath>/test2</BasePath>
+  </HTTPProxyConnection>
+
+  <FaultRules/>
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Revision-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <PreFlow name="PreFlow">
+    <Request>
+      <Step>
+        <Name>VerifyAPIKey</Name>
+      </Step>
+      <Step>
+        <Name>Quota-1</Name>
+      </Step>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Clean-Request-Headers-From-Response</Name>
+      </Step>
+    </Response>
+  </PreFlow>
+
+  <PostFlow name="PostFlow">
+    <Request>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Inject-Proxy-Revision-Header</Name>
+      </Step>
+    </Response>
+  </PostFlow>
+
+  <PostClientFlow name="PostClientFlow">
+    <Request>
+    </Request>
+    <Response>
+    </Response>
+  </PostClientFlow>
+
+  <Flows>
+
+    <Flow name="flow1">
+      <Request>
+      </Request>
+      <Response>
+        <Step>
+          <Name>AM-Response</Name>
+        </Step>
+      </Response>
+      <Condition>(proxy.pathsuffix MatchesPath "/t1") and (request.verb = "GET")</Condition>
+    </Flow>
+
+    <Flow name="unknown request">
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+    </Flow>
+
+  </Flows>
+
+  <RouteRule name="NoRouteRule"/>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/test2.xml
+++ b/test/fixtures/resources/PO035/bundles/fail-test3/apiproxy/test2.xml
@@ -1,0 +1,4 @@
+<APIProxy revision="1" name="test2">
+  <ConfigurationVersion minorVersion="0" majorVersion="4"/>
+  <DisplayName>test2</DisplayName>
+</APIProxy>

--- a/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/policies/AM-Clean-Request-Headers-From-Response.xml
+++ b/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/policies/AM-Clean-Request-Headers-From-Response.xml
@@ -1,0 +1,20 @@
+<AssignMessage name='AM-Clean-Request-Headers-From-Response'>
+  <Remove>
+    <Headers>
+      <Header name='Host'/>
+      <Header name='Accept'/>
+      <Header name='Authorization'/>
+      <Header name='user-agent'/>
+      <Header name='X-Request-id'/>
+      <Header name='x-client-data'/>
+      <Header name='x-cloud-trace-context'/>
+      <Header name='X-Powered-By'/>
+      <Header name='X-b3-traceid'/>
+      <Header name='X-b3-spanid'/>
+      <Header name='X-b3-sampled'/>
+      <Header name='X-Forwarded-For'/>
+      <Header name='X-Forwarded-Port'/>
+      <Header name='X-Forwarded-Proto'/>
+    </Headers>
+  </Remove>
+</AssignMessage>

--- a/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
+++ b/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='AM-Inject-Proxy-Revision-Header'>
+  <Set>
+    <Headers>
+      <Header name='APIProxy'>{apiproxy.name} r{apiproxy.revision}</Header>
+    </Headers>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/policies/AM-Response.xml
+++ b/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/policies/AM-Response.xml
@@ -1,0 +1,12 @@
+<AssignMessage name='AM-Response'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <Set>
+    <Payload contentType='application/json'>{
+    "status" : "ok"
+}
+</Payload>
+    <ReasonPhrase>OK</ReasonPhrase>
+    <StatusCode>200</StatusCode>
+  </Set>
+  <AssignTo>response</AssignTo>
+</AssignMessage>

--- a/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/policies/Quota-1.xml
+++ b/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/policies/Quota-1.xml
@@ -1,0 +1,13 @@
+<Quota name='Quota-1'>
+  <Identifier ref='client_id'/>
+  <!-- this is good! -->
+  <UseQuotaConfigInAPIProduct stepName="VerifyAPIKey">
+    <DefaultConfig>
+      <Allow>120</Allow>
+      <Interval>1</Interval>
+      <TimeUnit>minute</TimeUnit>
+    </DefaultConfig>
+  </UseQuotaConfigInAPIProduct>
+  <Distributed>true</Distributed>
+  <Synchronous>false</Synchronous>
+</Quota>

--- a/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/policies/RF-Unknown-Request.xml
+++ b/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/policies/RF-Unknown-Request.xml
@@ -1,0 +1,16 @@
+<RaiseFault name='RF-Unknown-Request'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <FaultResponse>
+    <Set>
+      <Payload contentType='application/json'>{
+  "error" : {
+    "code" : 404.01,
+    "message" : "that request was unknown; try a different request."
+  }
+}
+</Payload>
+      <StatusCode>404</StatusCode>
+      <ReasonPhrase>Not Found</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+</RaiseFault>

--- a/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/policies/VerifyAPIKey.xml
+++ b/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/policies/VerifyAPIKey.xml
@@ -1,0 +1,3 @@
+<VerifyAPIKey name='VerifyAPIKey'>
+  <APIKey ref='request.header.X-Apikey'/>
+</VerifyAPIKey>

--- a/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/proxies/endpoint1.xml
@@ -1,0 +1,75 @@
+<ProxyEndpoint name="endpoint1">
+  <Description>Proxy Endpoint 1</Description>
+  <HTTPProxyConnection>
+    <BasePath>/test2</BasePath>
+  </HTTPProxyConnection>
+
+  <FaultRules/>
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Revision-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <PreFlow name="PreFlow">
+    <Request>
+      <Step>
+        <Name>VerifyAPIKey</Name>
+      </Step>
+      <Step>
+        <Name>Quota-1</Name>
+      </Step>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Clean-Request-Headers-From-Response</Name>
+      </Step>
+    </Response>
+  </PreFlow>
+
+  <PostFlow name="PostFlow">
+    <Request>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Inject-Proxy-Revision-Header</Name>
+      </Step>
+    </Response>
+  </PostFlow>
+
+  <PostClientFlow name="PostClientFlow">
+    <Request>
+    </Request>
+    <Response>
+    </Response>
+  </PostClientFlow>
+
+  <Flows>
+
+    <Flow name="flow1">
+      <Request>
+      </Request>
+      <Response>
+        <Step>
+          <Name>AM-Response</Name>
+        </Step>
+      </Response>
+      <Condition>(proxy.pathsuffix MatchesPath "/t1") and (request.verb = "GET")</Condition>
+    </Flow>
+
+    <Flow name="unknown request">
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+    </Flow>
+
+  </Flows>
+
+  <RouteRule name="NoRouteRule"/>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/test1.xml
+++ b/test/fixtures/resources/PO035/bundles/pass-test1/apiproxy/test1.xml
@@ -1,0 +1,4 @@
+<APIProxy revision="1" name="test1">
+  <ConfigurationVersion minorVersion="0" majorVersion="4"/>
+  <DisplayName>test1</DisplayName>
+</APIProxy>

--- a/test/fixtures/resources/PO035/policies/fail/Asynch-empty-SyncMessageCount-element.xml
+++ b/test/fixtures/resources/PO035/policies/fail/Asynch-empty-SyncMessageCount-element.xml
@@ -1,0 +1,11 @@
+<Quota name="Asynch-empty-SyncMessageCount-element">
+  <DisplayName>Quota-1</DisplayName>
+  <Allow countRef="my-count"/>
+  <Interval>2</Interval>
+  <TimeUnit>minute</TimeUnit>
+  <Synchronous>true</Synchronous>
+  <Identifier>verifyapikey.Quota-1.app.name</Identifier>
+  <AsynchronousConfiguration>
+    <SyncMessageCount/>
+  </AsynchronousConfiguration>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/Asynch-non-integer-SyncIntervalInSeconds-element.xml
+++ b/test/fixtures/resources/PO035/policies/fail/Asynch-non-integer-SyncIntervalInSeconds-element.xml
@@ -1,0 +1,11 @@
+<Quota name="Asynch-non-integer-SyncIntervalInSeconds-element">
+  <DisplayName>Quota-1</DisplayName>
+  <Allow countRef="my-count"/>
+  <Interval>2</Interval>
+  <TimeUnit>minute</TimeUnit>
+  <Synchronous>true</Synchronous>
+  <Identifier>verifyapikey.Quota-1.app.name</Identifier>
+  <AsynchronousConfiguration>
+    <SyncIntervalInSeconds>true</SyncIntervalInSeconds>
+  </AsynchronousConfiguration>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/Asynch-too-many-elements.xml
+++ b/test/fixtures/resources/PO035/policies/fail/Asynch-too-many-elements.xml
@@ -1,0 +1,12 @@
+<Quota name="Asynch-too-many-elements">
+  <DisplayName>Quota-1</DisplayName>
+  <Allow countRef="my-count"/>
+  <Interval>2</Interval>
+  <TimeUnit>minute</TimeUnit>
+  <Synchronous>true</Synchronous>
+  <Identifier>verifyapikey.Quota-1.app.name</Identifier>
+  <AsynchronousConfiguration>
+    <SyncIntervalInSeconds>20</SyncIntervalInSeconds>
+    <SyncMessageCount>5</SyncMessageCount>
+  </AsynchronousConfiguration>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/CountOnly-in-apigee-profile.xml
+++ b/test/fixtures/resources/PO035/policies/fail/CountOnly-in-apigee-profile.xml
@@ -1,0 +1,10 @@
+<Quota name="CountOnly-in-apigee-profile">
+  <DisplayName>Quota-1</DisplayName>
+  <Allow countRef="my-count"/>
+  <Interval>2</Interval>
+  <TimeUnit>minute</TimeUnit>
+  <Synchronous>true</Synchronous>
+  <Identifier>verifyapikey.Quota-1.app.name</Identifier>
+  <CountOnly>true</CountOnly>
+  <SharedName>common-proxy</SharedName>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/Indentifier-instead-of-Identifier.xml
+++ b/test/fixtures/resources/PO035/policies/fail/Indentifier-instead-of-Identifier.xml
@@ -1,0 +1,10 @@
+<Quota name="Indentifier-instead-of-Identifier">
+  <DisplayName>Quota-1</DisplayName>
+  <Properties/>
+  <Allow countRef="verifyapikey.Verify-API-Key-1.counter"/>
+  <Interval>1</Interval>
+  <Distributed>true</Distributed>
+  <Synchronous>true</Synchronous>
+  <TimeUnit>minute</TimeUnit>
+  <Indentifier>verifyapikey.Quota-1.app.name</Indentifier>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/MessageWeight-Explicit.xml
+++ b/test/fixtures/resources/PO035/policies/fail/MessageWeight-Explicit.xml
@@ -1,0 +1,9 @@
+<Quota name="MessageWeight-Explicit">
+  <DisplayName>Quota-1</DisplayName>
+  <Allow countRef="my-count"/>
+  <Interval>2</Interval>
+  <TimeUnit>minute</TimeUnit>
+  <Synchronous>true</Synchronous>
+  <Identifier>verifyapikey.Quota-1.app.name</Identifier>
+  <MessageWeight>2</MessageWeight>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/Missing-TimeUnit.xml
+++ b/test/fixtures/resources/PO035/policies/fail/Missing-TimeUnit.xml
@@ -1,0 +1,10 @@
+<Quota name="Missing-TimeUnit">
+  <DisplayName>Quota-1</DisplayName>
+  <Allow countRef="my-count"/>
+  <Interval>2</Interval>
+<!--
+  <TimeUnit>minute</TimeUnit>
+-->
+  <Synchronous>true</Synchronous>
+  <Identifier>verifyapikey.Quota-1.app.name</Identifier>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/Multiple-Interval.xml
+++ b/test/fixtures/resources/PO035/policies/fail/Multiple-Interval.xml
@@ -1,0 +1,9 @@
+<Quota name="Multiple-1">
+  <DisplayName>Quota-1</DisplayName>
+  <Allow countRef="my-count"/>
+  <Interval>1</Interval>
+  <Interval>2</Interval>
+  <TimeUnit>minute</TimeUnit>
+  <Synchronous>true</Synchronous>
+  <Identifier>verifyapikey.Quota-1.app.name</Identifier>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/Non-Boolean.xml
+++ b/test/fixtures/resources/PO035/policies/fail/Non-Boolean.xml
@@ -1,0 +1,8 @@
+<Quota name="Non-Boolean">
+  <DisplayName>Quota-1</DisplayName>
+  <Allow countRef="my-count"/>
+  <Interval>1</Interval>
+  <TimeUnit>minute</TimeUnit>
+  <Synchronous>probably</Synchronous>
+  <Identifier>verifyapikey.Quota-1.app.name</Identifier>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/PreciseAtSecondsLevel.xml
+++ b/test/fixtures/resources/PO035/policies/fail/PreciseAtSecondsLevel.xml
@@ -1,0 +1,13 @@
+<Quota name='##'>
+    <DisplayName>##</DisplayName>
+    <Identifier ref='${1:request.queryparam.apikey}' />
+    <!-- the count specified is used unless overridden by the variable referenced here -->
+    <Allow countRef='verifyapikey.${2:VerifyAPIKey-1}.apiproduct.developer.quota.limit' count='1000'/>
+    <!-- use the interval in the variable; if not present use the value specified here. -->
+    <Interval ref='verifyapikey.$2.apiproduct.developer.quota.interval'>1</Interval>
+    <!-- use the timeunit provided in the variable; if not present use the value specified here. -->
+    <TimeUnit ref='verifyapikey.$2.apiproduct.developer.quota.timeunit'>month</TimeUnit>
+    <Distributed>true</Distributed>
+    <Synchronous>false</Synchronous>
+    <PreciseAtSecondsLevel>false</PreciseAtSecondsLevel>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/Quota-via-Classes.xml
+++ b/test/fixtures/resources/PO035/policies/fail/Quota-via-Classes.xml
@@ -1,0 +1,14 @@
+<Quota name="Quota-via-Classes">
+  <Allow>
+    <!-- the element should be Class, not Classes -->
+    <Classes ref="quota-class">
+      <Allow class='peak' count='1000'/>
+      <Allow class='off-peak' count='5000'/>
+    </Classes>
+  </Allow>
+  <Interval>1</Interval>
+  <Distributed>true</Distributed>
+  <Synchronous>true</Synchronous>
+  <TimeUnit>minute</TimeUnit>
+  <Identifier>verifyapikey.Quota-1.app.name</Identifier>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/UseProductQuotaConfig-1.xml
+++ b/test/fixtures/resources/PO035/policies/fail/UseProductQuotaConfig-1.xml
@@ -1,0 +1,15 @@
+<Quota name='UseProductQuotaConfig-1'>
+  <Identifier ref='client_id'/>
+  <!-- this is good! -->
+  <UseQuotaConfigInAPIProduct stepName="VerifyAPIKey">
+    <DefaultConfig>
+      <Allow>120</Allow>
+      <Interval>1</Interval>
+      <TimeUnit>minute</TimeUnit>
+      <!-- this is misplaced -->
+      <Foo>minute</Foo>
+    </DefaultConfig>
+  </UseQuotaConfigInAPIProduct>
+  <Distributed>true</Distributed>
+  <Synchronous>false</Synchronous>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/UseProductQuotaConfig-missing-stepName.xml
+++ b/test/fixtures/resources/PO035/policies/fail/UseProductQuotaConfig-missing-stepName.xml
@@ -1,0 +1,13 @@
+<Quota name='UseProductQuotaConfig-missing-stepName'>
+  <Identifier ref='client_id'/>
+  <!-- missing stepName attr -->
+  <UseQuotaConfigInAPIProduct>
+    <DefaultConfig>
+      <Allow>120</Allow>
+      <Interval>1</Interval>
+      <TimeUnit>minute</TimeUnit>
+    </DefaultConfig>
+  </UseQuotaConfigInAPIProduct>
+  <Distributed>true</Distributed>
+  <Synchronous>false</Synchronous>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/messages.js
+++ b/test/fixtures/resources/PO035/policies/fail/messages.js
@@ -1,0 +1,32 @@
+// These are the error messages only for the failed policies.
+module.exports = {
+  "Indentifier-instead-of-Identifier.xml": [
+    "element <Indentifier> is not allowed here."
+  ],
+  "PreciseAtSecondsLevel.xml": [
+    "element <PreciseAtSecondsLevel> is not allowed here."
+  ],
+  "Non-Boolean.xml": ["value for <Synchronous> should be one of [true,false]."],
+  "UseProductQuotaConfig-1.xml": ["element <Foo> is not allowed here."],
+  "Multiple-Interval.xml": ["extra <Interval> element."],
+  "Missing-TimeUnit.xml": ["missing <TimeUnit> element."],
+  "UseProductQuotaConfig-missing-stepName.xml": ["missing stepName attribute."],
+  "CountOnly-in-apigee-profile.xml": [
+    "element <CountOnly> is not allowed here.",
+    "element <SharedName> is not allowed here."
+  ],
+  "MessageWeight-Explicit.xml": [
+    "element <MessageWeight> must not have a text value.",
+    "element <MessageWeight> must have a ref attribute."
+  ],
+  "Asynch-too-many-elements.xml": [
+    "element <AsynchronousConfiguration> must have exactly one of {SyncIntervalInSeconds, SyncMessageCount} as a child."
+  ],
+  "Asynch-non-integer-SyncIntervalInSeconds-element.xml": [
+    "element <SyncIntervalInSeconds> must have a text value representing an integer."
+  ],
+  "Asynch-empty-SyncMessageCount-element.xml": [
+    "element <SyncMessageCount> must have a text value representing an integer."
+  ],
+  "Quota-via-Classes.xml": ["element <Classes> is not allowed here."]
+};

--- a/test/fixtures/resources/PO035/policies/pass/Quota-1.xml
+++ b/test/fixtures/resources/PO035/policies/pass/Quota-1.xml
@@ -1,0 +1,10 @@
+<Quota async="false" continueOnError="false" enabled="true" name="Quota-1">
+  <DisplayName>Quota-1</DisplayName>
+  <Properties/>
+  <Allow countRef="verifyapikey.Verify-API-Key-1.counter"/>
+  <Interval>1</Interval>
+  <Distributed>true</Distributed>
+  <Synchronous>true</Synchronous>
+  <TimeUnit>minute</TimeUnit>
+  <Identifier>verifyapikey.Quota-1.app.name</Identifier>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/pass/Quota-via-Class.xml
+++ b/test/fixtures/resources/PO035/policies/pass/Quota-via-Class.xml
@@ -1,0 +1,13 @@
+<Quota name="Quota-via-Class">
+  <Allow>
+    <Class ref="quota-class">
+      <Allow class='peak' count='1000'/>
+      <Allow class='off-peak' count='5000'/>
+    </Class>
+  </Allow>
+  <Interval>1</Interval>
+  <Distributed>true</Distributed>
+  <Synchronous>true</Synchronous>
+  <TimeUnit>minute</TimeUnit>
+  <Identifier>verifyapikey.Quota-1.app.name</Identifier>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/pass/enforce after VerifyApiKey.xml
+++ b/test/fixtures/resources/PO035/policies/pass/enforce after VerifyApiKey.xml
@@ -1,0 +1,12 @@
+<Quota name='##'>
+    <DisplayName>##</DisplayName>
+    <Identifier ref='request.queryparam.apikey' />
+    <!-- the count specified is used unless overridden by the variable referenced here -->
+    <Allow countRef='verifyapikey.VerifyAPIKey-1.apiproduct.developer.quota.limit' count='1000'/>
+    <!-- use the interval in the variable; if not present use the value specified here. -->
+    <Interval ref='verifyapikey.VerifyAPIKey-1.apiproduct.developer.quota.interval'>1</Interval>
+    <!-- use the timeunit provided in the variable; if not present use the value specified here. -->
+    <TimeUnit ref='verifyapikey.VerifyAPIKey-1.apiproduct.developer.quota.timeunit'>day</TimeUnit>
+    <Distributed>true</Distributed>
+    <Synchronous>false</Synchronous>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/pass/simple flexi.xml
+++ b/test/fixtures/resources/PO035/policies/pass/simple flexi.xml
@@ -1,0 +1,10 @@
+<Quota name="##" type='flexi'>
+  <!-- <Identifier ref='client_id' /> -->
+
+  <Allow count='3'/>
+  <Interval>1</Interval>
+  <TimeUnit>minute</TimeUnit>
+
+  <Distributed>true</Distributed>
+  <Synchronous>false</Synchronous>
+</Quota>

--- a/test/specs/PO035-quota-hygiene-bundles.js
+++ b/test/specs/PO035-quota-hygiene-bundles.js
@@ -1,0 +1,144 @@
+/*
+  Copyright 2019-2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const assert = require("assert"),
+  path = require("path"),
+  util = require("util"),
+  ruleId = "PO035",
+  debug = require("debug")("apigeelint:" + ruleId),
+  bl = require("../../lib/package/bundleLinter.js");
+
+/*
+ *
+ * At least one of the tests for PO035 depends on the full bundle. Specifically,
+ * there is a check in the linter that look for the referenced policy when using
+ * UseQuotaConfigInAPIProduct. For that reason we need this test module as well
+ * as the one that checks just bare policies.
+ *
+ **/
+
+const testOne = (testcase, _label) => {
+  it(`${testcase.testname} should generate the expected errors`, () => {
+    const configuration = {
+      debug: true,
+      source: {
+        type: "filesystem",
+        path: path.resolve(
+          __dirname,
+          "../fixtures/resources/PO035/bundles",
+          testcase.testname,
+          "apiproxy"
+        ),
+        bundleType: "apiproxy",
+        profile: testcase.profile
+      },
+      excluded: {},
+      setExitCode: false,
+      output: () => {} // suppress output
+    };
+
+    debug(`PO035 configuration: ${util.format(configuration)}`);
+    bl.lint(configuration, (bundle) => {
+      const items = bundle.getReport();
+      assert.ok(items);
+      assert.ok(items.length);
+      const po035Items = items.filter((item) =>
+        item.messages.some((m) => m.ruleId == "PO035")
+      );
+      debug(`po035Items: ${util.format(po035Items.map((i) => i.filePath))}`);
+
+      if (!testcase.expectErrors) {
+        assert.equal(po035Items.length, 0);
+      } else {
+        assert.equal(po035Items.length, Object.keys(testcase.expected).length);
+
+        Object.keys(testcase.expected).forEach((policyName, caseNum) => {
+          debug(`policyName: ${policyName}`);
+          const policyItems = po035Items.filter((item) =>
+            item.filePath.endsWith(policyName)
+          );
+          debug(`policyItems: ${util.format(policyItems)}`);
+
+          assert.equal(policyItems.length, 1);
+          const po035Messages = policyItems[0].messages.filter(
+            (m) => m.ruleId == "PO035"
+          );
+          debug(`po035Messages: ${util.format(po035Messages)}`);
+          assert.equal(
+            po035Messages.length,
+            testcase.expected[policyName].length
+          );
+          //po035Messages.forEach((m, _ix) => assert.equal(m.severity, 1));
+
+          testcase.expected[policyName].forEach((item, ix) => {
+            assert.equal(
+              po035Messages[ix].message,
+              item,
+              `${policyName} case(${caseNum}) message(${ix})`
+            );
+          });
+        });
+      }
+    });
+  });
+};
+
+const testCases = [
+  {
+    testname: "fail-test1",
+    profile: "apigeex",
+    expectErrors: true,
+    expected: {
+      "Quota-1.xml": [
+        "the stepName attribute refers to a policy that does not exist."
+      ]
+    }
+  },
+  {
+    testname: "fail-test2",
+    profile: "apigeex",
+    expectErrors: true,
+    expected: {
+      "Quota-1.xml": [
+        "the stepName attribute refers to the Quota policy itself."
+      ]
+    }
+  },
+  {
+    testname: "fail-test3",
+    profile: "apigeex",
+    expectErrors: true,
+    expected: {
+      "Quota-1.xml": [
+        "the stepName attribute refers to a policy of the wrong type."
+      ]
+    }
+  },
+  {
+    testname: "pass-test1",
+    profile: "apigeex",
+    expectErrors: false,
+    expected: null
+  }
+];
+
+describe(`PO035 - Quota hygiene`, () => {
+  testCases.forEach((tc, ix0) => {
+    testOne(tc, `case ${ix0}`);
+  });
+});

--- a/test/specs/PO035-quota-hygiene-policies.js
+++ b/test/specs/PO035-quota-hygiene-policies.js
@@ -1,0 +1,119 @@
+/*
+  Copyright 2019-2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const testID = "PO035",
+  assert = require("assert"),
+  fs = require("fs"),
+  util = require("util"),
+  path = require("path"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Policy = require("../../lib/package/Policy.js"),
+  Dom = require("@xmldom/xmldom").DOMParser,
+  rootDir = path.resolve(__dirname, "../fixtures/resources/PO035/policies"),
+  debug = require("debug")("apigeelint:" + testID);
+
+const loadPolicy = (sourceDir, shortFileName) => {
+  const fqPath = path.join(sourceDir, shortFileName),
+    policyXml = fs.readFileSync(fqPath).toString("utf-8"),
+    doc = new Dom().parseFromString(policyXml),
+    p = new Policy(sourceDir, shortFileName, { bundletype: "apiproxy" }, doc);
+  p.getElement = () => doc.documentElement;
+  return p;
+};
+
+describe(`${testID} - policy passes hygiene evaluation`, function () {
+  const sourceDir = path.join(rootDir, "pass");
+  const testOne = (shortFileName) => {
+    const policy = loadPolicy(sourceDir, shortFileName),
+      policyType = policy.getType();
+    it(`check ${shortFileName} passes`, () => {
+      assert.notEqual(policyType, undefined, `${policyType} should be defined`);
+      plugin.onPolicy(policy, (e, foundIssues) => {
+        assert.equal(e, undefined, "should be undefined");
+        const messages = policy.getReport().messages;
+        debug(util.format(messages));
+        assert.equal(foundIssues, false, "should be no issues");
+        assert.ok(messages, "messages should exist");
+        assert.equal(messages.length, 0, "unexpected number of messages");
+      });
+    });
+  };
+
+  const candidates = fs
+    .readdirSync(sourceDir)
+    .filter((shortFileName) => shortFileName.endsWith(".xml"));
+
+  it(`checks that there are tests`, () => {
+    assert.ok(candidates.length > 0, "tests should exist");
+  });
+
+  candidates.forEach(testOne);
+});
+
+describe(`${testID} - policy does not pass hygiene evaluation`, () => {
+  const sourceDir = path.join(rootDir, "fail"),
+    expectedErrorMessages = require(path.join(sourceDir, "messages.js")),
+    testOne = (shortFileName) => {
+      const policy = loadPolicy(sourceDir, shortFileName),
+        policyType = policy.getType();
+      it(`check ${shortFileName} throws error`, () => {
+        assert.notEqual(
+          policyType,
+          undefined,
+          `${policyType} should be defined`
+        );
+        plugin.onPolicy(policy, (e, foundIssues) => {
+          assert.equal(undefined, e, "should be undefined");
+          assert.equal(true, foundIssues, "should be issues");
+          const messages = policy.getReport().messages;
+          assert.ok(messages, "messages for issues should exist");
+          const expected = expectedErrorMessages[policy.fileName];
+          assert.ok(
+            expected,
+            "test configuration failure: did not find an expected message"
+          );
+          debug(util.format(messages));
+          assert.equal(
+            expected.length,
+            messages.length,
+            "unexpected number of messages"
+          );
+          for (let i = 0; i < expected.length; i++) {
+            assert.ok(messages[i].message, "did not find message member");
+            assert.equal(
+              expected[i],
+              messages[i].message,
+              `did not find expected message #${i}`
+            );
+            debug(`message[${i}]: ${messages[i].message}`);
+          }
+        });
+      });
+    };
+
+  const candidates = fs
+    .readdirSync(sourceDir)
+    .filter((shortFileName) => shortFileName.endsWith(".xml"));
+
+  it(`checks that there are tests`, () => {
+    assert.ok(candidates.length > 0, "tests should exist");
+  });
+
+  candidates.forEach(testOne);
+});


### PR DESCRIPTION
This plugin checks hygiene for the Quota policy. Earlier today someone on the community asked about a quota policy configuration that used Indentifier, rather than Identifier, as the element in a Quota policy.  

This plugin will find that, and other myriad problems with the Quota step configuration. 

Please review!  