### PR TITLE
fix: PD002 checks for zero unconditional RouteRules

### DIFF
--- a/lib/package/plugins/PD002-emptyRouteRules.js
+++ b/lib/package/plugins/PD002-emptyRouteRules.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -15,40 +15,46 @@
 */
 
 const ruleId = require("../myUtil.js").getRuleId();
-      //debug = require("debug")("apigeelint:" + ruleId);
 
 const plugin = {
-        ruleId,
-        name: "Unreachable Route Rules - Defaults",
-        message:
-        "Check RouteRules in a ProxyEndpoint to ensure that one and only one has a blank set of conditions.",
-        fatal: false,
-        severity: 2, //error
-        nodeType: "RouteRule",
-        enabled: true
-      };
+  ruleId,
+  name: "Unconditional Route Rule Structure",
+  message:
+    "Check RouteRules in a ProxyEndpoint to ensure that one and only one has a blank set of conditions.",
+  fatal: false,
+  severity: 2, //2=error
+  nodeType: "RouteRule",
+  enabled: true
+};
 
-const onProxyEndpoint = function(ep, cb) {
-    let routeRules = ep.getRouteRules(),
-        hadError = false;
+const onProxyEndpoint = function (ep, cb) {
+  const routeRules = ep.getRouteRules();
+  let hadError = false;
 
   if (routeRules) {
-    let blankRR = routeRules.filter( rr =>
-                                     !rr.getCondition() ||
-                                     rr.getCondition().getExpression() === "");
+    const blankRR = routeRules.filter(
+      (rr) => !rr.getCondition() || rr.getCondition().getExpression() === ""
+    );
     if (blankRR.length > 1) {
-      blankRR.forEach( rr =>
-                       ep.addMessage({
-                         plugin,
-                         source: rr.getSource(),
-                         line: rr.getElement().lineNumber,
-                         column: rr.getElement().columnNumber,
-                         message: `Multiple RouteRules with no Condition. Only the first is evaluated.`
-                       }));
+      blankRR.slice(1).forEach((rr) =>
+        ep.addMessage({
+          plugin,
+          source: rr.getSource(),
+          line: rr.getElement().lineNumber,
+          column: rr.getElement().columnNumber,
+          message: `Multiple RouteRules with no Condition. Only the first is evaluated.`
+        })
+      );
       hadError = true;
+    } else if (blankRR.length == 0) {
+      ep.addMessage({
+        plugin,
+        severity: 1, //1=warning
+        message: `There is no RouteRule with no Condition. Your proxy may not operate correctly.`
+      });
     }
   }
-  if (typeof(cb) == 'function') {
+  if (typeof cb == "function") {
     cb(null, hadError);
   }
 };

--- a/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/failed-route.xml
+++ b/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/failed-route.xml
@@ -1,0 +1,4 @@
+<APIProxy revision="1" name="failed-route">
+  <ConfigurationVersion minorVersion="0" majorVersion="4"/>
+  <DisplayName>failed-route</DisplayName>
+</APIProxy>

--- a/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/policies/AM-Clean-Request-Headers-From-Response.xml
+++ b/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/policies/AM-Clean-Request-Headers-From-Response.xml
@@ -1,0 +1,21 @@
+<AssignMessage name='AM-Clean-Request-Headers-From-Response'>
+  <Remove>
+    <Headers>
+      <Header name='Host'/>
+      <Header name='Accept'/>
+      <Header name='Authorization'/>
+      <Header name='Origin'/>
+      <Header name='user-agent'/>
+      <Header name='X-Request-id'/>
+      <Header name='x-client-data'/>
+      <Header name='x-cloud-trace-context'/>
+      <Header name='X-Powered-By'/>
+      <Header name='X-b3-traceid'/>
+      <Header name='X-b3-spanid'/>
+      <Header name='X-b3-sampled'/>
+      <Header name='X-Forwarded-For'/>
+      <Header name='X-Forwarded-Port'/>
+      <Header name='X-Forwarded-Proto'/>
+    </Headers>
+  </Remove>
+</AssignMessage>

--- a/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
+++ b/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/policies/AM-Inject-Proxy-Revision-Header.xml
@@ -1,0 +1,7 @@
+<AssignMessage name='AM-Inject-Proxy-Revision-Header'>
+  <Set>
+    <Headers>
+      <Header name='APIProxy'>{apiproxy.name} r{apiproxy.revision}</Header>
+    </Headers>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/policies/AM-Response.xml
+++ b/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/policies/AM-Response.xml
@@ -1,0 +1,12 @@
+<AssignMessage name='AM-Response'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <Set>
+    <Payload contentType='application/json'>{
+    "status" : "ok"
+}
+</Payload>
+    <ReasonPhrase>OK</ReasonPhrase>
+    <StatusCode>200</StatusCode>
+  </Set>
+  <AssignTo>response</AssignTo>
+</AssignMessage>

--- a/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/policies/RF-Unknown-Request.xml
+++ b/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/policies/RF-Unknown-Request.xml
@@ -1,0 +1,16 @@
+<RaiseFault name='RF-Unknown-Request'>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <FaultResponse>
+    <Set>
+      <Payload contentType='application/json'>{
+  "error" : {
+    "code" : 404.01,
+    "message" : "that request was unknown; try a different request."
+  }
+}
+</Payload>
+      <StatusCode>404</StatusCode>
+      <ReasonPhrase>Not Found</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+</RaiseFault>

--- a/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/proxies/endpoint1.xml
@@ -1,0 +1,79 @@
+<ProxyEndpoint name="endpoint1">
+  <Description>Proxy Endpoint 1</Description>
+  <HTTPProxyConnection>
+    <BasePath>/failed-route</BasePath>
+  </HTTPProxyConnection>
+
+  <FaultRules/>
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Revision-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <PreFlow name="PreFlow">
+    <Request>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Clean-Request-Headers-From-Response</Name>
+      </Step>
+    </Response>
+  </PreFlow>
+
+  <PostFlow name="PostFlow">
+    <Request>
+    </Request>
+    <Response>
+      <Step>
+        <Name>AM-Inject-Proxy-Revision-Header</Name>
+      </Step>
+    </Response>
+  </PostFlow>
+
+  <PostClientFlow name="PostClientFlow">
+    <Request>
+    </Request>
+    <Response>
+    </Response>
+  </PostClientFlow>
+
+  <Flows>
+
+    <Flow name="flow1">
+      <Request>
+      </Request>
+      <Response>
+        <Step>
+          <Name>AM-Response</Name>
+        </Step>
+      </Response>
+      <Condition>(proxy.pathsuffix MatchesPath "/t1") and (request.verb = "GET")</Condition>
+    </Flow>
+
+    <Flow name="unknown request">
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response>
+      </Response>
+    </Flow>
+
+  </Flows>
+
+  <RouteRule name="BrokenRouteRule">
+    <TargetEndpoint>target-1</TargetEndpoint>
+    <Condition>proxy.pathsuffix = "/foobar"</Condition>
+  </RouteRule>
+
+  <!-- There is no applicable routerule. This will
+       generate an error at runtime
+
+{"fault":{"faultstring":"Unable to route the message to a Target
+Endpoint","detail":{"errorcode":"messaging.runtime.RouteFailed"}}}%
+  -->
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/targets/target-1.xml
+++ b/test/fixtures/resources/PD002-no-unconditional-routerule/apiproxy/targets/target-1.xml
@@ -1,0 +1,22 @@
+<TargetEndpoint name="target-1">
+  <Description/>
+  <FaultRules/>
+  <PreFlow name="PreFlow">
+    <Request/>
+    <Response/>
+  </PreFlow>
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response/>
+  </PostFlow>
+  <Flows/>
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <Enforce>true</Enforce>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+    </SSLInfo>
+    <Properties/>
+    <URL>https://echo.dchiesa.demo.altostrat.com</URL>
+  </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/specs/PD002-at-least-one-unconditional-RouteRule.js
+++ b/test/specs/PD002-at-least-one-unconditional-RouteRule.js
@@ -1,0 +1,69 @@
+/*
+  Copyright 2019-2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const ruleId = "PD002",
+  assert = require("assert"),
+  path = require("path"),
+  util = require("util"),
+  debug = require("debug")(`apigeelint:${ruleId}`),
+  bl = require("../../lib/package/bundleLinter.js");
+
+describe(`${ruleId} - bundle with no unconditional route`, () => {
+  it("should generate the expected errors", () => {
+    const configuration = {
+      debug: true,
+      source: {
+        type: "filesystem",
+        path: path.resolve(
+          __dirname,
+          "../fixtures/resources/PD002-no-unconditional-routerule/apiproxy"
+        ),
+        bundleType: "apiproxy"
+      },
+      profile: "apigeex",
+      excluded: { TD004: true, TD002: true },
+      setExitCode: false,
+      output: () => {} // suppress output
+    };
+
+    bl.lint(configuration, (bundle) => {
+      const items = bundle.getReport();
+      assert.ok(items);
+      assert.ok(items.length);
+      const actualErrors = items.filter(
+        (item) => item.messages && item.messages.length
+      );
+      assert.ok(actualErrors.length);
+      debug(util.format(actualErrors));
+      debug(JSON.stringify(actualErrors));
+
+      const ep1 = actualErrors.find((e) =>
+        e.filePath.endsWith("endpoint1.xml")
+      );
+      assert.ok(ep1);
+      debug(util.format(ep1.messages));
+      const pd002Messages = ep1.messages.filter((m) => m.ruleId == "PD002");
+      assert.equal(pd002Messages.length, 1);
+      assert.ok(pd002Messages[0].message);
+      assert.equal(
+        pd002Messages[0].message,
+        "There is no RouteRule with no Condition. Your proxy may not operate correctly."
+      );
+    });
+  });
+});


### PR DESCRIPTION
Alter plugin PD002 to now check for zero unconditional RouteRules. 

Without this change PD002 checks for _more than one_ unconditional RouteRule. But it does not check for _exactly one_.  With zero unconditional RouteRules, at runtime the proxy can generate this error: 
```
{
  "fault": {
    "faultstring": "Unable to route the message to a Target Endpoint",
    "detail": {
      "errorcode": "messaging.runtime.RouteFailed"
    }
  }
}
```

This change ALSO modifies PD002 to flag the _redundant_ RouteRules when there are multiple. Previously it flagged every unconditional RouteRule (1..n); now it flags only 2..n.  