### PR TITLE
feat: handle ingest of zipped bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,31 +14,25 @@ This utility is intended to capture the best practices knowledge from across Api
 
 ## Status
 
-At this point, we are focused on plugin execution and modelling the various lintable assets including Bundles, Proxies, SharedFlows, Targets, Flows, Steps, and Policies.
+This tool is mature and stable, works with proxy and sharedflow bundles, and
+continues to get enhancements.  There are a variety of plugins that test
+Bundles, Policies, ProxyEndpoints, and more.
 
-Plugins that test these abstractions are being developed concurrently.
-
-Reporters (the means to report out results), Ingesters (bundle loaders) are to be developed with Filesystem being the only supported means of loading a bundle and all reporting now going to console.
+The tool can report results out to the console, or to a file.  The tool can
+ingest from an exploded directory, or from a zipped bundle.
 
 ## Installation
 
 You can install apigeellint using npm. But, there is a minimum version of `npm` required.
 
-1. First verify the version of npm:
+1. First verify the version of node and npm:
    ```
    npm --version
+   node --version
    ```
 
-   If the version is 8.3.0 or later, then proceed to step 2.
-   If the version is less than `8.3.0`, then update:
-   ```
-   npm install npm@8.3.0 -g
-   ```
-
-   Alternatively, you may choose to get the latest npm:
-   ```
-   npm install npm@latest -g
-   ```
+   If the npm version is 10.5.0 or later, and node version is 20 or later, then proceed to step 2.
+   Otherwise, you need to update npm and/or node.
 
 2. Then install apigeelint:
    ```
@@ -54,7 +48,7 @@ Usage: apigeelint [options]
 
 Options:
   -V, --version                           output the version number
-  -s, --path <path>                       Path of the proxies
+  -s, --path <path>                       Path of the proxy to analyze
   -f, --formatter [value]                 Specify formatters (default: json.js)
   -w, --write [value]                     file path to write results
   -e, --excluded [value]                  The comma separated list of tests to exclude (default: none)
@@ -72,11 +66,49 @@ Example:
 apigeelint -s sampleProxy/apiproxy -f table.js
 ```
 
-Where `-s` points to the apiProxy source directory and `-f` is the output formatter desired.
+Where `-s` points to the apiProxy source directory or bundled zip file, and `-f` is the output
+formatter desired.
 
 Possible formatters are: "json.js" (the default), "stylish.js", "compact.js", "codeframe.js", "codeclimate.js", "html.js", "table.js", "unix.js", "visualstudio.js", "checkstyle.js", "jslint-xml.js", "junit.js" and "tap.js".
 
 ## Examples
+
+### Basic usage: ingest from a directory
+```
+apigeelint -f table.js -s path/to/your/apiproxy
+```
+
+The path here should be a directory name, probably ending in "apiproxy".  The
+contents of that directory should be like this:
+
+```
+apiproxy/
+apiproxy/proxies/
+apiproxy/proxies/endpoint1.xml
+apiproxy/servicecallout-async-test.xml
+apiproxy/resources/
+apiproxy/resources/jsc/
+apiproxy/resources/jsc/...
+apiproxy/policies/
+apiproxy/policies/RF-Unknown-Request.xml
+apiproxy/policies/AM-Response.xml
+apiproxy/policies/...
+...
+```
+
+
+### Basic usage: ingest from a zipped proxy bundle
+
+You can export API Proxy or Sharedflow bundles from Apigee, producing a zip
+archive. This tool also can read and analyze these zipped bundles:
+
+```
+apigeelint -f table.js -s path/to/your/apiproxy.zip
+```
+
+The tool will unzip the bundle  to a temporary directory, perform the analysis,
+and then remove the temporary directory.
+
 
 ### Using External Plugins:
 ```

--- a/lib/package/Bundle.js
+++ b/lib/package/Bundle.js
@@ -32,16 +32,16 @@ const findFolders = require("./findFolders.js"),
 function _buildEndpoints(folder, tag, bundle, processFunction) {
   try {
     if (fs.existsSync(folder)) {
-      fs.readdirSync(folder).forEach(function (proxyFile) {
+      fs.readdirSync(folder).forEach(function (endptFile) {
         //can't be a directory
         //must end in .xml
-        const fname = path.join(folder, proxyFile);
-        if (proxyFile.endsWith(".xml") && fs.lstatSync(fname).isFile()) {
+        const fqFname = path.join(folder, endptFile);
+        if (endptFile.endsWith(".xml") && fs.lstatSync(fqFname).isFile()) {
           const doc = xpath.select(
             tag,
-            new Dom().parseFromString(fs.readFileSync(fname).toString())
+            new Dom().parseFromString(fs.readFileSync(fqFname).toString())
           );
-          doc.forEach((element) => processFunction(element, fname, bundle));
+          doc.forEach((element) => processFunction(element, fqFname, bundle));
         }
       });
     }
@@ -54,9 +54,9 @@ function _buildEndpoints(folder, tag, bundle, processFunction) {
 function buildProxyEndpoints(bundle) {
   var folder = bundle.proxyRoot + "/proxies/",
     tag = "ProxyEndpoint",
-    processFunction = function (element, fname, bundle) {
+    processFunction = function (element, fqFname, bundle) {
       bundle.proxyEndpoints = bundle.proxyEndpoints || [];
-      bundle.proxyEndpoints.push(new Endpoint(element, bundle, fname));
+      bundle.proxyEndpoints.push(new Endpoint(element, bundle, fqFname));
     };
   _buildEndpoints(folder, tag, bundle, processFunction);
 }
@@ -64,10 +64,10 @@ function buildProxyEndpoints(bundle) {
 function buildsharedflows(bundle) {
   var folder = bundle.proxyRoot + "/sharedflows/",
     tag = "SharedFlow",
-    processFunction = function (element, fname, bundle) {
+    processFunction = function (element, fqFname, bundle) {
       bundle.proxyEndpoints = bundle.proxyEndpoints || [];
       bundle.proxyEndpoints.push(
-        new Endpoint(element, bundle, fname, bundleType.BundleType.SHAREDFLOW)
+        new Endpoint(element, bundle, fqFname, bundleType.BundleType.SHAREDFLOW)
       );
     };
   _buildEndpoints(folder, tag, bundle, processFunction);
@@ -206,7 +206,7 @@ function processFileSystem(config, bundle, cb) {
   //bundle.policies = [];
   //process.chdir(config.source.path);
   bundle.report = {
-    filePath: lintUtil.effectivePath(bundle.root, bundleTypeName),
+    filePath: lintUtil.effectivePath(bundle, bundle.root),
     errorCount: 0,
     warningCount: 0,
     fixableErrorCount: 0,
@@ -256,6 +256,9 @@ function Bundle(config, cb) {
   this.excluded = config.excluded;
   this.profile = config.profile;
   this.ignoreDirectives = config.ignoreDirectives;
+  this.sourcePath = config.source.sourcePath;
+  this.resolvedPath = config.source.path;
+  this.sourceType = config.source.type;
 
   if (config.source.type === "ManagementServer") {
     //shared flow not implemented for management server

--- a/lib/package/Endpoint.js
+++ b/lib/package/Endpoint.js
@@ -22,16 +22,17 @@ const Flow = require("./Flow.js"),
   debug = require("debug")("apigeelint:Endpoint"),
   util = require("util"),
   fs = require("fs"),
+      path = require("path"),
   getcb = lintUtil.curry(lintUtil.diagcb, debug),
   HTTPProxyConnection = require("./HTTPProxyConnection.js"),
   HTTPTargetConnection = require("./HTTPTargetConnection.js"),
   bundleTypes = require("./BundleTypes.js");
 
-function Endpoint(element, parent, fname, bundletype) {
+function Endpoint(element, bundle, fname, bundletype) {
   debug(`> new Endpoint() ${fname}`);
   this.bundleType = bundletype ? bundletype : "apiproxy"; //default to apiproxy if bundletype not passed
   this.fileName = fname;
-  this.parent = parent; // the bundle
+  this.parent = bundle;
   this.element = element;
   this.preFlow = null;
   this.postFlow = null;
@@ -40,7 +41,8 @@ function Endpoint(element, parent, fname, bundletype) {
   this.httpProxyConnection = null;
   this.httpTargetConnection = null;
   this.report = {
-    filePath: lintUtil.effectivePath(fname, this.bundleType),
+    //filePath: path.join(bundle.sourcePath, path.basename(fname)),
+    filePath: lintUtil.effectivePath(bundle, fname),
     errorCount: 0,
     warningCount: 0,
     fixableErrorCount: 0,

--- a/lib/package/Policy.js
+++ b/lib/package/Policy.js
@@ -15,25 +15,27 @@
 */
 
 const fs = require("fs"),
+  path = require("path"),
   xpath = require("xpath"),
   lintUtil = require("./lintUtil.js"),
   Dom = require("@xmldom/xmldom").DOMParser,
   debug = require("debug")("apigeelint:Policy");
 
-function Policy(path, fn, parent, doc) {
-  this.fileName = fn;
-  this.filePath = path + "/" + fn;
+function Policy(realpath, fname, bundle, doc) {
+  this.fileName = fname;
+  const resolvedFilePath = path.join(realpath, fname);
+  this.filePath = resolvedFilePath;
   this.bundleType =
-    parent && parent.bundletype ? parent.bundletype : "apiproxy";
-  this.parent = parent;
+    bundle && bundle.bundletype ? bundle.bundletype : "apiproxy";
+  this.parent = bundle;
   if (doc) this.element = doc;
   this.report = {
-    filePath: lintUtil.effectivePath(this.filePath, this.bundleType),
+    filePath: lintUtil.effectivePath(bundle, resolvedFilePath),
     errorCount: 0,
     warningCount: 0,
     fixableErrorCount: 0,
     fixableWarningCount: 0,
-    messages: []
+    messages: [],
   };
 }
 
@@ -93,7 +95,7 @@ Policy.prototype.getDisplayName = function () {
       if (nodes[0].childNodes && nodes[0].childNodes[0]) {
         this.displayName = nodes[0].childNodes[0].nodeValue;
         debug(
-          `policy(${this.name}) DisplayName(${nodes[0].childNodes[0].nodeValue})`
+          `policy(${this.name}) DisplayName(${nodes[0].childNodes[0].nodeValue})`,
         );
       } else {
         this.displayName = "";
@@ -114,7 +116,7 @@ Policy.prototype.select = function (xs) {
 Policy.prototype.getElement = function () {
   if (!this.element) {
     this.element = new Dom().parseFromString(
-      fs.readFileSync(this.filePath).toString()
+      fs.readFileSync(this.filePath).toString(),
     ).documentElement;
   }
   return this.element;

--- a/lib/package/Resource.js
+++ b/lib/package/Resource.js
@@ -15,16 +15,18 @@
 */
 
 const fs = require("fs"),
+      path = require("path"),
   lintUtil = require("./lintUtil.js");
 
-function Resource(parent, path, fname) {
-  this.parent = parent;
-  this.path = path;
+function Resource(bundle, realpath, fname) {
+  this.parent = bundle;
+  this.path = realpath;
   this.fname = fname;
-  this.bundleType = parent.bundletype ? parent.bundletype : "apiproxy";
+  this.bundleType = bundle.bundletype ? bundle.bundletype : "apiproxy";
   this.messages = { warnings: [], errors: [] };
   this.report = {
-    filePath: lintUtil.effectivePath(this.path, this.bundleType),
+    //filePath: path.join(bundle.sourcePath, path.basename(fname)),
+    filePath: lintUtil.effectivePath(bundle, realpath),
     errorCount: 0,
     warningCount: 0,
     fixableErrorCount: 0,

--- a/lib/package/lintUtil.js
+++ b/lib/package/lintUtil.js
@@ -44,8 +44,10 @@ function getNodeModulesPathFor() {
   const r = (acc, c) => {
     if (!acc) {
       let candidate = path.join(__dirname, c);
-      return checkCandidate(candidate)
-        || checkCandidate(path.join(candidate, "node_modules"));
+      return (
+        checkCandidate(candidate) ||
+        checkCandidate(path.join(candidate, "node_modules"))
+      );
     }
     return acc;
   };
@@ -60,7 +62,7 @@ function rBuildTagBreadCrumb(doc, bc) {
   if (doc && doc.parentNode) {
     bc = rBuildTagBreadCrumb(
       doc.parentNode,
-      doc.parentNode.nodeName + ":" + bc
+      doc.parentNode.nodeName + ":" + bc,
     );
   }
   return bc;
@@ -187,10 +189,12 @@ const getRuleId = () => {
   }
 };
 
-function effectivePath(root, bundleTypeName) {
-  return root;
-  // // will this work on Windows?
-  // return root.substring(root.lastIndexOf("/" + bundleTypeName) + 1);
+function effectivePath(bundle, fpath) {
+  if (bundle && bundle.sourceType == "zip") {
+    return fpath.replace(path.dirname(bundle.resolvedPath), bundle.sourcePath);
+  }
+
+  return fpath;
 }
 
 //Courtesy - https://stackoverflow.com/a/52171480
@@ -228,15 +232,13 @@ const xmlNodeTypeAsString = (function () {
     keys = Object.keys(Node.prototype).filter((key) => key.endsWith("_NODE"));
   d(`keys(${keys})`);
 
-  return (typ) =>
-    keys.find((key) => Node[key] == typ) || "unknown";
+  return (typ) => keys.find((key) => Node[key] == typ) || "unknown";
 })();
 
 const directiveRe = new RegExp("^\\s*apigeelint\\s+disable\\s?=(.+)$");
 const isApigeelintDirective = (textContent) => {
   const match = directiveRe.exec(textContent);
-  return match &&
-     match[1].split(",").map((s) => s.trim());
+  return match && match[1].split(",").map((s) => s.trim());
 };
 
 function findDirectives(elt, indent) {
@@ -246,8 +248,8 @@ function findDirectives(elt, indent) {
   if (!indent) {
     d(
       `root: (nodeType: ${elt.nodeType}, ${xmlNodeTypeAsString(
-        elt.nodeType
-      )}) ${elt.nodeName}`
+        elt.nodeType,
+      )}) ${elt.nodeName}`,
     );
   }
   let acc = [];
@@ -258,8 +260,8 @@ function findDirectives(elt, indent) {
     const node = elt.childNodes.item(ix);
     d(
       `${indent}Node ${ix}: (nodeType: ${node.nodeType}, ${xmlNodeTypeAsString(
-        node.nodeType
-      )}) ${node.nodeName}`
+        node.nodeType,
+      )}) ${node.nodeName}`,
     );
     if (node.nodeType == Node.COMMENT_NODE) {
       d(`${indent}  text: ${node.textContent}`);
@@ -292,5 +294,5 @@ module.exports = {
   findDirectives,
   /* exported for testing */
   getNodeModulesPathFor,
-  xmlNodeTypeAsString
+  xmlNodeTypeAsString,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10",
+        "adm-zip": "^0.5.16",
         "babel-code-frame": "latest",
         "chalk": "4.1.2",
         "commander": "^2.9.0",
@@ -26,6 +27,7 @@
         "strip-ansi": "^6.0.1",
         "table": "latest",
         "text-table": "latest",
+        "tmp": "^0.2.3",
         "xpath": "latest"
       },
       "bin": {
@@ -898,6 +900,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -6268,6 +6279,15 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/to-buffer": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "private": false,
   "dependencies": {
     "@xmldom/xmldom": "^0.8.10",
+    "adm-zip": "^0.5.16",
     "babel-code-frame": "latest",
     "chalk": "4.1.2",
     "commander": "^2.9.0",
@@ -47,6 +48,7 @@
     "strip-ansi": "^6.0.1",
     "table": "latest",
     "text-table": "latest",
+    "tmp": "^0.2.3",
     "xpath": "latest"
   },
   "devDependencies": {

--- a/test/specs/PO007-PolicyNameConventions.js
+++ b/test/specs/PO007-PolicyNameConventions.js
@@ -80,7 +80,7 @@ const testOne =
   (testcase, ix, cb) => {
       let policyXml = testcase,
           doc = new Dom().parseFromString(policyXml),
-          p = new Policy(doc.documentElement, this);
+          p = new Policy("", `testcase-${ix}`, this, doc);
           p.getElement = () => doc.documentElement;
 
     let policyName = p.getName(),

--- a/test/specs/PO007-corsPolicyName.js
+++ b/test/specs/PO007-corsPolicyName.js
@@ -1,55 +1,81 @@
-// PO007-corsPolicyName.js
-// ------------------------------------------------------------------
+/*
+  Copyright 2022-2024 Google LLC
 
-/* jshint esversion:9, node:true, strict:implied */
-/* global describe, it */
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 
 const testID = "PO007",
-      assert = require("assert"),
-      fs = require("fs"),
-      path = require("path"),
-      bl = require("../../lib/package/bundleLinter.js"),
-      plugin = require(bl.resolvePlugin(testID)),
-      Policy = require("../../lib/package/Policy.js"),
-      Dom = require("@xmldom/xmldom").DOMParser;
+  assert = require("assert"),
+  fs = require("fs"),
+  path = require("path"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Policy = require("../../lib/package/Policy.js"),
+  Dom = require("@xmldom/xmldom").DOMParser;
 
-const test =
-  (filename, cb) => {
-    it(`should correctly process ${filename}`, () => {
-      let fqfname = path.resolve(__dirname, '../fixtures/resources/PO007-cors-policy', filename),
-          policyXml = fs.readFileSync(fqfname, 'utf-8'),
-          doc = new Dom().parseFromString(policyXml),
-          p = new Policy(doc.documentElement, this);
+const test = (filename, cb) => {
+  it(`should correctly process ${filename}`, () => {
+    let baseDir = path.resolve(
+        __dirname,
+        "../fixtures/resources/PO007-cors-policy",
+      ),
+      fqfname = path.resolve(baseDir, filename),
+      policyXml = fs.readFileSync(fqfname, "utf-8"),
+      doc = new Dom().parseFromString(policyXml),
+      p = new Policy(baseDir, fqfname, this, doc);
 
-      p.getElement = () => doc.documentElement;
+    p.getElement = () => doc.documentElement;
 
-      plugin.onPolicy(p, (e, foundIssues) => {
-        assert.equal(e, undefined, "should be undefined");
-        cb(p, foundIssues);
-      });
+    plugin.onPolicy(p, (e, foundIssues) => {
+      assert.equal(e, undefined, "should be undefined");
+      cb(p, foundIssues);
     });
-  };
+  });
+};
 
 describe(`PO007 - CORS policy name`, () => {
-
-  test('CORS-1.xml', (p, foundIssues) => {
+  test("CORS-1.xml", (p, foundIssues) => {
     assert.equal(foundIssues, false);
     assert.ok(p.getReport().messages, "messages undefined");
-    assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
+    assert.equal(
+      p.getReport().messages.length,
+      0,
+      JSON.stringify(p.getReport().messages),
+    );
   });
 
-  test('AM-CORS-1.xml', (p, foundIssues) => {
+  test("AM-CORS-1.xml", (p, foundIssues) => {
     assert.equal(foundIssues, true);
     assert.ok(p.getReport().messages, "messages undefined");
-    assert.equal(p.getReport().messages.length, 1, "unexpected number of messages");
-    assert.ok(p.getReport().messages[0].message, 'did not find message member');
-    assert.equal(p.getReport().messages[0].message, 'Non-standard name for policy (AM-CORS-1). Valid prefixes for the CORS policy: ["cors"]. Valid patterns: ["^cors$"].');
+    assert.equal(
+      p.getReport().messages.length,
+      1,
+      "unexpected number of messages",
+    );
+    assert.ok(p.getReport().messages[0].message, "did not find message member");
+    assert.equal(
+      p.getReport().messages[0].message,
+      'Non-standard name for policy (AM-CORS-1). Valid prefixes for the CORS policy: ["cors"]. Valid patterns: ["^cors$"].',
+    );
   });
 
-  test('CORS.xml', (p, foundIssues) => {
+  test("CORS.xml", (p, foundIssues) => {
     assert.equal(foundIssues, false);
     assert.ok(p.getReport().messages, "messages undefined");
-    assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
+    assert.equal(
+      p.getReport().messages.length,
+      0,
+      JSON.stringify(p.getReport().messages),
+    );
   });
-
 });

--- a/test/specs/PO007-quotaPrefix.js
+++ b/test/specs/PO007-quotaPrefix.js
@@ -1,67 +1,87 @@
-// quotaPrefix.js
-// ------------------------------------------------------------------
-//
-// created: Mon Nov 16 17:03:04 2020
-// last saved: <2021-December-07 14:20:16>
+/*
+  Copyright 2022-2024 Google LLC
 
-/* jshint esversion:9, node:true, strict:implied */
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 /* global describe, it */
 
 const testID = "PO007",
-      assert = require("assert"),
-      bl = require("../../lib/package/bundleLinter.js"),
-      plugin = require(bl.resolvePlugin(testID)),
-      Policy = require("../../lib/package/Policy.js"),
-      Dom = require("@xmldom/xmldom").DOMParser;
+  assert = require("assert"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Policy = require("../../lib/package/Policy.js"),
+  Dom = require("@xmldom/xmldom").DOMParser;
 
-const policyXmlTemplate = '<Quota name="@@PNAME@@">\n' +
-      '   <Identifier ref="client_id"/>\n' +
-      '   <Allow countRef="apiproduct.developer.quota.limit" count="10000"/>\n' +
-      '   <Interval ref="apiproduct.developer.quota.interval">1</Interval>\n' +
-      '   <TimeUnit ref="apiproduct.developer.quota.timeunit">month</TimeUnit>\n' +
-      '   <Distributed>true</Distributed>\n' +
-      '   <Synchronous>true</Synchronous>\n' +
-      '</Quota>\n';
+const policyXmlTemplate =
+  '<Quota name="@@PNAME@@">\n' +
+  '   <Identifier ref="client_id"/>\n' +
+  '   <Allow countRef="apiproduct.developer.quota.limit" count="10000"/>\n' +
+  '   <Interval ref="apiproduct.developer.quota.interval">1</Interval>\n' +
+  '   <TimeUnit ref="apiproduct.developer.quota.timeunit">month</TimeUnit>\n' +
+  "   <Distributed>true</Distributed>\n" +
+  "   <Synchronous>true</Synchronous>\n" +
+  "</Quota>\n";
 
-const test = (expectSuccess) =>
-  (policyName) => {
-    it(`allows acceptable policyName(${policyName})`, () => {
-      let policyXml = policyXmlTemplate.replace('@@PNAME@@', policyName),
-          doc = new Dom().parseFromString(policyXml),
-          p = new Policy(doc.documentElement, this);
+const test = (expectSuccess) => (policyName) => {
+  it(`allows acceptable policyName(${policyName})`, () => {
+    let policyXml = policyXmlTemplate.replace("@@PNAME@@", policyName),
+      doc = new Dom().parseFromString(policyXml),
+      p = new Policy("/", "fakename.xml", this, doc);
 
-      p.getElement = () => doc.documentElement;
+    p.getElement = () => doc.documentElement;
 
-      plugin.onPolicy(p, (e, foundIssues) => {
-        assert.equal(e, undefined, "should be undefined");
-        if (expectSuccess) {
-          assert.equal(foundIssues, false);
-          assert.ok(p.getReport().messages, "messages undefined");
-          assert.equal(p.getReport().messages.length, 0, JSON.stringify(p.getReport().messages));
-        }
-        else {
-          assert.equal(foundIssues, true);
-          assert.ok(p.getReport().messages, "messages undefined");
-          assert.equal(p.getReport().messages.length, 1, "unexpected number of messages");
-          assert.ok(p.getReport().messages[0].message, 'did not find message member');
-          assert.equal(p.getReport().messages[0].message, `Non-standard name for policy (${policyName}). Valid prefixes for the Quota policy: ["quota","q"]. Valid patterns: ["^q$","^quota$"].`);
-        }
-      });
+    plugin.onPolicy(p, (e, foundIssues) => {
+      assert.equal(e, undefined, "should be undefined");
+      if (expectSuccess) {
+        assert.equal(foundIssues, false);
+        assert.ok(p.getReport().messages, "messages undefined");
+        assert.equal(
+          p.getReport().messages.length,
+          0,
+          JSON.stringify(p.getReport().messages),
+        );
+      } else {
+        assert.equal(foundIssues, true);
+        assert.ok(p.getReport().messages, "messages undefined");
+        assert.equal(
+          p.getReport().messages.length,
+          1,
+          "unexpected number of messages",
+        );
+        assert.ok(
+          p.getReport().messages[0].message,
+          "did not find message member",
+        );
+        assert.equal(
+          p.getReport().messages[0].message,
+          `Non-standard name for policy (${policyName}). Valid prefixes for the Quota policy: ["quota","q"]. Valid patterns: ["^q$","^quota$"].`,
+        );
+      }
     });
-  };
+  });
+};
 
 const positiveCase = test(true);
 const negativeCase = test(false);
 
 describe(`PO007 - QuotaPolicyPrefix`, () => {
+  positiveCase("Q-Enforce");
+  positiveCase("Quota-Enforce");
+  positiveCase("QUOTA-1");
+  positiveCase("Q");
+  positiveCase("Quota");
 
-  positiveCase('Q-Enforce');
-  positiveCase('Quota-Enforce');
-  positiveCase('QUOTA-1');
-  positiveCase('Q');
-  positiveCase('Quota');
-
-  negativeCase('unQ-Enforce');
-  negativeCase('NotQuota');
-
+  negativeCase("unQ-Enforce");
+  negativeCase("NotQuota");
 });

--- a/test/specs/PO018-checkRegexLookAround.js
+++ b/test/specs/PO018-checkRegexLookAround.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -16,72 +16,58 @@
 /* global it, describe */
 
 const assert = require("assert"),
-      testID = "PO018",
-      debug = require("debug")("apigeelint:" + testID),
-      Bundle = require("../../lib/package/Bundle.js"),
-      Policy = require("../../lib/package/Policy.js"),
-      bl = require("../../lib/package/bundleLinter.js"),
-      plugin = require(bl.resolvePlugin(testID)),
-      Dom = require("@xmldom/xmldom").DOMParser,
-      test = function(caseNum, exp, assertion) {
-        it(`tests case ${caseNum}, expect to see ${assertion}`,
-           function() {
-             let doc = new Dom().parseFromString(exp),
-                 p = new Policy(doc, this);
+  testID = "PO018",
+  debug = require("debug")("apigeelint:" + testID),
+  Bundle = require("../../lib/package/Bundle.js"),
+  Policy = require("../../lib/package/Policy.js"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Dom = require("@xmldom/xmldom").DOMParser,
+  test = function (caseNum, exp, assertion) {
+    it(`tests case ${caseNum}, expect to see ${assertion}`, function () {
+      let doc = new Dom().parseFromString(exp),
+        p = new Policy("/", "fakename.xml", this, doc);
 
-             p.addMessage = function(msg) {
-               debug(msg);
-             };
-             p.getElement = function() {
-               return doc;
-             };
-             plugin.onPolicy(p, function(err, result) {
-               assert.equal(
-                 err,
-                 undefined,
-                 err ? " err " : " no err"
-               );
-               assert.equal(
-                 result,
-                 assertion,
-                 result ? " (? found " : "(? not found"
-               );
-             });
-           }
-          );
+      p.addMessage = function (msg) {
+        debug(msg);
       };
+      p.getElement = function () {
+        return doc;
+      };
+      plugin.onPolicy(p, function (err, result) {
+        assert.equal(err, undefined, err ? " err " : " no err");
+        assert.equal(result, assertion, result ? " (? found " : "(? not found");
+      });
+    });
+  };
 
-
-describe(`${testID} - ${plugin.plugin.name}`, function() {
-
+describe(`${testID} - ${plugin.plugin.name}`, function () {
   test(
     1,
     '<RegularExpressionProtection async="false" continueOnError="false" enabled="true" name="regExLookAround"><DisplayName>regExLookAround</DisplayName><Source>request</Source><IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables><URIPath><Pattern>.*Exception in thread.*</Pattern></URIPath></RegularExpressionProtection>',
-    false
+    false,
   );
 
   test(
     2,
     '<RegularExpressionProtection async="false" continueOnError="false" enabled="true" name="regExLookAround"><DisplayName>regExLookAround</DisplayName><Source>request</Source><IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables><URIPath><Pattern>(?/(@?[w_?w:*]+([[^]]+])*)?)+</Pattern></URIPath></RegularExpressionProtection>',
-    true
+    true,
   );
 
   test(
     3,
     '<RegularExpressionProtection async="false" continueOnError="false" enabled="true" name="regExLookAround"><DisplayName>regExLookAround</DisplayName><Source>request</Source><IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables><URIPath><Pattern>((?i)/(@?[w_?w:*]+([[^]]+])*)?)+</Pattern></URIPath></RegularExpressionProtection>',
-    false
+    false,
   );
 
   test(
     4,
     '<RegularExpressionProtection async="false" continueOnError="false" enabled="true" name="regExLookAround"><DisplayName>regExLookAround</DisplayName><Source>request</Source><IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables><URIPath><Pattern>(?i)(?/(@?[w_?w:*]+([[^]]+])*)?)+</Pattern></URIPath></RegularExpressionProtection>',
-    true
+    true,
   );
 });
 
-
-describe(`${testID} - ${plugin.plugin.name}`, function() {
-
+describe(`${testID} - ${plugin.plugin.name}`, function () {
   debug("test configuration: " + JSON.stringify(configuration));
 
   let bundle = new Bundle(configuration);
@@ -89,7 +75,7 @@ describe(`${testID} - ${plugin.plugin.name}`, function() {
 
   let report = bundle.getReport();
 
-  it("should create a report object with valid schema", function() {
+  it("should create a report object with valid schema", function () {
     let formatter = bl.getFormatter("json.js");
 
     if (!formatter) {
@@ -97,15 +83,10 @@ describe(`${testID} - ${plugin.plugin.name}`, function() {
     }
 
     let schema = require("./../fixtures/reportSchema.js"),
-        Validator = require("jsonschema").Validator,
-        v = new Validator(),
-        jsonReport = JSON.parse(formatter(bundle.getReport())),
-        validationResult = v.validate(jsonReport, schema);
-    assert.equal(
-      validationResult.errors.length,
-      0,
-      validationResult.errors
-    );
+      Validator = require("jsonschema").Validator,
+      v = new Validator(),
+      jsonReport = JSON.parse(formatter(bundle.getReport())),
+      validationResult = v.validate(jsonReport, schema);
+    assert.equal(validationResult.errors.length, 0, validationResult.errors);
   });
-
 });

--- a/test/specs/PO022-distributedQuotaCheck.js
+++ b/test/specs/PO022-distributedQuotaCheck.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -16,43 +16,36 @@
 /* global it, describe */
 
 const assert = require("assert"),
-      testID = "PO022",
-      debug = require("debug")("apigeelint:" + testID),
-      Bundle = require("../../lib/package/Bundle.js"),
-      bl = require("../../lib/package/bundleLinter.js"),
-      Policy = require("../../lib/package/Policy.js"),
-      plugin = require(bl.resolvePlugin(testID)),
-      Dom = require("@xmldom/xmldom").DOMParser,
-      test = function(exp, caseNum, assertion) {
-        it(`tests ${caseNum}, expect(${assertion})`,
-           function() {
-             let doc = new Dom().parseFromString(exp),
-                 p = new Policy(doc, this);
+  testID = "PO022",
+  debug = require("debug")("apigeelint:" + testID),
+  Bundle = require("../../lib/package/Bundle.js"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  Policy = require("../../lib/package/Policy.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Dom = require("@xmldom/xmldom").DOMParser,
+  test = function (exp, caseNum, assertion) {
+    it(`tests ${caseNum}, expect(${assertion})`, function () {
+      let doc = new Dom().parseFromString(exp),
+        p = new Policy("/", "fakename.xml", this, doc);
 
-             p.addMessage = function(msg) {
-               debug(msg);
-             };
-             p.getElement = function() {
-               return doc;
-             };
-             plugin.onPolicy(p, function(e, result) {
-               assert.equal(
-                 e,
-                 undefined,
-                 e ? " error " : " no error"
-               );
-               assert.equal(
-                 result,
-                 assertion,
-                 result ? "  distirbuted is true " : "distirbuted is true not found"
-               );
-             });
-           }
-          );
+      p.addMessage = function (msg) {
+        debug(msg);
       };
+      p.getElement = function () {
+        return doc;
+      };
+      plugin.onPolicy(p, function (e, result) {
+        assert.equal(e, undefined, e ? " error " : " no error");
+        assert.equal(
+          result,
+          assertion,
+          result ? "  distirbuted is true " : "distirbuted is true not found",
+        );
+      });
+    });
+  };
 
-describe(`${testID} - ${plugin.plugin.name}`, function() {
-
+describe(`${testID} - ${plugin.plugin.name}`, function () {
   test(
     `<Quota name="CheckQuota">
   <Interval ref="verifyapikey.verify-api-key.apiproduct.developer.quota.interval">1</Interval>
@@ -60,7 +53,7 @@ describe(`${testID} - ${plugin.plugin.name}`, function() {
   <Allow count="200" countRef="verifyapikey.verify-api-key.apiproduct.developer.quota.limit"/>
 </Quota>`,
     1,
-    true
+    true,
   );
 
   test(
@@ -71,7 +64,7 @@ describe(`${testID} - ${plugin.plugin.name}`, function() {
   <Allow count="200" countRef="verifyapikey.verify-api-key.apiproduct.developer.quota.limit"/>
 </Quota>`,
     2,
-    true
+    true,
   );
 
   test(
@@ -82,7 +75,7 @@ describe(`${testID} - ${plugin.plugin.name}`, function() {
   <Allow count="200" countRef="verifyapikey.verify-api-key.apiproduct.developer.quota.limit"/>
 </Quota>`,
     3,
-    false
+    false,
   );
 
   test(
@@ -95,32 +88,26 @@ describe(`${testID} - ${plugin.plugin.name}`, function() {
   </URIPath>
 </RegularExpressionProtection>`,
     4,
-    false
+    false,
   );
 });
 
-describe(`${testID} - Print plugin results`, function() {
+describe(`${testID} - Print plugin results`, function () {
   debug("test configuration: " + JSON.stringify(configuration));
   var bundle = new Bundle(configuration);
   bl.executePlugin(testID, bundle);
   let report = bundle.getReport();
 
-  it("should create a report object with valid schema", function() {
-
+  it("should create a report object with valid schema", function () {
     let formatter = bl.getFormatter("json.js");
     if (!formatter) {
       assert.fail("formatter implementation not defined");
     }
     let schema = require("./../fixtures/reportSchema.js"),
-        Validator = require("jsonschema").Validator,
-        v = new Validator(),
-        jsonReport = JSON.parse(formatter(report)),
-        validationResult = v.validate(jsonReport, schema);
-    assert.equal(
-      validationResult.errors.length,
-      0,
-      validationResult.errors
-    );
+      Validator = require("jsonschema").Validator,
+      v = new Validator(),
+      jsonReport = JSON.parse(formatter(report)),
+      validationResult = v.validate(jsonReport, schema);
+    assert.equal(validationResult.errors.length, 0, validationResult.errors);
   });
-
 });

--- a/test/specs/PO024-ResponseCacheErrorResponseCheck.js
+++ b/test/specs/PO024-ResponseCacheErrorResponseCheck.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -16,44 +16,40 @@
 /* global it, describe */
 
 const assert = require("assert"),
-      testID = "PO024",
-      debug = require("debug")("apigeelint:" + testID),
-      Bundle = require("../../lib/package/Bundle.js"),
-      bl = require("../../lib/package/bundleLinter.js"),
-      Policy = require("../../lib/package/Policy.js"),
-      plugin = require(bl.resolvePlugin(testID)),
-      Dom = require("@xmldom/xmldom").DOMParser,
-      test = function(caseNum, exp, assertion) {
-        it(`tests case ${caseNum}, expect(${assertion})`,
-           function() {
-             let doc = new Dom().parseFromString(exp),
-                 p = new Policy(doc, this);
+  testID = "PO024",
+  debug = require("debug")("apigeelint:" + testID),
+  Bundle = require("../../lib/package/Bundle.js"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  Policy = require("../../lib/package/Policy.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Dom = require("@xmldom/xmldom").DOMParser,
+  test = function (caseNum, exp, assertion) {
+    it(`tests case ${caseNum}, expect(${assertion})`, function () {
+      let doc = new Dom().parseFromString(exp),
+        p = new Policy("/", "fakename", this, doc);
 
-             p.addMessage = function(msg) {
-               debug(msg);
-             };
-             p.getElement = function() {
-               return doc;
-             };
-             plugin.onPolicy(p, function(err, result) {
-               assert.equal(err, undefined, err ? " err " : " no err");
-               assert.equal(
-                 result,
-                 assertion,
-                 result
-                   ? "warning/error was returned"
-                   : "warning/error was not returned"
-               );
-             });
-           }
-          );
+      p.addMessage = function (msg) {
+        debug(msg);
       };
+      p.getElement = function () {
+        return doc;
+      };
+      plugin.onPolicy(p, function (err, result) {
+        assert.equal(err, undefined, err ? " err " : " no err");
+        assert.equal(
+          result,
+          assertion,
+          result
+            ? "warning/error was returned"
+            : "warning/error was not returned",
+        );
+      });
+    });
+  };
 
 //now generate a full report and check the format of the report
 
-
-describe(`${testID} - ${plugin.plugin.name}`, function() {
-
+describe(`${testID} - ${plugin.plugin.name}`, function () {
   test(
     1,
     `<ResponseCache name="ResponseCache">
@@ -64,7 +60,7 @@ describe(`${testID} - ${plugin.plugin.name}`, function() {
           <TimeoutInSec>600</TimeoutInSec>
       </ExpirySettings>
   </ResponseCache>`,
-    true
+    true,
   );
   test(
     2,
@@ -77,7 +73,7 @@ describe(`${testID} - ${plugin.plugin.name}`, function() {
       </ExpirySettings>
       <ExcludeErrorResponse>false</ExcludeErrorResponse>
   </ResponseCache>`,
-    true
+    true,
   );
   test(
     3,
@@ -90,7 +86,7 @@ describe(`${testID} - ${plugin.plugin.name}`, function() {
       </ExpirySettings>
       <ExcludeErrorResponse/>
   </ResponseCache>`,
-    true
+    true,
   );
   test(
     4,
@@ -103,14 +99,13 @@ describe(`${testID} - ${plugin.plugin.name}`, function() {
       </ExpirySettings>
       <ExcludeErrorResponse>true</ExcludeErrorResponse>
   </ResponseCache>`,
-    false
+    false,
   );
   test(
     5,
     '<RegularExpressionProtection async="false" continueOnError="false" enabled="true" name="regExLookAround"><DisplayName>regExLookAround</DisplayName><Source>request</Source><IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables><URIPath><Pattern>(?/(@?[w_?w:*]+([[^]]+])*)?)+</Pattern></URIPath></RegularExpressionProtection>',
-    false
+    false,
   );
-
 
   debug("test configuration: " + JSON.stringify(configuration));
 
@@ -120,25 +115,21 @@ describe(`${testID} - ${plugin.plugin.name}`, function() {
   //need a case where we are using ref for the key
   //also prefix
 
-  describe(`Print plugin results (${testID})`, function() {
+  describe(`Print plugin results (${testID})`, function () {
     let report = bundle.getReport(),
-        formatter = bl.getFormatter("json.js");
+      formatter = bl.getFormatter("json.js");
 
     if (!formatter) {
       assert.fail("formatter implementation not defined");
     }
 
-    it("should create a report object with valid schema", function() {
+    it("should create a report object with valid schema", function () {
       let schema = require("./../fixtures/reportSchema.js"),
-          Validator = require("jsonschema").Validator,
-          v = new Validator(),
-          jsonReport = JSON.parse(formatter(bundle.getReport())),
-          validationResult = v.validate(jsonReport, schema);
-      assert.equal(
-        validationResult.errors.length,
-        0,
-        validationResult.errors
-      );
+        Validator = require("jsonschema").Validator,
+        v = new Validator(),
+        jsonReport = JSON.parse(formatter(bundle.getReport())),
+        validationResult = v.validate(jsonReport, schema);
+      assert.equal(validationResult.errors.length, 0, validationResult.errors);
     });
   });
 

--- a/test/specs/PO026-assignVariableHygieneInRaiseFault.js
+++ b/test/specs/PO026-assignVariableHygieneInRaiseFault.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -29,14 +29,14 @@ const testID = "PO026",
 const test = (suffix, cb) => {
   let filename = `RF-Example-TextPlain-${suffix}.xml`;
   it(`should correctly process ${filename}`, () => {
-    let fqfname = path.resolve(
+    let baseDir = path.resolve(
         __dirname,
         "../fixtures/resources/PO026-assignVariable-in-RaiseFault",
-        filename
       ),
+      fqfname = path.resolve(baseDir, filename),
       policyXml = fs.readFileSync(fqfname, "utf-8"),
       doc = new Dom().parseFromString(policyXml),
-      p = new Policy(doc.documentElement, this);
+      p = new Policy(baseDir, filename, this, doc);
 
     p.getElement = () => doc.documentElement;
 
@@ -56,7 +56,7 @@ describe(`PO026 - AssignVariable in RaiseFault`, () => {
     assert.equal(
       p.getReport().messages.length,
       0,
-      JSON.stringify(p.getReport().messages)
+      JSON.stringify(p.getReport().messages),
     );
   });
 
@@ -66,12 +66,12 @@ describe(`PO026 - AssignVariable in RaiseFault`, () => {
     assert.equal(
       p.getReport().messages.length,
       1,
-      "unexpected number of messages"
+      "unexpected number of messages",
     );
     assert.ok(p.getReport().messages[0].message, "did not find message member");
     assert.equal(
       p.getReport().messages[0].message,
-      "You should have at least one of: {Ref,Value,Template}"
+      "You should have at least one of: {Ref,Value,Template}",
     );
   });
 });

--- a/test/specs/PO026-profile.js
+++ b/test/specs/PO026-profile.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2022 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -72,14 +72,14 @@ const testID = "PO026",
 
 const po026Test = (filename, profile, cb) => {
   it(`should correctly process ${filename} for profile ${profile}`, () => {
-    const fqfname = path.resolve(
+    const baseDir = path.resolve(
         __dirname,
         "../fixtures/resources/PO026-assignVariable-policies",
-        filename,
       ),
+      fqfname = path.resolve(baseDir, filename),
       policyXml = fs.readFileSync(fqfname, "utf-8"),
       doc = new Dom().parseFromString(policyXml),
-      p = new Policy(doc.documentElement, this);
+      p = new Policy(baseDir, filename, this, doc);
 
     p.getElement = () => doc.documentElement;
 

--- a/test/specs/PO027-hmacHygiene.js
+++ b/test/specs/PO027-hmacHygiene.js
@@ -31,7 +31,7 @@ const loadPolicy = (sourceDir, shortFileName) => {
     let fqPath = path.join(sourceDir, shortFileName),
         policyXml = fs.readFileSync(fqPath).toString('utf-8'),
         doc = new Dom().parseFromString(policyXml),
-        p = new Policy(doc.documentElement, this);
+        p = new Policy(rootDir, shortFileName, this, doc);
         p.getElement = () => doc.documentElement;
         p.fileName = shortFileName;
         return p;

--- a/test/specs/PO028-policy-in-profile.js
+++ b/test/specs/PO028-policy-in-profile.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2022 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,88 +17,92 @@
 /* global describe, it */
 
 const testID = "PO028",
-      assert = require("assert"),
-      fs = require("fs"),
-      path = require("path"),
-      util = require("util"),
-      bl = require("../../lib/package/bundleLinter.js"),
-      plugin = require(bl.resolvePlugin(testID)),
-      Policy = require("../../lib/package/Policy.js"),
-      Dom = require("@xmldom/xmldom").DOMParser,
-      rootDir = path.resolve(__dirname, '../fixtures/resources/PO028'),
-      debug = require("debug")("apigeelint:" + testID);
+  assert = require("assert"),
+  fs = require("fs"),
+  path = require("path"),
+  util = require("util"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Policy = require("../../lib/package/Policy.js"),
+  Dom = require("@xmldom/xmldom").DOMParser,
+  rootDir = path.resolve(__dirname, "../fixtures/resources/PO028"),
+  debug = require("debug")("apigeelint:" + testID);
 
 const loadPolicy = (sourceDir, shortFileName) => {
-    let fqPath = path.join(sourceDir, shortFileName),
-        policyXml = fs.readFileSync(fqPath).toString('utf-8'),
-        doc = new Dom().parseFromString(policyXml),
-        p = new Policy(doc.documentElement, this);
-        p.getElement = () => doc.documentElement;
-        p.fileName = shortFileName;
-        return p;
+  let fqPath = path.join(sourceDir, shortFileName),
+    policyXml = fs.readFileSync(fqPath).toString("utf-8"),
+    doc = new Dom().parseFromString(policyXml),
+    p = new Policy(rootDir, shortFileName, this, doc);
+  p.getElement = () => doc.documentElement;
+  p.fileName = shortFileName;
+  return p;
+};
+
+const messageRe = new RegExp(
+  "^The policy type \\(([A-Za-z]+)\\) is not available in the profile apigeex?.$",
+);
+
+const testOneProfile = function (okExpected, profile) {
+  let testOne = (testCasesDir) => (shortFileName) => {
+    let policy = loadPolicy(testCasesDir, shortFileName);
+    let policyType = policy.getType();
+    let expectedResult = okExpected ? "succeeds" : "throws error";
+    it(`check ${policyType} ${expectedResult}`, () => {
+      assert.notEqual(policyType, undefined, `${policyType} should be defined`);
+      plugin.onBundle({ profile });
+      plugin.onPolicy(policy, (e, foundIssues) => {
+        assert.equal(e, undefined, "should be undefined");
+        if (okExpected) {
+          debug(`foundIssues: ${foundIssues}`);
+          assert.equal(foundIssues, false, "should be issues");
+          let messages = policy.getReport().messages;
+          debug(`messages:` + util.format(messages));
+          assert.ok(messages, "messages should exist");
+          assert.equal(messages.length, 0, "unexpected number of messages");
+        } else {
+          assert.equal(foundIssues, true, "should be issues");
+          let messages = policy.getReport().messages;
+          assert.ok(messages, "messages should exist");
+          assert.equal(messages.length, 1, "unexpected number of messages");
+          debug(`message[0]: ${messages[0].message}`);
+          assert.ok(messages[0].message, "did not find message member");
+          assert.ok(
+            messages[0].message.match(messageRe),
+            "did not find expected message",
+          );
+          assert.equal(messages[0].severity, 2, "severity should be error");
+        }
+      });
+    });
   };
 
-const messageRe = new RegExp('^The policy type \\(([A-Za-z]+)\\) is not available in the profile apigeex?.$');
+  let profileDir = path.join(rootDir, profile);
+  let subdir = okExpected ? "positive" : "negative";
+  let testCasesDir = path.join(profileDir, subdir);
 
-const testOneProfile = function(okExpected, profile) {
+  let testCases = fs
+    .readdirSync(testCasesDir)
+    .filter((n) => n.endsWith(".xml"));
+  assert.ok(testCases.length, "test cases do not exist");
+  testCases.forEach(testOne(testCasesDir));
 
-        let testOne = (testCasesDir) => (shortFileName) => {
-              let policy = loadPolicy(testCasesDir, shortFileName);
-              let policyType = policy.getType();
-              let expectedResult = okExpected?'succeeds': 'throws error';
-              it(`check ${policyType} ${expectedResult}`, () => {
-                assert.notEqual(policyType, undefined, `${policyType} should be defined`);
-                plugin.onBundle({profile});
-                plugin.onPolicy(policy, (e, foundIssues) => {
-                  assert.equal(e, undefined, "should be undefined");
-                  if (okExpected) {
-                    debug(`foundIssues: ${foundIssues}`);
-                    assert.equal(foundIssues, false, "should be issues");
-                    let messages = policy.getReport().messages;
-                    debug(`messages:` + util.format(messages));
-                    assert.ok(messages, "messages should exist");
-                    assert.equal(messages.length, 0, "unexpected number of messages");
-                  }
-                  else {
-                    assert.equal(foundIssues, true, "should be issues");
-                    let messages = policy.getReport().messages;
-                    assert.ok(messages, "messages should exist");
-                    assert.equal(messages.length, 1, "unexpected number of messages");
-                    debug(`message[0]: ${messages[0].message}`);
-                    assert.ok(messages[0].message, 'did not find message member');
-                    assert.ok(messages[0].message.match(messageRe), 'did not find expected message');
-                    assert.equal(messages[0].severity, 2, 'severity should be error');
-                  }
-                });
-              });
-            };
-
-        let profileDir = path.join(rootDir, profile);
-        let subdir = okExpected?'positive':'negative';
-        let testCasesDir = path.join(profileDir, subdir);
-
-        let testCases = fs.readdirSync(testCasesDir).filter( n => n.endsWith(".xml"));
-        assert.ok(testCases.length, "test cases do not exist");
-        testCases.forEach( testOne(testCasesDir) );
-
-        // let negativeDir = path.join(profileDir, 'negative');
-        // let negativeTestCases = fs.readdirSync(negativeDir).filter( n => n.endsWith(".xml"));
-        // assert.ok(negativeTestCases.length, "test cases do not exist");
-        // negativeTestCases.forEach( testOne(false) );
-      };
+  // let negativeDir = path.join(profileDir, 'negative');
+  // let negativeTestCases = fs.readdirSync(negativeDir).filter( n => n.endsWith(".xml"));
+  // assert.ok(negativeTestCases.length, "test cases do not exist");
+  // negativeTestCases.forEach( testOne(false) );
+};
 
 describe(`${testID} - valid policies in --profile 'apigeex'`, () => {
-  testOneProfile(true, 'apigeex');
+  testOneProfile(true, "apigeex");
 });
 
 describe(`${testID} - invalid policies in --profile 'apigeex'`, () => {
-  testOneProfile(false, 'apigeex');
+  testOneProfile(false, "apigeex");
 });
-
 
 describe(`${testID} - valid policies in --profile 'apigee'`, () => {
-  testOneProfile(true, 'apigee');
+  testOneProfile(true, "apigee");
 });
 describe(`${testID} - invalid policies in --profile 'apigee'`, () => {
-  testOneProfile(false, 'apigee');
+  testOneProfile(false, "apigee");
 });

--- a/test/specs/PO029-policyTypes.js
+++ b/test/specs/PO029-policyTypes.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,69 +17,71 @@
 /* global describe, it */
 
 const testID = "PO029",
-      assert = require("assert"),
-      fs = require("fs"),
-      path = require("path"),
-      bl = require("../../lib/package/bundleLinter.js"),
-      plugin = require(bl.resolvePlugin(testID)),
-      Policy = require("../../lib/package/Policy.js"),
-      Dom = require("@xmldom/xmldom").DOMParser,
-      rootDir = path.resolve(__dirname, '../fixtures/resources/PO029-policyTypes');
+  assert = require("assert"),
+  fs = require("fs"),
+  path = require("path"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Policy = require("../../lib/package/Policy.js"),
+  Dom = require("@xmldom/xmldom").DOMParser,
+  rootDir = path.resolve(__dirname, "../fixtures/resources/PO029-policyTypes");
 
 const loadPolicy = (sourceDir, shortFileName) => {
-    let fqPath = path.join(sourceDir, shortFileName),
-        policyXml = fs.readFileSync(fqPath).toString('utf-8'),
-        doc = new Dom().parseFromString(policyXml),
-        p = new Policy(doc.documentElement, this);
-        p.getElement = () => doc.documentElement;
-        p.fileName = shortFileName;
-        return p;
+  let fqPath = path.join(sourceDir, shortFileName),
+    policyXml = fs.readFileSync(fqPath).toString("utf-8"),
+    doc = new Dom().parseFromString(policyXml),
+    p = new Policy(rootDir, shortFileName, this, doc);
+
+  p.getElement = () => doc.documentElement;
+  p.fileName = shortFileName;
+  return p;
+};
+
+describe(`${testID} - policy is of known type`, function () {
+  let sourceDir = path.join(rootDir, "positive");
+  let testOne = (shortFileName) => {
+    let policy = loadPolicy(sourceDir, shortFileName);
+    let policyType = policy.getType();
+    it(`check ${policyType} is known`, () => {
+      assert.notEqual(policyType, undefined, `${policyType} should be defined`);
+      plugin.onPolicy(policy, (e, foundIssues) => {
+        assert.equal(e, undefined, "should be undefined");
+        assert.equal(foundIssues, false, "should be no issues");
+        let messages = policy.getReport().messages;
+        assert.ok(messages, "messages should exist");
+        assert.equal(messages.length, 0, "unexpected number of messages");
+      });
+    });
   };
 
-describe(`${testID} - policy is of known type`, function() {
-  let sourceDir = path.join(rootDir, 'positive');
-  let testOne = (shortFileName) => {
-        let policy = loadPolicy(sourceDir, shortFileName);
-        let policyType = policy.getType();
-        it(`check ${policyType} is known`, () => {
-          assert.notEqual(policyType, undefined, `${policyType} should be defined`);
-          plugin.onPolicy(policy, (e, foundIssues) => {
-            assert.equal(e, undefined, "should be undefined");
-            assert.equal(foundIssues, false, "should be no issues");
-            let messages = policy.getReport().messages;
-            assert.ok(messages, "messages should exist");
-            assert.equal(messages.length, 0, "unexpected number of messages");
-          });
-        });
-      };
-
   fs.readdirSync(sourceDir)
-    .filter( shortFileName => shortFileName.endsWith(".xml"))
-    .forEach( testOne );
-
+    .filter((shortFileName) => shortFileName.endsWith(".xml"))
+    .forEach(testOne);
 });
 
 describe(`${testID} - policy is of unknown type`, () => {
-  let sourceDir = path.join(rootDir, 'negative');
+  let sourceDir = path.join(rootDir, "negative");
   let testOne = (shortFileName) => {
-        let policy = loadPolicy(sourceDir, shortFileName);
-        let policyType = policy.getType();
-        it(`check ${policyType} is unknown`, () => {
-          assert.notEqual(policyType, undefined, `${policyType} should be defined`);
-          plugin.onPolicy(policy, (e, foundIssues) => {
-            assert.equal(e, undefined, "should be undefined");
-            assert.equal(foundIssues, true, "should be issues");
-            let messages = policy.getReport().messages;
-            assert.ok(messages, "messages should exist");
-            assert.equal(messages.length, 1, "unexpected number of messages");
-            assert.ok(messages[0].message, 'did not find message member');
-            assert.equal(messages[0].message, `The policy type (${policyType}) is not recognized`);
-          });
-        });
-      };
+    let policy = loadPolicy(sourceDir, shortFileName);
+    let policyType = policy.getType();
+    it(`check ${policyType} is unknown`, () => {
+      assert.notEqual(policyType, undefined, `${policyType} should be defined`);
+      plugin.onPolicy(policy, (e, foundIssues) => {
+        assert.equal(e, undefined, "should be undefined");
+        assert.equal(foundIssues, true, "should be issues");
+        let messages = policy.getReport().messages;
+        assert.ok(messages, "messages should exist");
+        assert.equal(messages.length, 1, "unexpected number of messages");
+        assert.ok(messages[0].message, "did not find message member");
+        assert.equal(
+          messages[0].message,
+          `The policy type (${policyType}) is not recognized`,
+        );
+      });
+    });
+  };
 
   fs.readdirSync(sourceDir)
-    .filter( shortFileName => shortFileName.endsWith(".xml"))
-    .forEach( testOne );
-
+    .filter((shortFileName) => shortFileName.endsWith(".xml"))
+    .forEach(testOne);
 });

--- a/test/specs/PO030-ExpirySettings.js
+++ b/test/specs/PO030-ExpirySettings.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,95 +17,103 @@
 /* global describe, it */
 
 const testID = "PO030",
-      assert = require("assert"),
-      fs = require("fs"),
-      path = require("path"),
-      util = require('util'),
-      bl = require("../../lib/package/bundleLinter.js"),
-      plugin = require(bl.resolvePlugin(testID)),
-      Policy = require("../../lib/package/Policy.js"),
-      Dom = require("@xmldom/xmldom").DOMParser,
-      rootDir = path.resolve(__dirname, '../fixtures/resources/PO030-ExpirySettings'),
-      debug = require("debug")("apigeelint:" + testID);
+  assert = require("assert"),
+  fs = require("fs"),
+  path = require("path"),
+  util = require("util"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Policy = require("../../lib/package/Policy.js"),
+  Dom = require("@xmldom/xmldom").DOMParser,
+  rootDir = path.resolve(
+    __dirname,
+    "../fixtures/resources/PO030-ExpirySettings",
+  ),
+  debug = require("debug")("apigeelint:" + testID);
 
-const loadPolicy = function(sourceDir, shortFileName) {
-        let fqPath = path.join(sourceDir, shortFileName),
-            policyXml = fs.readFileSync(fqPath).toString('utf-8'),
-            doc = new Dom().parseFromString(policyXml),
-            p = new Policy(doc.documentElement, this);
-        p.fileName = shortFileName;
-        p.getElement = () => doc.documentElement;
-        return p;
-      };
+const loadPolicy = function (sourceDir, shortFileName) {
+  let fqPath = path.join(sourceDir, shortFileName),
+    policyXml = fs.readFileSync(fqPath).toString("utf-8"),
+    doc = new Dom().parseFromString(policyXml),
+    p = new Policy(rootDir, shortFileName, this, doc);
+  p.fileName = shortFileName;
+  p.getElement = () => doc.documentElement;
+  return p;
+};
 
-describe(`${testID} - ExpirySettings looks good`, function() {
-  let sourceDir = path.join(rootDir, 'pass');
+describe(`${testID} - ExpirySettings looks good`, function () {
+  let sourceDir = path.join(rootDir, "pass");
   let testOne = (shortFileName) => {
-        it(`checks no error (${shortFileName})`, () => {
-          let policy = loadPolicy(sourceDir, shortFileName);
-          // I don't know why this it function must return a Promise, in order
-          // for the assertions to actually work.  It seems the similar tests
-          // for PO029 do not require this. Not clear why. But in any case, do
-          // not change this unless you're sure.
-          return new Promise(function(resolve, reject) {
-            plugin.onPolicy(policy, (e, foundIssues) => {
-              try {
-                assert.equal(e, undefined, "should be undefined");
-                assert.equal(foundIssues, false, "should be no issues");
-                let messages = policy.getReport().messages;
-                assert.ok(messages, "messages should exist");
-                assert.equal(messages.length, 0, "unexpected number of messages");
-              }
-              catch(ex) {
-                return reject(ex);
-              }
-              return resolve();
-            });
-          });
+    it(`checks no error (${shortFileName})`, () => {
+      let policy = loadPolicy(sourceDir, shortFileName);
+      // I don't know why this it function must return a Promise, in order
+      // for the assertions to actually work.  It seems the similar tests
+      // for PO029 do not require this. Not clear why. But in any case, do
+      // not change this unless you're sure.
+      return new Promise(function (resolve, reject) {
+        plugin.onPolicy(policy, (e, foundIssues) => {
+          try {
+            assert.equal(e, undefined, "should be undefined");
+            assert.equal(foundIssues, false, "should be no issues");
+            let messages = policy.getReport().messages;
+            assert.ok(messages, "messages should exist");
+            assert.equal(messages.length, 0, "unexpected number of messages");
+          } catch (ex) {
+            return reject(ex);
+          }
+          return resolve();
         });
-      };
+      });
+    });
+  };
 
   fs.readdirSync(sourceDir)
-    .filter( shortFileName => shortFileName.endsWith(".xml"))
-    .forEach( testOne );
+    .filter((shortFileName) => shortFileName.endsWith(".xml"))
+    .forEach(testOne);
 });
 
 describe(`${testID} - ExpirySettings looks wrong`, () => {
-  let sourceDir = path.join(rootDir, 'fail');
-  const expectedErrorMessages = require(path.join(sourceDir, 'messages.js'));
+  let sourceDir = path.join(rootDir, "fail");
+  const expectedErrorMessages = require(path.join(sourceDir, "messages.js"));
 
   let testOne = (shortFileName) => {
-        let policy = loadPolicy(sourceDir, shortFileName);
-        it(`checks expected error (${shortFileName})`, () => {
-          assert.ok(policy, "policy should exist");
-          // I don't know why this it function must return a Promise, in order
-          // for the assertions to actually work.  It seems the similar tests
-          // for PO029 do not require this. Not clear why. But in any case, do
-          // not change this unless you're sure.
-          return new Promise(function(resolve, reject) {
-            plugin.onPolicy(policy, (e, foundIssues) => {
-              try {
-                assert.equal(e, undefined, "should be undefined");
-                assert.equal(foundIssues, true, "should be issues");
-                let messages = policy.getReport().messages;
-                assert.ok(messages, "messages should exist");
-                assert.equal(messages.length, 1, "unexpected number of messages");
-                assert.ok(messages[0].message, 'did not find message member');
-                let expected = expectedErrorMessages[policy.fileName];
-                assert.ok(expected, 'test configuration failure: did not find an expected message');
-                assert.equal(messages[0].message, expected, 'did not find expected message');
-                debug(`message[0]: ${messages[0].message}`);
-              }
-              catch(ex) {
-                return reject(ex);
-              }
-              return resolve();
-            });
-          });
+    let policy = loadPolicy(sourceDir, shortFileName);
+    it(`checks expected error (${shortFileName})`, () => {
+      assert.ok(policy, "policy should exist");
+      // I don't know why this it function must return a Promise, in order
+      // for the assertions to actually work.  It seems the similar tests
+      // for PO029 do not require this. Not clear why. But in any case, do
+      // not change this unless you're sure.
+      return new Promise(function (resolve, reject) {
+        plugin.onPolicy(policy, (e, foundIssues) => {
+          try {
+            assert.equal(e, undefined, "should be undefined");
+            assert.equal(foundIssues, true, "should be issues");
+            let messages = policy.getReport().messages;
+            assert.ok(messages, "messages should exist");
+            assert.equal(messages.length, 1, "unexpected number of messages");
+            assert.ok(messages[0].message, "did not find message member");
+            let expected = expectedErrorMessages[policy.fileName];
+            assert.ok(
+              expected,
+              "test configuration failure: did not find an expected message",
+            );
+            assert.equal(
+              messages[0].message,
+              expected,
+              "did not find expected message",
+            );
+            debug(`message[0]: ${messages[0].message}`);
+          } catch (ex) {
+            return reject(ex);
+          }
+          return resolve();
         });
-      };
+      });
+    });
+  };
 
   fs.readdirSync(sourceDir)
-    .filter( shortFileName => shortFileName.endsWith(".xml"))
-    .forEach( testOne );
+    .filter((shortFileName) => shortFileName.endsWith(".xml"))
+    .forEach(testOne);
 });

--- a/test/specs/PO031-AssignMessage-Payload-ContentType.js
+++ b/test/specs/PO031-AssignMessage-Payload-ContentType.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,95 +17,104 @@
 /* global describe, it */
 
 const testID = "PO031",
-      assert = require("assert"),
-      fs = require("fs"),
-      path = require("path"),
-      //util = require('util'),
-      bl = require("../../lib/package/bundleLinter.js"),
-      plugin = require(bl.resolvePlugin(testID)),
-      Policy = require("../../lib/package/Policy.js"),
-      Dom = require("@xmldom/xmldom").DOMParser,
-      rootDir = path.resolve(__dirname, '../fixtures/resources/PO031-AssignMessage-Payload-ContentType'),
-      debug = require("debug")("apigeelint:" + testID);
+  assert = require("assert"),
+  fs = require("fs"),
+  path = require("path"),
+  //util = require('util'),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Policy = require("../../lib/package/Policy.js"),
+  Dom = require("@xmldom/xmldom").DOMParser,
+  rootDir = path.resolve(
+    __dirname,
+    "../fixtures/resources/PO031-AssignMessage-Payload-ContentType",
+  ),
+  debug = require("debug")("apigeelint:" + testID);
 
-const loadPolicy = function(sourceDir, shortFileName) {
-        let fqPath = path.join(sourceDir, shortFileName),
-            policyXml = fs.readFileSync(fqPath).toString('utf-8'),
-            doc = new Dom().parseFromString(policyXml),
-            p = new Policy(doc.documentElement, this);
-        p.fileName = shortFileName;
-        p.getElement = () => doc.documentElement;
-        return p;
-      };
+const loadPolicy = function (sourceDir, shortFileName) {
+  let fqPath = path.join(sourceDir, shortFileName),
+    policyXml = fs.readFileSync(fqPath).toString("utf-8"),
+    doc = new Dom().parseFromString(policyXml),
+    p = new Policy(rootDir, shortFileName, this, doc);
 
-describe(`${testID} - Payload Content-Type looks good`, function() {
-  let sourceDir = path.join(rootDir, 'pass');
+  p.fileName = shortFileName;
+  p.getElement = () => doc.documentElement;
+  return p;
+};
+
+describe(`${testID} - Payload Content-Type looks good`, function () {
+  let sourceDir = path.join(rootDir, "pass");
   let testOne = (shortFileName) => {
-        it(`checks no error (${shortFileName})`, () => {
-          let policy = loadPolicy(sourceDir, shortFileName);
-          // I don't know why this it function must return a Promise, in order
-          // for the assertions to actually work.  It seems the similar tests
-          // for PO029 do not require this. Not clear why. But in any case, do
-          // not change this unless you're sure.
-          return new Promise(function(resolve, reject) {
-            plugin.onPolicy(policy, (e, foundIssues) => {
-              try {
-                assert.equal(e, undefined, "should be undefined");
-                assert.equal(foundIssues, false, "should be no issues");
-                let messages = policy.getReport().messages;
-                assert.ok(messages, "messages should exist");
-                assert.equal(messages.length, 0, "unexpected number of messages");
-              }
-              catch(ex) {
-                return reject(ex);
-              }
-              return resolve();
-            });
-          });
+    it(`checks no error (${shortFileName})`, () => {
+      let policy = loadPolicy(sourceDir, shortFileName);
+      // I don't know why this it function must return a Promise, in order
+      // for the assertions to actually work.  It seems the similar tests
+      // for PO029 do not require this. Not clear why. But in any case, do
+      // not change this unless you're sure.
+      return new Promise(function (resolve, reject) {
+        plugin.onPolicy(policy, (e, foundIssues) => {
+          try {
+            assert.equal(e, undefined, "should be undefined");
+            assert.equal(foundIssues, false, "should be no issues");
+            let messages = policy.getReport().messages;
+            assert.ok(messages, "messages should exist");
+            assert.equal(messages.length, 0, "unexpected number of messages");
+          } catch (ex) {
+            return reject(ex);
+          }
+          return resolve();
         });
-      };
+      });
+    });
+  };
 
   fs.readdirSync(sourceDir)
-    .filter( shortFileName => shortFileName.endsWith(".xml"))
-    .forEach( testOne );
+    .filter((shortFileName) => shortFileName.endsWith(".xml"))
+    .forEach(testOne);
 });
 
 describe(`${testID} - Payload content-type looks wrong`, () => {
-  let sourceDir = path.join(rootDir, 'fail');
-  const expectedErrorMessages = require(path.join(sourceDir, 'messages.js'));
+  let sourceDir = path.join(rootDir, "fail");
+  const expectedErrorMessages = require(path.join(sourceDir, "messages.js"));
 
   let testOne = (shortFileName) => {
-        let policy = loadPolicy(sourceDir, shortFileName);
-        it(`checks expected error (${shortFileName})`, () => {
-          assert.ok(policy, "policy should exist");
-          // I don't know why this it function must return a Promise, in order
-          // for the assertions to actually work.  It seems the similar tests
-          // for PO029 do not require this. Not clear why. But in any case, do
-          // not change this unless you're sure.
-          return new Promise(function(resolve, reject) {
-            plugin.onPolicy(policy, (e, foundIssues) => {
-              try {
-                assert.equal(e, undefined, "should be undefined");
-                assert.equal(foundIssues, true, "should be issues");
-                let messages = policy.getReport().messages;
-                assert.ok(messages, "messages should exist");
-                assert.equal(messages.length, 1, "unexpected number of messages");
-                assert.ok(messages[0].message, 'did not find message member');
-                let expected = expectedErrorMessages[policy.fileName];
-                assert.ok(expected, 'test configuration failure: did not find an expected message');
-                assert.equal(messages[0].message, expected, 'did not find expected message');
-                debug(`message[0]: ${messages[0].message}`);
-              }
-              catch(ex) {
-                return reject(ex);
-              }
-              return resolve();
-            });
-          });
+    let policy = loadPolicy(sourceDir, shortFileName);
+    it(`checks expected error (${shortFileName})`, () => {
+      assert.ok(policy, "policy should exist");
+      // I don't know why this it function must return a Promise, in order
+      // for the assertions to actually work.  It seems the similar tests
+      // for PO029 do not require this. Not clear why. But in any case, do
+      // not change this unless you're sure.
+      return new Promise(function (resolve, reject) {
+        plugin.onPolicy(policy, (e, foundIssues) => {
+          try {
+            assert.equal(e, undefined, "should be undefined");
+            assert.equal(foundIssues, true, "should be issues");
+            let messages = policy.getReport().messages;
+            assert.ok(messages, "messages should exist");
+            assert.equal(messages.length, 1, "unexpected number of messages");
+            assert.ok(messages[0].message, "did not find message member");
+            let expected = expectedErrorMessages[policy.fileName];
+            assert.ok(
+              expected,
+              "test configuration failure: did not find an expected message",
+            );
+            assert.equal(
+              messages[0].message,
+              expected,
+              "did not find expected message",
+            );
+            debug(`message[0]: ${messages[0].message}`);
+          } catch (ex) {
+            return reject(ex);
+          }
+          return resolve();
         });
-      };
+      });
+    });
+  };
 
   fs.readdirSync(sourceDir)
-    .filter( shortFileName => shortFileName.endsWith(".xml"))
-    .forEach( testOne );
+    .filter((shortFileName) => shortFileName.endsWith(".xml"))
+    .forEach(testOne);
 });

--- a/test/specs/PO033-extractVariables-JSON-Variable-type.js
+++ b/test/specs/PO033-extractVariables-JSON-Variable-type.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2023 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -32,7 +32,8 @@ const loadPolicy = (sourceDir, shortFileName) => {
   const fqPath = path.join(sourceDir, shortFileName),
     policyXml = fs.readFileSync(fqPath).toString("utf-8"),
     doc = new Dom().parseFromString(policyXml),
-    p = new Policy(doc.documentElement, this);
+    p = new Policy(rootDir, shortFileName, this, doc);
+
   p.getElement = () => doc.documentElement;
   p.fileName = shortFileName;
   return p;
@@ -81,12 +82,12 @@ describe(`${testID} - policy does not pass ExtractVariables hygiene check`, () =
         const expected = expectedErrorMessages[policy.fileName];
         assert.ok(
           expected,
-          "test configuration failure: did not find an expected message"
+          "test configuration failure: did not find an expected message",
         );
         assert.equal(
           expected,
           messages[0].message,
-          "did not find expected message"
+          "did not find expected message",
         );
         debug(`message[0]: ${messages[0].message}`);
       });

--- a/test/specs/PO036-service-callout-response-element-syntax.js
+++ b/test/specs/PO036-service-callout-response-element-syntax.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2021 Google LLC
+  Copyright 2019-2024 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,14 +30,11 @@ const testID = "PO036",
 const test = (suffix, cb) => {
   const filename = `SC-Response-element-${suffix}.xml`;
   it(`should correctly process ${filename}`, () => {
-    const fqfname = path.resolve(
-        __dirname,
-        "../fixtures/resources/PO036",
-        filename
-      ),
+    const baseDir = path.resolve(__dirname, "../fixtures/resources/PO036"),
+      fqfname = path.resolve(baseDir, filename),
       policyXml = fs.readFileSync(fqfname, "utf-8"),
       doc = new Dom().parseFromString(policyXml),
-      p = new Policy(doc.documentElement, this);
+      p = new Policy(baseDir, filename, this, doc);
 
     p.getElement = () => doc.documentElement;
 
@@ -69,12 +66,12 @@ describe(`PO036 - ServiceCallout Response element`, () => {
     assert.ok(messages[0].message, "did not find message 0");
     assert.equal(
       messages[0].message,
-      "The Response element, when present, should specify a non-empty TEXT value."
+      "The Response element, when present, should specify a non-empty TEXT value.",
     );
     assert.ok(messages[1].message, "did not find message 1");
     assert.equal(
       messages[1].message,
-      "The Response element, when present, should not specify any attributes."
+      "The Response element, when present, should not specify any attributes.",
     );
   });
 
@@ -87,7 +84,7 @@ describe(`PO036 - ServiceCallout Response element`, () => {
     assert.ok(messages[0].message, "did not find message 0");
     assert.equal(
       messages[0].message,
-      "The Response element, when present, should specify a non-empty TEXT value."
+      "The Response element, when present, should specify a non-empty TEXT value.",
     );
   });
 
@@ -100,7 +97,7 @@ describe(`PO036 - ServiceCallout Response element`, () => {
     assert.ok(messages[0].message, "did not find message 0");
     assert.equal(
       messages[0].message,
-      "When the Response element is present, the TEXT value should have no spaces."
+      "When the Response element is present, the TEXT value should have no spaces.",
     );
   });
 
@@ -113,7 +110,7 @@ describe(`PO036 - ServiceCallout Response element`, () => {
     assert.ok(messages[0].message, "did not find message 0");
     assert.equal(
       messages[0].message,
-      "Policy has more than one Response element."
+      "Policy has more than one Response element.",
     );
   });
 
@@ -126,7 +123,7 @@ describe(`PO036 - ServiceCallout Response element`, () => {
     assert.ok(messages[0].message, "did not find message 0");
     assert.equal(
       messages[0].message,
-      "The Response element, when present, should specify a non-empty TEXT value."
+      "The Response element, when present, should specify a non-empty TEXT value.",
     );
   });
 
@@ -139,7 +136,7 @@ describe(`PO036 - ServiceCallout Response element`, () => {
     assert.ok(messages[0].message, "did not find message 0");
     assert.equal(
       messages[0].message,
-      "The Response element, when present, should not specify any attributes."
+      "The Response element, when present, should not specify any attributes.",
     );
   });
 });

--- a/test/specs/PO038-test.js
+++ b/test/specs/PO038-test.js
@@ -32,7 +32,7 @@ const loadPolicy = (sourceDir, shortFileName) => {
   const fqPath = path.join(sourceDir, shortFileName),
     policyXml = fs.readFileSync(fqPath).toString("utf-8"),
     doc = new Dom().parseFromString(policyXml),
-    p = new Policy(doc.documentElement, this);
+    p = new Policy(rootDir, shortFileName, this, doc);
   p.getElement = () => doc.documentElement;
   p.fileName = shortFileName;
   return p;
@@ -109,7 +109,6 @@ describe(`${testID} - policy does not pass KVM hygiene check`, () => {
           "did not find expected message",
         );
       });
-
     });
   };
 

--- a/test/specs/TD008-test.js
+++ b/test/specs/TD008-test.js
@@ -32,7 +32,7 @@ const loadEndpoint = (sourceDir, shortFileName) => {
   const fqPath = path.join(sourceDir, shortFileName),
     xml = fs.readFileSync(fqPath).toString("utf-8"),
     doc = new Dom().parseFromString(xml),
-    endpoint = new Endpoint(doc.documentElement, null, "");
+    endpoint = new Endpoint(doc.documentElement, this, "");
   endpoint.getFileName = () => shortFileName;
   return endpoint;
 };

--- a/test/specs/TD009-test.js
+++ b/test/specs/TD009-test.js
@@ -32,7 +32,7 @@ const loadEndpoint = (sourceDir, shortFileName) => {
   const fqPath = path.join(sourceDir, shortFileName),
     xml = fs.readFileSync(fqPath).toString("utf-8"),
     doc = new Dom().parseFromString(xml),
-    endpoint = new Endpoint(doc.documentElement, null, "");
+    endpoint = new Endpoint(doc.documentElement, this, "");
   endpoint.getFileName = () => shortFileName;
   return endpoint;
 };

--- a/test/specs/TD010-test.js
+++ b/test/specs/TD010-test.js
@@ -32,7 +32,7 @@ const loadEndpoint = (sourceDir, shortFileName) => {
   const fqPath = path.join(sourceDir, shortFileName),
     xml = fs.readFileSync(fqPath).toString("utf-8"),
     doc = new Dom().parseFromString(xml),
-    endpoint = new Endpoint(doc.documentElement, null, "");
+    endpoint = new Endpoint(doc.documentElement, this, "");
   endpoint.getFileName = () => shortFileName;
   return endpoint;
 };

--- a/test/specs/TD011-test.js
+++ b/test/specs/TD011-test.js
@@ -32,7 +32,7 @@ const loadEndpoint = (sourceDir, shortFileName) => {
   const fqPath = path.join(sourceDir, shortFileName),
     xml = fs.readFileSync(fqPath).toString("utf-8"),
     doc = new Dom().parseFromString(xml),
-    endpoint = new Endpoint(doc.documentElement, null, "");
+    endpoint = new Endpoint(doc.documentElement, this, "");
   endpoint.getFileName = () => shortFileName;
   return endpoint;
 };

--- a/test/specs/TD012-test.js
+++ b/test/specs/TD012-test.js
@@ -32,7 +32,7 @@ const loadEndpoint = (sourceDir, shortFileName) => {
   const fqPath = path.join(sourceDir, shortFileName),
     xml = fs.readFileSync(fqPath).toString("utf-8"),
     doc = new Dom().parseFromString(xml),
-    endpoint = new Endpoint(doc.documentElement, null, "");
+    endpoint = new Endpoint(doc.documentElement, this, "");
   endpoint.getFileName = () => shortFileName;
   return endpoint;
 };

--- a/test/specs/testBundle.js
+++ b/test/specs/testBundle.js
@@ -1,42 +1,66 @@
+/*
+  Copyright 2019-2024 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
 const assert = require("assert"),
-      path = require("path"),
-      Bundle = require("../../lib/package/Bundle.js");
+  path = require("path"),
+  Bundle = require("../../lib/package/Bundle.js");
 
-describe("addMessage", function() {
-    it("Should add a message for 'undefined' proxies", function() {
-        const proxyPath = path.resolve(__dirname, '../fixtures/resources/newBundle/apiproxy');
-        const configuration = {
-            debug: true,
-            source: {
-                type: "filesystem",
-                path: proxyPath,
-                bundleType: "apiproxy"
-            },
-            profile: 'apigee',
-            excluded: {},
-            setExitCode: false,
-            output: () => {} // suppress output
-        };
-    
-        const message = "This is a test";
-        const plugin = {
-            ruleId: "TR001",
-            severity: 1, //warning
-            nodeType: "Bundle"
-        };
+describe("addMessage", function () {
+  it("Should add a message for 'undefined' proxies", function () {
+    const proxyPath = path.resolve(
+      __dirname,
+      "../fixtures/resources/newBundle/apiproxy",
+    );
+    const configuration = {
+      debug: true,
+      source: {
+        type: "filesystem",
+        path: proxyPath,
+        sourcePath: proxyPath,
+        bundleType: "apiproxy",
+      },
+      profile: "apigee",
+      excluded: {},
+      setExitCode: false,
+      output: () => {}, // suppress output
+    };
 
-        let bundle = new Bundle(configuration);
-        bundle.addMessage({
-            plugin,
-            message: message           
-        });
+    const message = "This is a test";
+    const plugin = {
+      ruleId: "TR001",
+      severity: 1, // 1=warning
+      nodeType: "Bundle",
+    };
 
-        bundle.getReport(report => {
-            let bundleResult = report.find(element => element.filePath === proxyPath);
-            assert.notEqual(bundleResult, null);
-            assert.equal(bundleResult.warningCount, 1);
-            let m = bundleResult.messages.find(element => element.message === message);
-            assert.equal(m.ruleId, plugin.ruleId);
-        });
+    let bundle = new Bundle(configuration);
+    bundle.addMessage({ plugin, message });
+
+    bundle.getReport((report) => {
+      console.log(JSON.stringify(report, null, 2));
+
+      let bundleResult = report.find(
+        (element) => element.filePath === proxyPath,
+      );
+
+      assert.notEqual(bundleResult, null);
+      assert.equal(bundleResult.warningCount, 1);
+      let m = bundleResult.messages.find(
+        (element) => element.message === message,
+      );
+      assert.equal(m.ruleId, plugin.ruleId);
     });
+  });
 });


### PR DESCRIPTION
This modifies the cli to now be able to handle zipped bundles (either proxy or sharedflow) .

Use the same `-s` switch to pass the source.  In the case of a zip, the tool will unzip the bundle to a tmp directory, and then perform the analysis.  The tool automatically removes the temp directory after completing the analysis. 

One wrinkle: 
- If there are errors or warnings, the tool will report these errors with filenames expressed relative to the zip file, using filenames that are not "real", eg

```

/usr/local/home/me/apiproxy-20241206-191914.zip/apiproxy/proxies/endpoint1.xml

║ Line     │ Column   │ Type     │ Message                                                │ Rule ID              ║
╟──────────┼──────────┼──────────┼────────────────────────────────────────────────────────┼──────────────────────╢
║ 91       │ 3        │ error    │ Multiple RouteRules with no Condition. Only the        │ PD002                ║
║          │          │          │ first is evaluated.                                    │                      ║

/usr/local/home/me/apiproxy-20241206-191914.zip/apiproxy/policies/SC-Unused.xml

║ Line     │ Column   │ Type     │ Message                                                │ Rule ID              ║
╟──────────┼──────────┼──────────┼────────────────────────────────────────────────────────┼──────────────────────╢
║ 0        │ 0        │ warning  │ SC-Unused is not attached to a Step in the bundle.     │ BN005                ║
║          │          │          │ Remove unused policies.                                │                      ║
```

There are a bunch of changes in this PR to tests, because of the handling of these relative filenames.

WDYT?
