### PR TITLE
feat: TD008 and TD009 to perform checks on LoadBalancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ This is the current list:
 | &nbsp; |:white_check_mark:| TD005 | TargetEndpoint SSLInfo references | TargetEndpoint SSLInfo should use references for KeyStore and TrustStore. |
 | &nbsp; |:white_check_mark:| TD006 | TargetEndpoint SSLInfo | When using a LoadBalancer, the SSLInfo should not be configured under HTTPTargetConnection. |
 | &nbsp; |:white_check_mark:| TD007 | TargetEndpoint SSLInfo | TargetEndpoint HTTPTargetConnection SSLInfo should use TrustStore. |
+| &nbsp; |:white_check_mark:| TD008 | TargetEndpoint LoadBalancer Servers | LoadBalancer should not have duplicate Server entries. |
+| &nbsp; |:white_check_mark:| TD009 | TargetEndpoint LoadBalancer | TargetEndpoint HTTPTargetConnection should have at most one LoadBalancer. |
 | Flow | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| FL001 | Unconditional Flows |  Only one unconditional flow will get executed. Error if more than one was detected. |
 | Step | &nbsp; | &nbsp; | &nbsp; | &nbsp; |

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ This is the current list:
 | &nbsp; |:white_check_mark:| TD005 | TargetEndpoint SSLInfo references | TargetEndpoint SSLInfo should use references for KeyStore and TrustStore. |
 | &nbsp; |:white_check_mark:| TD006 | TargetEndpoint SSLInfo | When using a LoadBalancer, the SSLInfo should not be configured under HTTPTargetConnection. |
 | &nbsp; |:white_check_mark:| TD007 | TargetEndpoint SSLInfo | TargetEndpoint HTTPTargetConnection SSLInfo should use TrustStore. |
-| &nbsp; |:white_check_mark:| TD008 | TargetEndpoint LoadBalancer Servers | LoadBalancer should not have duplicate Server entries. |
+| &nbsp; |:white_check_mark:| TD008 | TargetEndpoint LoadBalancer Servers | LoadBalancer should not have duplicate Server entries or multiple Fallbacks. |
 | &nbsp; |:white_check_mark:| TD009 | TargetEndpoint LoadBalancer | TargetEndpoint HTTPTargetConnection should have at most one LoadBalancer. |
 | Flow | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| FL001 | Unconditional Flows |  Only one unconditional flow will get executed. Error if more than one was detected. |

--- a/lib/package/plugins/TD008-target-LB-duplicate-servers.js
+++ b/lib/package/plugins/TD008-target-LB-duplicate-servers.js
@@ -1,0 +1,123 @@
+/*
+  Copyright 2019-2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const ruleId = require("../myUtil.js").getRuleId(),
+  xpath = require("xpath");
+
+const plugin = {
+  ruleId,
+  name: "TargetEndpoint HTTPTargetConnection LoadBalancer with duplicate Server elements",
+  message: "Duplicate Server elements found within LoadBalancer.",
+  fatal: false,
+  severity: 1, // 1 = warn, 2 = error
+  nodeType: "Endpoint",
+  enabled: true
+};
+
+const path = require("path"),
+  debug = require("debug")("apigeelint:" + ruleId);
+
+const onTargetEndpoint = function (endpoint, cb) {
+  const htc = endpoint.getHTTPTargetConnection(),
+    shortFilename = path.basename(endpoint.getFileName());
+  let flagged = false;
+
+  debug(`onTargetEndpoint shortfile(${shortFilename})`);
+  if (htc) {
+    try {
+      const loadBalancers = htc.select("LoadBalancer");
+      debug(`loadBalancers(${loadBalancers.length})`);
+
+      if (loadBalancers.length == 1) {
+        const loadBalancer = loadBalancers[0];
+        const servers = xpath.select("Server", loadBalancer);
+        if (servers.length > 1) {
+          const previouslyDetected = [];
+          servers.slice(0, -1).forEach((item, i) => {
+            if (!previouslyDetected.includes(i)) {
+              const dupesForI = [];
+              const compares = servers.slice(i + 1);
+              compares.forEach((c, j) => {
+                const indexOfCompared = j + i + 1;
+                if (!previouslyDetected.includes(indexOfCompared)) {
+                  const attrsA = xpath.select("@*", item);
+                  const attrsB = xpath.select("@*", c);
+                  if (!attrsA || !attrsA.find((attr) => attr.name == "name")) {
+                    endpoint.addMessage({
+                      plugin,
+                      line: item.lineNumber,
+                      column: item.columnNumber,
+                      message:
+                        "Missing name attribute for server within LoadBalancer"
+                    });
+                    flagged = true;
+                  } else {
+                    const nameAttrA = attrsA.find(
+                      (attr) => attr.name == "name"
+                    );
+
+                    if (attrsB) {
+                      const nameAttrB = attrsB.find(
+                        (attr) => attr.name == "name"
+                      );
+                      if (nameAttrB && nameAttrB.value == nameAttrA.value) {
+                        debug(`duplicate found at index ${indexOfCompared}`);
+                        dupesForI.push(indexOfCompared);
+                      }
+                    }
+                  }
+                }
+              });
+
+              if (dupesForI.length) {
+                dupesForI.forEach((ix) =>
+                  endpoint.addMessage({
+                    plugin,
+                    line: servers[ix].lineNumber,
+                    column: servers[ix].columnNumber,
+                    message: plugin.message
+                  })
+                );
+                flagged = true;
+                previouslyDetected.push(...dupesForI);
+              }
+            }
+          });
+        }
+      }
+    } catch (exc1) {
+      console.error("exception: " + exc1);
+      debug(`onTargetEndpoint exc(${exc1})`);
+      debug(`${exc1.stack}`);
+      endpoint.addMessage({
+        plugin,
+        message: "Exception while processing: " + exc1
+      });
+
+      flagged = true;
+    }
+  }
+
+  if (typeof cb == "function") {
+    debug(`onTargetEndpoint isFlagged(${flagged})`);
+    cb(null, flagged);
+  }
+};
+
+module.exports = {
+  plugin,
+  onTargetEndpoint
+};

--- a/lib/package/plugins/TD008-target-LB-servers.js
+++ b/lib/package/plugins/TD008-target-LB-servers.js
@@ -43,6 +43,21 @@ const onTargetEndpoint = function (endpoint, cb) {
 
       if (loadBalancers.length == 1) {
         const loadBalancer = loadBalancers[0];
+        // check multiple fallbacks
+        const fallbacks = xpath.select(
+          "Server[IsFallback = 'true']",
+          loadBalancer
+        );
+        if (fallbacks.length > 1) {
+          endpoint.addMessage({
+            plugin,
+            line: loadBalancers[0].lineNumber,
+            column: loadBalancers[0].columnNumber,
+            message: "Multiple Server entries with IsFallback=true"
+          });
+          flagged = true;
+        }
+
         const servers = xpath.select("Server", loadBalancer);
         if (servers.length > 1) {
           const previouslyDetected = [];

--- a/lib/package/plugins/TD009-target-LB-multiple-LB.js
+++ b/lib/package/plugins/TD009-target-LB-multiple-LB.js
@@ -1,0 +1,70 @@
+/*
+  Copyright 2019-2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const ruleId = require("../myUtil.js").getRuleId();
+
+const plugin = {
+  ruleId,
+  name: "TargetEndpoint HTTPTargetConnection should have at most one LoadBalancer",
+  message:
+    "TargetEndpoint HTTPTargetConnection should not have more than one LoadBalancer.",
+  fatal: false,
+  severity: 1, // 1 = warn, 2 = error
+  nodeType: "Endpoint",
+  enabled: true
+};
+
+const path = require("path"),
+  debug = require("debug")("apigeelint:" + ruleId);
+
+const onTargetEndpoint = function (endpoint, cb) {
+  const htc = endpoint.getHTTPTargetConnection(),
+    shortFilename = path.basename(endpoint.getFileName());
+  let flagged = false;
+
+  debug(`onTargetEndpoint shortfile(${shortFilename})`);
+  if (htc) {
+    try {
+      const loadBalancers = htc.select("LoadBalancer");
+      debug(`loadBalancers(${loadBalancers.length})`);
+
+      if (loadBalancers.length > 1) {
+        endpoint.addMessage({
+          plugin,
+          line: loadBalancers[1].lineNumber,
+          column: loadBalancers[1].columnNumber,
+          message: plugin.message
+        });
+        debug(`onTargetEndpoint set flagged`);
+        flagged = true;
+      }
+    } catch (exc1) {
+      console.error("exception: " + exc1);
+      debug(`onTargetEndpoint exc(${exc1})`);
+      debug(`${exc1.stack}`);
+    }
+  }
+
+  if (typeof cb == "function") {
+    debug(`onTargetEndpoint isFlagged(${flagged})`);
+    cb(null, flagged);
+  }
+};
+
+module.exports = {
+  plugin,
+  onTargetEndpoint
+};

--- a/test/fixtures/resources/TD008/fail/t1.xml
+++ b/test/fixtures/resources/TD008/fail/t1.xml
@@ -1,0 +1,8 @@
+<TargetEndpoint name="default">
+    <HTTPTargetConnection>
+      <LoadBalancer>
+         <Server name="server1"/>
+         <Server name="server1"/>
+      </LoadBalancer>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/TD008/fail/t2.xml
+++ b/test/fixtures/resources/TD008/fail/t2.xml
@@ -1,0 +1,9 @@
+<TargetEndpoint name="default">
+    <HTTPTargetConnection>
+      <LoadBalancer>
+         <Server name="server1"/>
+         <Server name="server2"/>
+         <Server name="server1"/>
+      </LoadBalancer>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/TD008/fail/t3.xml
+++ b/test/fixtures/resources/TD008/fail/t3.xml
@@ -1,0 +1,12 @@
+<TargetEndpoint name="default">
+    <HTTPTargetConnection>
+      <LoadBalancer>
+         <Server name="server1"/>
+         <Server name="server2"/>
+         <Server name="server3"/>
+         <Server name="server2"/>
+         <Server name="server4"/>
+         <Server name="server2"/>
+      </LoadBalancer>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/TD008/fail/t4.xml
+++ b/test/fixtures/resources/TD008/fail/t4.xml
@@ -1,0 +1,14 @@
+<TargetEndpoint name="default">
+    <HTTPTargetConnection>
+      <LoadBalancer>
+         <Server name="server1"/>
+         <!-- two servers marked fallback will fail the TD008 check -->
+         <Server name="server2">
+           <IsFallback>true</IsFallback>
+         </Server>
+         <Server name="server3">
+           <IsFallback>true</IsFallback>
+         </Server>
+      </LoadBalancer>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/TD008/fail/t5.xml
+++ b/test/fixtures/resources/TD008/fail/t5.xml
@@ -1,0 +1,9 @@
+<TargetEndpoint name="default">
+    <HTTPTargetConnection>
+      <LoadBalancer>
+         <Server name="server1"/>
+         <Server />
+         <Server name="server3"/>
+      </LoadBalancer>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/TD008/pass/t1.xml
+++ b/test/fixtures/resources/TD008/pass/t1.xml
@@ -1,0 +1,8 @@
+<TargetEndpoint name="default">
+    <HTTPTargetConnection>
+      <LoadBalancer>
+         <Server name="server1"/>
+         <Server name="server2"/>
+      </LoadBalancer>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/TD008/pass/t2.xml
+++ b/test/fixtures/resources/TD008/pass/t2.xml
@@ -1,0 +1,9 @@
+<TargetEndpoint name="default">
+    <HTTPTargetConnection>
+      <LoadBalancer>
+         <Server name="server1"/>
+         <Server name="server2"/>
+         <Server name="server3"/>
+      </LoadBalancer>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/TD008/pass/t3.xml
+++ b/test/fixtures/resources/TD008/pass/t3.xml
@@ -1,0 +1,7 @@
+<TargetEndpoint name="default">
+    <HTTPTargetConnection>
+      <LoadBalancer>
+         <Server name="server1"/>
+      </LoadBalancer>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/TD008/pass/t4.xml
+++ b/test/fixtures/resources/TD008/pass/t4.xml
@@ -1,0 +1,12 @@
+<TargetEndpoint name="default">
+    <HTTPTargetConnection>
+      <LoadBalancer>
+         <Server name="server1"/>
+         <Server name="server2"/>
+         <!-- single fallback is OK -->
+         <Server name="server3">
+           <IsFallback>true</IsFallback>
+         </Server>
+      </LoadBalancer>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/TD009/fail/t1.xml
+++ b/test/fixtures/resources/TD009/fail/t1.xml
@@ -1,0 +1,11 @@
+<TargetEndpoint name="default">
+  <HTTPTargetConnection>
+    <!-- multiple LoadBalancer elements will fail the TD009 check -->
+      <LoadBalancer>
+         <Server name="server1"/>
+      </LoadBalancer>
+      <LoadBalancer>
+         <Server name="server2"/>
+      </LoadBalancer>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/TD009/pass/t1.xml
+++ b/test/fixtures/resources/TD009/pass/t1.xml
@@ -1,0 +1,9 @@
+<TargetEndpoint name="default">
+  <HTTPTargetConnection>
+    <!-- a single LoadBalancer element will pass the TD009 check -->
+      <LoadBalancer>
+         <Server name="server1"/>
+         <Server name="server2"/>
+      </LoadBalancer>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/TD009/pass/t2.xml
+++ b/test/fixtures/resources/TD009/pass/t2.xml
@@ -1,0 +1,16 @@
+<TargetEndpoint name="t2">
+    <HTTPTargetConnection>
+
+      <!-- zero LoadBalancer elements will also pass the TD009 check -->
+
+      <SSLInfo>
+        <Enabled>true</Enabled>
+        <Enforce>true</Enforce>
+        <CommonName
+            wildcardMatch="false">echo.dchiesa.demo.altostrat.com</CommonName>
+        <TrustStore>ref://myTrustStoreRef</TrustStore>
+      </SSLInfo>
+
+      <URL>https://echo.dchiesa.demo.altostrat.com</URL>
+    </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/specs/TD008-test.js
+++ b/test/specs/TD008-test.js
@@ -1,0 +1,93 @@
+/*
+  Copyright 2019-2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const testID = "TD008",
+  assert = require("assert"),
+  fs = require("fs"),
+  util = require("util"),
+  path = require("path"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Endpoint = require("../../lib/package/Endpoint.js"),
+  Dom = require("@xmldom/xmldom").DOMParser,
+  rootDir = path.resolve(__dirname, "../fixtures/resources/TD008"),
+  debug = require("debug")("apigeelint:" + testID);
+
+const loadEndpoint = (sourceDir, shortFileName) => {
+  const fqPath = path.join(sourceDir, shortFileName),
+    xml = fs.readFileSync(fqPath).toString("utf-8"),
+    doc = new Dom().parseFromString(xml),
+    endpoint = new Endpoint(doc.documentElement, null, "");
+  endpoint.getFileName = () => shortFileName;
+  return endpoint;
+};
+
+describe(`${testID} - endpoint passes duplicate server check`, function () {
+  const sourceDir = path.join(rootDir, "pass");
+  const testOne = (shortFileName) => {
+    const endpoint = loadEndpoint(sourceDir, shortFileName);
+
+    it(`check ${shortFileName} passes`, () => {
+      plugin.onTargetEndpoint(endpoint, (e, foundIssues) => {
+        assert.equal(e, undefined, "should be undefined");
+        const messages = endpoint.getReport().messages;
+        debug(util.format(messages));
+        assert.equal(foundIssues, false, "should be no issues");
+        assert.ok(messages, "messages should exist");
+        assert.equal(messages.length, 0, "unexpected number of messages");
+      });
+    });
+  };
+
+  const candidates = fs
+    .readdirSync(sourceDir)
+    .filter((shortFileName) => shortFileName.endsWith(".xml"));
+
+  it(`checks that there are tests`, () => {
+    assert.ok(candidates.length > 0, "tests should exist");
+  });
+
+  candidates.forEach(testOne);
+});
+
+describe(`${testID} - endpoint does not pass duplicate server check`, () => {
+  const sourceDir = path.join(rootDir, "fail");
+
+  const testOne = (shortFileName) => {
+    const policy = loadEndpoint(sourceDir, shortFileName);
+    it(`check ${shortFileName} throws error`, () => {
+      plugin.onTargetEndpoint(policy, (e, foundIssues) => {
+        assert.equal(undefined, e, "should be undefined");
+        assert.equal(true, foundIssues, "should be issues");
+        const messages = policy.getReport().messages;
+        assert.ok(messages, "messages for issues should exist");
+        debug(util.format(messages));
+      });
+    });
+  };
+
+  const candidates = fs
+    .readdirSync(sourceDir)
+    .filter((shortFileName) => shortFileName.endsWith(".xml"));
+
+  it(`checks that there are tests`, () => {
+    assert.ok(candidates.length > 0, "tests should exist");
+  });
+
+  candidates.forEach(testOne);
+});

--- a/test/specs/TD009-test.js
+++ b/test/specs/TD009-test.js
@@ -1,0 +1,93 @@
+/*
+  Copyright 2019-2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const testID = "TD009",
+  assert = require("assert"),
+  fs = require("fs"),
+  util = require("util"),
+  path = require("path"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Endpoint = require("../../lib/package/Endpoint.js"),
+  Dom = require("@xmldom/xmldom").DOMParser,
+  rootDir = path.resolve(__dirname, "../fixtures/resources/TD009"),
+  debug = require("debug")("apigeelint:" + testID);
+
+const loadEndpoint = (sourceDir, shortFileName) => {
+  const fqPath = path.join(sourceDir, shortFileName),
+    xml = fs.readFileSync(fqPath).toString("utf-8"),
+    doc = new Dom().parseFromString(xml),
+    endpoint = new Endpoint(doc.documentElement, null, "");
+  endpoint.getFileName = () => shortFileName;
+  return endpoint;
+};
+
+describe(`${testID} - endpoint passes multiple LB check`, function () {
+  const sourceDir = path.join(rootDir, "pass");
+  const testOne = (shortFileName) => {
+    const endpoint = loadEndpoint(sourceDir, shortFileName);
+
+    it(`check ${shortFileName} passes`, () => {
+      plugin.onTargetEndpoint(endpoint, (e, foundIssues) => {
+        assert.equal(e, undefined, "should be undefined");
+        const messages = endpoint.getReport().messages;
+        debug(util.format(messages));
+        assert.equal(foundIssues, false, "should be no issues");
+        assert.ok(messages, "messages should exist");
+        assert.equal(messages.length, 0, "unexpected number of messages");
+      });
+    });
+  };
+
+  const candidates = fs
+    .readdirSync(sourceDir)
+    .filter((shortFileName) => shortFileName.endsWith(".xml"));
+
+  it(`checks that there are tests`, () => {
+    assert.ok(candidates.length > 0, "tests should exist");
+  });
+
+  candidates.forEach(testOne);
+});
+
+describe(`${testID} - endpoint does not pass multiple LB check`, () => {
+  const sourceDir = path.join(rootDir, "fail");
+
+  const testOne = (shortFileName) => {
+    const policy = loadEndpoint(sourceDir, shortFileName);
+    it(`check ${shortFileName} throws error`, () => {
+      plugin.onTargetEndpoint(policy, (e, foundIssues) => {
+        assert.equal(undefined, e, "should be undefined");
+        assert.equal(true, foundIssues, "should be issues");
+        const messages = policy.getReport().messages;
+        assert.ok(messages, "messages for issues should exist");
+        debug(util.format(messages));
+      });
+    });
+  };
+
+  const candidates = fs
+    .readdirSync(sourceDir)
+    .filter((shortFileName) => shortFileName.endsWith(".xml"));
+
+  it(`checks that there are tests`, () => {
+    assert.ok(candidates.length > 0, "tests should exist");
+  });
+
+  candidates.forEach(testOne);
+});


### PR DESCRIPTION
New Plugins TD008 and TD009.  

TD008 addresses #469 and #470 .  It checks for duplicate server entries, or cases in which there are multiple IsFallback entries. Or, when there is no `name=` attribute on the Server entry. 

TD009 checks for multiple LoadBalancers. 

Updated README.

