### PR TITLE
feat: PO036 check usage of Response element in ServiceCallout

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ This is the current list:
 | &nbsp; |:white_check_mark:| PO033 | ExtractVariables policy hygiene | In an ExtractVariables policy, check variable types and other hygiene. |
 | &nbsp; |:white_check_mark:| PO034 | AssignMessage policy hygiene | In an AssignMessage policy, check element placement and other hygiene. |
 | &nbsp; |:white_check_mark:| PO035 | Quota policy hygiene | In a Quota policy, check element placement and other hygiene. |
+| &nbsp; |:white_check_mark:| PO036 | ServiceCallout Response element usage | The Response element, when present, should specify a text value and no attributes. |
 | FaultRules | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| FR001 | No Condition on FaultRule | Use Condition elements on FaultRules, unless it is the fallback rule. |
 | &nbsp; |:white_check_mark:| FR002 | DefaultFaultRule Structure | DefaultFaultRule should have only supported child elements, at most one AlwaysEnforce element, and at most one Condition element. |

--- a/lib/package/plugins/PO036-serviceCallout-response-element.js
+++ b/lib/package/plugins/PO036-serviceCallout-response-element.js
@@ -1,0 +1,101 @@
+/*
+  Copyright 2019-2020,2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const myUtil = require("../myUtil.js"),
+  xpath = require("xpath"),
+  ruleId = myUtil.getRuleId(),
+  debug = require("debug")("apigeelint:" + ruleId);
+
+const plugin = {
+  ruleId,
+  name: "Check ServiceCallout for Response element",
+  message:
+    "There should be a simple text value in the Response element for the ServiceCallout policy.",
+  fatal: false,
+  severity: 2, //2=error
+  nodeType: "Policy",
+  enabled: true
+};
+
+const onPolicy = function (policy, cb) {
+  let hadWarning = false;
+  if (policy.getType() === "ServiceCallout") {
+    debug(`found policy ${policy.getName()}`);
+    const responseElts = xpath.select(
+      "/ServiceCallout/Response",
+      policy.getElement()
+    );
+    try {
+      if (responseElts && responseElts[0]) {
+        debug(`found ${responseElts.length} response element(s)`);
+        if (responseElts[1]) {
+          hadWarning = true;
+          policy.addMessage({
+            plugin,
+            message: "Policy has more than one Response element."
+          });
+        }
+        const textValue =
+          responseElts[0].childNodes &&
+          responseElts[0].childNodes[0] &&
+          responseElts[0].childNodes[0].nodeValue;
+        debug(`textValue '${textValue}'`);
+        if (textValue && textValue.trim()) {
+          const re1 = new RegExp("\\s", "g");
+          if (re1.test(textValue)) {
+            hadWarning = true;
+            policy.addMessage({
+              plugin,
+              message:
+                "When the Response element is present, the TEXT value should have no spaces."
+            });
+          }
+        } else if (!textValue || !textValue.trim()) {
+          hadWarning = true;
+          policy.addMessage({
+            plugin,
+            message:
+              "The Response element, when present, should specify a non-empty TEXT value."
+          });
+        }
+        const attrs = xpath.select("@*", responseElts[0]);
+
+        if (attrs && attrs[0]) {
+          hadWarning = true;
+          policy.addMessage({
+            plugin,
+            message:
+              "The Response element, when present, should not specify any attributes."
+          });
+        }
+      }
+    } catch (e1) {
+      hadWarning = true;
+      policy.addMessage({
+        plugin,
+        message: "Exception while examining Response element: " + e1.message
+      });
+    }
+  }
+  if (typeof cb == "function") {
+    cb(null, hadWarning);
+  }
+};
+
+module.exports = {
+  plugin,
+  onPolicy
+};

--- a/test/fixtures/resources/PO036/SC-Response-element-invalid1.xml
+++ b/test/fixtures/resources/PO036/SC-Response-element-invalid1.xml
@@ -1,0 +1,18 @@
+<ServiceCallout name='SC-Response-element-invalid1'>
+  <Request variable='simpleGetRequest'>
+    <Set>
+      <Verb>GET</Verb>
+    </Set>
+  </Request>
+  <Response variable='jwksResponse'/> <!-- this is wrong syntax -->
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+    </SSLInfo>
+    <Properties>
+      <Property name='success.codes'>2xx</Property>
+    </Properties>
+    <URL>https://www.googleapis.com/oauth2/v3/certs</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/test/fixtures/resources/PO036/SC-Response-element-invalid2.xml
+++ b/test/fixtures/resources/PO036/SC-Response-element-invalid2.xml
@@ -1,0 +1,18 @@
+<ServiceCallout name='SC-Response-element-invalid2'>
+  <Request variable='simpleGetRequest'>
+    <Set>
+      <Verb>GET</Verb>
+    </Set>
+  </Request>
+  <Response/> <!-- missing text value -->
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+    </SSLInfo>
+    <Properties>
+      <Property name='success.codes'>2xx</Property>
+    </Properties>
+    <URL>https://www.googleapis.com/oauth2/v3/certs</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/test/fixtures/resources/PO036/SC-Response-element-invalid3.xml
+++ b/test/fixtures/resources/PO036/SC-Response-element-invalid3.xml
@@ -1,0 +1,18 @@
+<ServiceCallout name='SC-Response-element-invalid3'>
+  <Request variable='simpleGetRequest'>
+    <Set>
+      <Verb>GET</Verb>
+    </Set>
+  </Request>
+  <Response>not a valid variable name</Response> <!-- TEXT value should have no spaces -->
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+    </SSLInfo>
+    <Properties>
+      <Property name='success.codes'>2xx</Property>
+    </Properties>
+    <URL>https://www.googleapis.com/oauth2/v3/certs</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/test/fixtures/resources/PO036/SC-Response-element-invalid4.xml
+++ b/test/fixtures/resources/PO036/SC-Response-element-invalid4.xml
@@ -1,0 +1,19 @@
+<ServiceCallout name='SC-Response-element-invalid4'>
+  <Request variable='simpleGetRequest'>
+    <Set>
+      <Verb>GET</Verb>
+    </Set>
+  </Request>
+  <Response>value1</Response>
+  <Response>value2</Response> <!-- invalid to have more than one of these -->
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+    </SSLInfo>
+    <Properties>
+      <Property name='success.codes'>2xx</Property>
+    </Properties>
+    <URL>https://www.googleapis.com/oauth2/v3/certs</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/test/fixtures/resources/PO036/SC-Response-element-invalid5.xml
+++ b/test/fixtures/resources/PO036/SC-Response-element-invalid5.xml
@@ -1,0 +1,18 @@
+<ServiceCallout name='SC-Response-element-invalid5'>
+  <Request variable='simpleGetRequest'>
+    <Set>
+      <Verb>GET</Verb>
+    </Set>
+  </Request>
+  <Response>  </Response> <!-- only whitespace in text value -->
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+    </SSLInfo>
+    <Properties>
+      <Property name='success.codes'>2xx</Property>
+    </Properties>
+    <URL>https://www.googleapis.com/oauth2/v3/certs</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/test/fixtures/resources/PO036/SC-Response-element-invalid6.xml
+++ b/test/fixtures/resources/PO036/SC-Response-element-invalid6.xml
@@ -1,0 +1,18 @@
+<ServiceCallout name='SC-Response-element-invalid6'>
+  <Request variable='simpleGetRequest'>
+    <Set>
+      <Verb>GET</Verb>
+    </Set>
+  </Request>
+  <Response variable='something'>text_value</Response> <!-- elt should never have attributes -->
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+    </SSLInfo>
+    <Properties>
+      <Property name='success.codes'>2xx</Property>
+    </Properties>
+    <URL>https://www.googleapis.com/oauth2/v3/certs</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/test/fixtures/resources/PO036/SC-Response-element-valid.xml
+++ b/test/fixtures/resources/PO036/SC-Response-element-valid.xml
@@ -1,0 +1,18 @@
+<ServiceCallout name='SC-Response-element-valid'>
+  <Request variable='simpleGetRequest'>
+    <Set>
+      <Verb>GET</Verb>
+    </Set>
+  </Request>
+  <Response>jwksResponse</Response>
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+    </SSLInfo>
+    <Properties>
+      <Property name='success.codes'>2xx</Property>
+    </Properties>
+    <URL>https://www.googleapis.com/oauth2/v3/certs</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/test/specs/PO036-service-callout-response-element-syntax.js
+++ b/test/specs/PO036-service-callout-response-element-syntax.js
@@ -1,0 +1,145 @@
+/*
+  Copyright 2019-2021 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* jshint esversion:9, node:true, strict:implied */
+/* global describe, it */
+
+const testID = "PO036",
+  assert = require("assert"),
+  fs = require("fs"),
+  path = require("path"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  debug = require("debug")("apigeelint:" + testID),
+  Policy = require("../../lib/package/Policy.js"),
+  Dom = require("@xmldom/xmldom").DOMParser;
+
+const test = (suffix, cb) => {
+  const filename = `SC-Response-element-${suffix}.xml`;
+  it(`should correctly process ${filename}`, () => {
+    const fqfname = path.resolve(
+        __dirname,
+        "../fixtures/resources/PO036",
+        filename
+      ),
+      policyXml = fs.readFileSync(fqfname, "utf-8"),
+      doc = new Dom().parseFromString(policyXml),
+      p = new Policy(doc.documentElement, this);
+
+    p.getElement = () => doc.documentElement;
+
+    //plugin.onBundle({ profile: "apigee" });
+
+    plugin.onPolicy(p, (e, foundIssues) => {
+      assert.equal(e, undefined, "should be undefined");
+      cb(p, foundIssues);
+    });
+  });
+};
+
+describe(`PO036 - ServiceCallout Response element`, () => {
+  test("valid", (p, foundIssues) => {
+    //assert.equal(foundIssues, false);
+    const messages = p.getReport().messages;
+    assert.ok(messages, "messages undefined");
+    debug(messages);
+    assert.equal(foundIssues, false);
+    //assert.equal(messages.length, 0, JSON.stringify(messages));
+  });
+
+  test("invalid1", (p, foundIssues) => {
+    assert.equal(foundIssues, true);
+    const messages = p.getReport().messages;
+    assert.ok(messages, "messages undefined");
+    debug(messages);
+    assert.equal(messages.length, 2, "unexpected number of messages");
+    assert.ok(messages[0].message, "did not find message 0");
+    assert.equal(
+      messages[0].message,
+      "The Response element, when present, should specify a non-empty TEXT value."
+    );
+    assert.ok(messages[1].message, "did not find message 1");
+    assert.equal(
+      messages[1].message,
+      "The Response element, when present, should not specify any attributes."
+    );
+  });
+
+  test("invalid2", (p, foundIssues) => {
+    assert.equal(foundIssues, true);
+    const messages = p.getReport().messages;
+    assert.ok(messages, "messages undefined");
+    debug(messages);
+    assert.equal(messages.length, 1, "unexpected number of messages");
+    assert.ok(messages[0].message, "did not find message 0");
+    assert.equal(
+      messages[0].message,
+      "The Response element, when present, should specify a non-empty TEXT value."
+    );
+  });
+
+  test("invalid3", (p, foundIssues) => {
+    assert.equal(foundIssues, true);
+    const messages = p.getReport().messages;
+    assert.ok(messages, "messages undefined");
+    debug(messages);
+    assert.equal(messages.length, 1, "unexpected number of messages");
+    assert.ok(messages[0].message, "did not find message 0");
+    assert.equal(
+      messages[0].message,
+      "When the Response element is present, the TEXT value should have no spaces."
+    );
+  });
+
+  test("invalid4", (p, foundIssues) => {
+    assert.equal(foundIssues, true);
+    const messages = p.getReport().messages;
+    assert.ok(messages, "messages undefined");
+    debug(messages);
+    assert.equal(messages.length, 1, "unexpected number of messages");
+    assert.ok(messages[0].message, "did not find message 0");
+    assert.equal(
+      messages[0].message,
+      "Policy has more than one Response element."
+    );
+  });
+
+  test("invalid5", (p, foundIssues) => {
+    assert.equal(foundIssues, true);
+    const messages = p.getReport().messages;
+    assert.ok(messages, "messages undefined");
+    debug(messages);
+    assert.equal(messages.length, 1, "unexpected number of messages");
+    assert.ok(messages[0].message, "did not find message 0");
+    assert.equal(
+      messages[0].message,
+      "The Response element, when present, should specify a non-empty TEXT value."
+    );
+  });
+
+  test("invalid6", (p, foundIssues) => {
+    assert.equal(foundIssues, true);
+    const messages = p.getReport().messages;
+    assert.ok(messages, "messages undefined");
+    debug(messages);
+    assert.equal(messages.length, 1, "unexpected number of messages");
+    assert.ok(messages[0].message, "did not find message 0");
+    assert.equal(
+      messages[0].message,
+      "The Response element, when present, should not specify any attributes."
+    );
+  });
+});


### PR DESCRIPTION
This plugin checks the usage of the `Response` element in the ServiceCallout policy. 
It rejects these , for example: 
```
  <Response variable='jwksResponse'/> <!-- this is wrong syntax -->

  <Response attr='something'>text_value</Response> <!-- should never have attributes -->

  <Response/> <!-- missing text value -->

  <Response>  </Response> <!-- only whitespace in text value -->

  <Response>not a valid variable name</Response> <!-- TEXT value should have no spaces -->
```

And it also flags repeated `Response` elements.