### PR TITLE
fix: correct handling of null in Conditions within TruthTable

### DIFF
--- a/lib/package/TruthTable.js
+++ b/lib/package/TruthTable.js
@@ -46,10 +46,13 @@ TruthTable.prototype.getEvaluation = function () {
       var tree = this.getAST(),
         vars = this.getVariables(),
         c2 = generateCombinationsFromVars(tree, vars);
+      debug(`vars: ${JSON.stringify(vars, null, 2)}`);
+      debug(`c2: ${JSON.stringify(c2, null, 2)}`);
 
       for (var i = 0; i < c2.length; i++) {
+        //debug(`interpreting: ${JSON.stringify(c2[i], null, 2)}`);
         var result = interpret(tree, c2[i]);
-
+        //debug(`result:(${JSON.stringify(result, null, 2)})`);
         var run = {
           substitutions: c2[i],
           result,
@@ -217,10 +220,13 @@ function interpret(tree, substitutions) {
       var result = {
         action: "javaRegex",
         value:
-          args[0].evaluation.value
-            .toString()
-            .toLowerCase()
-            .indexOf(args[1].evaluation.value.toString().toLowerCase()) >= 0,
+          args[0].evaluation.value == null
+            ? args[0].evaluation.value
+            : args[0].evaluation.value
+                .toString()
+                .toLowerCase()
+                .indexOf(args[1].evaluation.value.toString().toLowerCase()) >=
+              0,
       };
       return result;
     },
@@ -862,6 +868,12 @@ function generateCombinationsFromVars(nodes, vars) {
       }
       //the underlying type of the value should guide us on other possible values
       switch (typeof node.value) {
+        case "object":
+          // In Apigee conditions, if there is a constant object, it is always «null»
+          varValues[node.varName].push(null);
+          varValues[node.varName].push({});
+          varValues[node.varName].push("something");
+          break;
         case "string":
           //strip quotes
           //add the default

--- a/test/specs/testTruthTable.js
+++ b/test/specs/testTruthTable.js
@@ -24,22 +24,23 @@ const assert = require("assert"),
           evaluation = tt.getEvaluation();
 
         debug(`evaluation: ${evaluation}`);
-
-        assert.equal(
-          expected,
-          evaluation,
-          JSON.stringify({
-            truthTable: tt,
-            evaluation,
-          }),
-        );
       } catch (parseExc) {
         debug(`expected: ${expected}`);
         assert.notEqual("ERR_ASSERTION", parseExc.code);
         debug(`parse Exception: ${JSON.stringify(parseExc)}`);
         debug(`parse Exception: ${parseExc.stack}`);
         assert.equal("exception", expected);
+        return;
       }
+
+      assert.equal(
+        expected,
+        evaluation,
+        JSON.stringify({
+          truthTable: tt,
+          evaluation,
+        }),
+      );
     });
   };
 
@@ -71,6 +72,16 @@ describe("TruthTable", function () {
   // It is not valid to place strings on LHS of expressions.
   // test('"bar" Matches "foo"', "absurdity");
   test('(fault.name Matches "InvalidApiKey")', "valid");
+
+  test("geocodeResponse.content != null", "valid");
+  test("geocodeResponse.content = null", "valid");
+  test("(geocodeResponse.content = null)", "valid");
+  test(
+    "(geocodeResponse.content = null) AND (geocodeResponse.content != null)",
+    "absurdity",
+  );
+  test('geocodeResponse.content != "foo"', "valid");
+  test('geocodeResponse.content = "foo"', "valid");
 
   test("false", "absurdity");
   test("true", "valid");


### PR DESCRIPTION
This fix adds proper handling of null in TruthTable, to allow expressions like 
  `geocodingResponse.content != null` 

