### PR TITLE
fix: PO035 allows both of Sync{IntervalInSeconds, MessageCount}

### DIFF
--- a/lib/package/plugins/PO035-quota-hygiene.js
+++ b/lib/package/plugins/PO035-quota-hygiene.js
@@ -290,7 +290,7 @@ const onPolicy = function (quotaPolicy, cb) {
         }
       }
 
-      // 7. For AsynchronousConfiguration, only one child
+      // 7. For AsynchronousConfiguration, check children
       const asyncElement = xpath.select1(
         `AsynchronousConfiguration`,
         policyRoot
@@ -305,28 +305,30 @@ const onPolicy = function (quotaPolicy, cb) {
           .join(" or ");
 
         const children = xpath.select(`*[${condition}]`, asyncElement);
-        if (children.length != 1) {
+        if (children.length == 0) {
           addIssue(
             `element <${
               asyncElement.tagName
-            }> must have exactly one of {${validChildElements.join(
+            }> must have at least one of {${validChildElements.join(
               ", "
             )}} as a child.`,
             asyncElement.lineNumber,
             asyncElement.columnNumber
           );
-        }
-        const child = children[0];
-        const textValue = xpath.select1("text()", child);
-        debug(`asynch textValue (${textValue})...`);
+        } else {
+          children.forEach((child) => {
+            const textValue = xpath.select1("text()", child);
+            debug(`asynch textValue (${textValue})...`);
 
-        const intValue = textValue && parseInt(textValue, 10);
-        if (!textValue || !intValue || intValue <= 0) {
-          addIssue(
-            `element <${child.tagName}> must have a text value representing an integer.`,
-            child.lineNumber,
-            child.columnNumber
-          );
+            const intValue = textValue && parseInt(textValue, 10);
+            if (!textValue || !intValue || intValue <= 0) {
+              addIssue(
+                `element <${child.tagName}> must have a text value representing an integer.`,
+                child.lineNumber,
+                child.columnNumber
+              );
+            }
+          });
         }
       }
 

--- a/test/fixtures/resources/PO035/policies/fail/Asynch-neither-child-element.xml
+++ b/test/fixtures/resources/PO035/policies/fail/Asynch-neither-child-element.xml
@@ -1,0 +1,10 @@
+<Quota name="Asynch-neither-child-element">
+  <DisplayName>Quota-1</DisplayName>
+  <Allow countRef="my-count"/>
+  <Interval>2</Interval>
+  <TimeUnit>minute</TimeUnit>
+  <Synchronous>true</Synchronous>
+  <Identifier>verifyapikey.Quota-1.app.name</Identifier>
+  <AsynchronousConfiguration>
+  </AsynchronousConfiguration>
+</Quota>

--- a/test/fixtures/resources/PO035/policies/fail/messages.js
+++ b/test/fixtures/resources/PO035/policies/fail/messages.js
@@ -19,8 +19,8 @@ module.exports = {
     "element <MessageWeight> must not have a text value.",
     "element <MessageWeight> must have a ref attribute."
   ],
-  "Asynch-too-many-elements.xml": [
-    "element <AsynchronousConfiguration> must have exactly one of {SyncIntervalInSeconds, SyncMessageCount} as a child."
+  "Asynch-neither-child-element.xml": [
+    "element <AsynchronousConfiguration> must have at least one of {SyncIntervalInSeconds, SyncMessageCount} as a child."
   ],
   "Asynch-non-integer-SyncIntervalInSeconds-element.xml": [
     "element <SyncIntervalInSeconds> must have a text value representing an integer."

--- a/test/fixtures/resources/PO035/policies/pass/Asynch-both-elements.xml
+++ b/test/fixtures/resources/PO035/policies/pass/Asynch-both-elements.xml
@@ -1,4 +1,4 @@
-<Quota name="Asynch-too-many-elements">
+<Quota name="Asynch-both-elements">
   <DisplayName>Quota-1</DisplayName>
   <Allow countRef="my-count"/>
   <Interval>2</Interval>


### PR DESCRIPTION
Contrary to the (current) documentation the `AsynchronousConfiguration` element within the Quota policy allows the use of both `SyncIntervalInSeconds` and  `SyncMessageCount`, in the same configuration.  This is valid: 
```
<Quota name="Q-Asynch">
  . . . 
  <AsynchronousConfiguration>
    <SyncIntervalInSeconds>20</SyncIntervalInSeconds>
    <SyncMessageCount>5</SyncMessageCount>
  </AsynchronousConfiguration>
</Quota>
```

This change modifies the PO035 plugin to allow that.

