### PR TITLE
fix: correct errant tests for PO039

### DIFF
--- a/test/specs/PO039-test.js
+++ b/test/specs/PO039-test.js
@@ -31,7 +31,7 @@ const test = (suffix, cb) => {
     const fqfname = path.join(rootDir, filename),
       policyXml = fs.readFileSync(fqfname, "utf-8"),
       doc = new Dom().parseFromString(policyXml),
-      p = new Policy(doc.documentElement, this);
+      p = new Policy(rootDir, filename, this, doc);
 
     p.getElement = () => doc.documentElement;
 


### PR DESCRIPTION
This is a one-line fix for tests for PO039.