### PR TITLE
Simplify download logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,15 @@ path, this will fail.
    apigeelint -f table.js -d org:ORG-NAME,api:NAME-OF-APIPROXY,rev:4
    ```
 
-3. To tell apigeelint to download the latest revision that is deployed in a particular
-   environment, specify the `env:` segment:
+3. To combine the prior two examples, specify a token and a revision:
+   ```sh
+   apigeelint -f table.js -d org:ORG-NAME,api:NAME-OF-APIPROXY,rev:4,token:ACCESS_TOKEN_HERE
+   ```
+
+4. To tell apigeelint to get a token via gcloud, then download the latest
+   revision that is deployed in a particular environment, specify the `env:`
+   segment:
+
    ```sh
    apigeelint -f table.js -d org:ORG-NAME,api:NAME-OF-APIPROXY,env:stg
    ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ continues to get enhancements.  There are a variety of plugins that test
 Bundles, Policies, ProxyEndpoints, and more.
 
 The tool can report results out to the console, or to a file.  The tool can
-ingest from an exploded directory, or from a zipped bundle.
+ingest from a directory containing the proxy bundle, or from a zipped bundle.
 
 ## Installation
 
@@ -49,7 +49,7 @@ Usage: apigeelint [options]
 
 Options:
   -V, --version                           output the version number
-  -s, --path <path>                       Path of the proxy to analyze
+  -s, --path <path>                       Path of the proxy or sharedflow to analyze (directory or zipped bundle)
   -d, --download [value]                  Download the API proxy or sharedflow to analyze. Exclusive of -s / --path. Example: org:ORG,api:PROXYNAME or org:ORG,sf:SHAREDFLOWNAME
   -f, --formatter [value]                 Specify formatters (default: json.js)
   -w, --write [value]                     file path to write results

--- a/cli.js
+++ b/cli.js
@@ -87,7 +87,7 @@ const findBundle = (p) => {
     .version(pkj.version)
     .option(
       "-s, --path <path>",
-      "Path of the exploded apiproxy or sharedflowbundle directory",
+      "Path of the proxy or sharedflow to analyze (directory or zipped bundle)",
     )
     .option(
       "-d, --download [value]",

--- a/lib/package/downloader.js
+++ b/lib/package/downloader.js
@@ -23,22 +23,22 @@ const fs = require("fs"),
   debug = require("debug")("apigeelint:download");
 
 const downloadBundle = async (downloadSpec) => {
-  // 0. validate the input. it should be one of the following formats:
+  // 0. validate the input. it should combine 2 or more of the following formats:
   let validSegmentExamples = [
     "org:ORGNAME",
     "api:APINAME",
     "sf:SHAREDFLOWNAME",
     "rev:REVISION",
     "env:ENVIRONMENT",
-    "org:ORGNAME,sf:SHAREDFLOWNAME,rev:REVISION",
-    "org:ORGNAME,sf:SHAREDFLOWNAME,env:ENVIRONMENT",
+    "token:TOKEN",
   ];
 
   const segments = downloadSpec.split(",");
 
-  const invalidArgument = (casenum_for_diagnostics) => {
+  const invalidArgument = (message) => {
     console.log(
       `Invalid download argument (${downloadSpec}).\n` +
+        `${message}\n` +
         "The value should be a set of 2 or more comma-separated segments of this form:\n  " +
         validSegmentExamples.join("\n  ") +
         "\n\n" +
@@ -56,52 +56,50 @@ const downloadBundle = async (downloadSpec) => {
   const processSegment = (acc, segment) => {
     const parts = segment.split(":");
     if (!parts || parts.length != 2) {
-      invalidArgument(2);
+      invalidArgument(`Incorrect structure: ${segment}`);
     }
-    switch (parts[0]) {
+    const [key, value] = parts;
+
+    if (!value) {
+      invalidArgument(`Missing value for key: ${key} in segment: ${segment}`);
+    }
+    switch (key) {
+      case "token":
       case "org":
-        if (acc.org || !parts[1]) {
-          invalidArgument(4);
+        if (acc[key]) {
+          invalidArgument(`You may specify ${key} at most once`);
         }
-        acc.org = parts[1];
+        acc[key] = value;
         break;
       case "api":
       case "sf":
-        if (acc.assetName || !parts[1]) {
-          invalidArgument(5);
+        if (acc.api || acc.sf) {
+          invalidArgument(`You must specify at most one of {api,sf}`);
         }
-        acc.assetName = parts[1];
-        acc.assetFlavor = parts[0];
+        acc[key] = value;
         break;
       case "rev":
-        if (acc.revision || acc.environment || !parts[1]) {
-          invalidArgument(6);
-        }
-        acc.revision = parts[1];
-        break;
       case "env":
-        if (acc.revision || acc.environment || !parts[1]) {
-          invalidArgument(7);
+        if (acc.rev || acc.env || !parts[1]) {
+          invalidArgument(`You may specify at most one of {rev,env}`);
         }
-        acc.environment = parts[1];
-        break;
-      case "token":
-        if (acc.token || !parts[1]) {
-          invalidArgument(8);
-        }
-        acc.token = parts[1];
+        acc[key] = value;
         break;
       default:
-        invalidArgument(3);
-        break;
+        invalidArgument(`unrecognized parameter: ${key}`);
     }
     return acc;
   };
 
   const digest = segments.reduce(processSegment, {});
   // make sure we got enough information
-  if (!digest.assetName || !digest.assetFlavor || !digest.org) {
-    invalidArgument(9);
+  if ((!digest.api && !digest.sf) || !digest.org) {
+    invalidArgument("incomplete parameters for download");
+  }
+
+  if (digest.rev && digest.env) {
+    // both revision or environment specified; should never happen.
+    invalidArgument("overspecified parameters for download (bothrev and env)");
   }
 
   try {
@@ -115,18 +113,19 @@ const downloadBundle = async (downloadSpec) => {
       child_process.execSync("gcloud auth print-access-token", execOptions);
 
     // 2. set up some basic stuff.
-    const collectionName = digest.assetFlavor == "api" ? "apis" : "sharedflows";
-    const urlbase = `https://apigee.googleapis.com/v1/organizations/${digest.org}`;
-    const headers = {
-      Accept: "application/json",
-      Authorization: `Bearer ${accessToken}`,
-    };
+    const collectionName = digest.api ? "api" : "sharedflow",
+      rev = digest.rev,
+      env = digest.env,
+      assetName = digest.sf || digest.api,
+      urlbase = `https://apigee.googleapis.com/v1/organizations/${digest.org}`,
+      headers = {
+        Accept: "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      };
 
     const determineRevision = async () => {
-      const rev = digest.revision,
-        env = digest.environment;
       const getLatestRevision = async () => {
-        const url = `${urlbase}/${collectionName}/${digest.assetName}/revisions`;
+        const url = `${urlbase}/${collectionName}s/${assetName}/revisions`;
         const revisionsResponse = await fetch(url, { method: "GET", headers });
         if (!revisionsResponse.ok) {
           throw new Error(
@@ -153,7 +152,7 @@ const downloadBundle = async (downloadSpec) => {
           );
         }
 
-        url = `${urlbase}/environments/${environment}/${collectionName}/${digest.assetName}/deployments`;
+        url = `${urlbase}/environments/${environment}/${collectionName}s/${assetName}/deployments`;
         const deploymentsResponse = await fetch(url, {
           method: "GET",
           headers,
@@ -177,17 +176,12 @@ const downloadBundle = async (downloadSpec) => {
         // }
         if (!r.deployments || !r.deployments.length) {
           throw new Error(
-            `That ${digest.assetFlavor} is not deployed in ${digest.environment}`,
+            `That ${collectionName} is not deployed in ${environment}`,
           );
         }
         r.deployments.sort((a, b) => Number(a.revision) - Number(b.revision));
         return r.deployments[r.deployments.length - 1].revision;
       };
-
-      if (rev && env) {
-        // both revision or environment specified
-        throw new Error("overspecified arguments"); // should never happen
-      }
 
       if ((!rev && !env) || (rev && rev.toLowerCase() == "latest")) {
         // no revision or environment specified,
@@ -215,23 +209,23 @@ const downloadBundle = async (downloadSpec) => {
       throw new Error(`Invalid revision number`);
     }
     // 4. verify that the revision exists
-    let url = `${urlbase}/${collectionName}/${digest.assetName}/revisions/${revision}`;
+    let url = `${urlbase}/${collectionName}s/${assetName}/revisions/${revision}`;
     const revisionResponse = await fetch(url, { method: "GET", headers });
     if (revisionResponse.status == 404) {
       throw new Error(
-        `Revision ${revision} of ${digest.assetFlavor} ${digest.assetName} does not appear to exist`,
+        `Revision ${revision} of ${collectionName} ${assetName} does not appear to exist`,
       );
     }
     if (!revisionResponse.ok) {
       throw new Error(
-        `cannot inquire revision ${revision} of ${digest.assetFlavor} ${digest.assetName}, on GET ${url}`,
+        `cannot inquire revision ${revision} of ${collectionName} ${assetName}, on GET ${url}`,
       );
     }
 
     // 5. export the revision.
-    url = `${urlbase}/${collectionName}/${digest.assetName}/revisions/${revision}?format=bundle`;
+    url = `${urlbase}/${collectionName}s/${assetName}/revisions/${revision}?format=bundle`;
     const tmpdir = tmp.dirSync({
-      prefix: `apigeelint-download-${digest.assetFlavor}`,
+      prefix: `apigeelint-download-${collectionName}`,
       keep: false,
       unsafeCleanup: true, // this does not seem to work in apigeelint
     });
@@ -242,7 +236,7 @@ const downloadBundle = async (downloadSpec) => {
 
     const pathToDownloadedAsset = path.join(
       tmpdir.name,
-      `${digest.assetName}-r${revision}.zip`,
+      `${assetName}-r${revision}.zip`,
     );
 
     const stream = fs.createWriteStream(pathToDownloadedAsset);

--- a/lib/package/downloader.js
+++ b/lib/package/downloader.js
@@ -37,13 +37,13 @@ const downloadBundle = async (downloadSpec) => {
 
   const invalidArgument = (message) => {
     console.log(
-      `Invalid download argument (${downloadSpec}).\n` +
+      `Error: Invalid download argument (${downloadSpec}).\n` +
         `${message}\n` +
         "The value should be a set of 2 or more comma-separated segments of this form:\n  " +
         validSegmentExamples.join("\n  ") +
         "\n\n" +
         "Specify segments in any order. You must always specify the org.\n" +
-        "Specify at least one of {api,sf}. Specify at most one of {rev,env}.\n" +
+        "Specify exactly one of {api,sf}. Specify at most one of {rev,env}.\n" +
         "The token segment is optional. Multiple segments of the same type are not allowed.",
     );
     process.exit(1);
@@ -74,7 +74,7 @@ const downloadBundle = async (downloadSpec) => {
       case "api":
       case "sf":
         if (acc.api || acc.sf) {
-          invalidArgument(`You must specify at most one of {api,sf}`);
+          invalidArgument(`You must specify exactly one of {api,sf}`);
         }
         acc[key] = value;
         break;


### PR DESCRIPTION
This is just a simplification of the parsing logic for the download option.
And a few touchups on messages emitted in error cases - incorrect arguments passed, and so on.

This PR does not change the behavior of apigeelint, other than rewording of error messages.