### PR TITLE
fix: get-installed-path needs direction on where to look

### DIFF
--- a/lib/package/myUtil.js
+++ b/lib/package/myUtil.js
@@ -24,8 +24,10 @@ const xpath = require("xpath"),
  * dom.js file within that module, to get it. This changes in xmldom v0.9.x, but
  * it has been in "beta" for more than a year.
  **/
-const gip = require("get-installed-path").getInstalledPathSync,
-  xmlDomPath = gip("@xmldom/xmldom", { local: true }),
+const path = require("path"),
+  myhome = path.resolve(__dirname, "../../"),
+  gip = require("get-installed-path").getInstalledPathSync,
+  xmlDomPath = gip("@xmldom/xmldom", { local: true, cwd: myhome }),
   Node = require(`${xmlDomPath}/lib/dom.js`).Node;
 
 function rBuildTagBreadCrumb(doc, bc) {


### PR DESCRIPTION
apigeelint uses get-installed-path to get the path of xmldom/xmldom , in order to read the constants that are exported in the v0.8.x version of that package.  Later versions of the package export the constants, but they're not yet released. 

ANYWAY, the get-installed-path looks in the wrong place if you run apigeelint from a directory that is not its home, and that causes the apigeelint cli to just throw an error and exit. This change fixes that. 
