### PR TITLE
chore: add debug messages for apigeelint rc file

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,6 +23,7 @@ const program = require("commander"),
   rc = require("./lib/package/apigeelintrc.js"),
   pkj = require("./package.json"),
   bundleType = require("./lib/package/BundleTypes.js");
+const debug = require("debug");
 
 const findBundle = (p) => {
   if (p.endsWith("/")) {
@@ -129,7 +130,10 @@ if (!program.norc) {
   if (rcSettings) {
     Object.keys(rcSettings)
       .filter((key) => key != "path" && key != "list" && !program[key])
-      .forEach((key) => (program[key] = rcSettings[key]));
+      .forEach((key) => {
+        debug("apigeelint:rc")(`applying [${key}] = ${rcSettings[key]}`)        ;
+        program[key] = rcSettings[key];
+      });
   }
 }
 

--- a/lib/package/apigeelintrc.js
+++ b/lib/package/apigeelintrc.js
@@ -2,7 +2,7 @@
 // ------------------------------------------------------------------
 //
 // created: Mon Apr 15 18:14:54 2024
-// last saved: <2024-April-16 13:54:37>
+// last saved: <2024-July-19 12:24:12>
 
 /* jshint esversion:9, node:true, strict:implied */
 /* global process, console, Buffer */
@@ -11,6 +11,7 @@ const os = require("os");
 const fs = require("fs");
 const path = require("path");
 const bundleType = require("./BundleTypes.js");
+const debug = require("debug")("apigeelint:rc");
 
 const locations = ["./", "~/"];
 
@@ -38,6 +39,7 @@ const findRc = (settingsfiles, sourcedir) => {
 const readRc = (settingsfiles, sourcedir) => {
   const rcFile = findRc(settingsfiles, sourcedir);
   if (rcFile) {
+    debug(`found rc file ${rcFile}`);
     const lines = fs
       .readFileSync(rcFile, "utf-8")
       .split("\n")


### PR DESCRIPTION
No functional changes. Just debug statements that will help identify which rc file  apigeelint loads. 

Usage
```
DEBUG=apigeelint:rc node cli.js ...
```
