### PR TITLE
fix: adjust TD012 warning messages, and test for same

### DIFF
--- a/lib/package/plugins/TD012-targetSslInfo-exactly-one-SSLInfo.js
+++ b/lib/package/plugins/TD012-targetSslInfo-exactly-one-SSLInfo.js
@@ -64,9 +64,19 @@ const onTargetEndpoint = function (endpoint, cb) {
               `onTargetEndpoint sslInfos.length(${util.format(sslInfos.length)})`,
             );
             if (sslInfos.length == 0) {
-              recordIssue(htc.getElement());
+              recordIssue(
+                htc.getElement(),
+                "TargetEndpoint HTTPTargetConnection is missing SSLInfo configuration",
+              );
             } else if (sslInfos.length > 1) {
-              sslInfos.slice(1).forEach((sslInfo) => recordIssue(sslInfo));
+              sslInfos
+                .slice(1)
+                .forEach((sslInfo) =>
+                  recordIssue(
+                    sslInfo,
+                    "TargetEndpoint HTTPTargetConnection has more than one SSLInfo",
+                  ),
+                );
             }
           } else if (sslInfos.length > 0) {
             recordIssue(
@@ -77,7 +87,14 @@ const onTargetEndpoint = function (endpoint, cb) {
         }
       } else if (loadBalancers.length == 1) {
         if (sslInfos.length > 1) {
-          sslInfos.slice(1).forEach((sslInfo) => recordIssue(sslInfo));
+          sslInfos
+            .slice(1)
+            .forEach((sslInfo) =>
+              recordIssue(
+                sslInfo,
+                "TargetEndpoint HTTPTargetConnection has more than one SSLInfo",
+              ),
+            );
         }
       }
     } catch (exc1) {

--- a/test/fixtures/resources/TD012/fail/messages.js
+++ b/test/fixtures/resources/TD012/fail/messages.js
@@ -1,0 +1,14 @@
+// These are the error messages only for the failed policies.
+module.exports = {
+  "t1-two-SSLInfos-with-URL.xml":
+    "TargetEndpoint HTTPTargetConnection has more than one SSLInfo",
+
+  "t2-missing-SSLInfo-with-URL.xml":
+    "TargetEndpoint HTTPTargetConnection is missing SSLInfo configuration",
+
+  "t3-one-SSLInfo-with-insecure-url.xml":
+    "SSLInfo should not be used with an insecure http url",
+
+  "t4-two-SSLInfos-with-LoadBalancer.xml":
+    "TargetEndpoint HTTPTargetConnection has more than one SSLInfo",
+};

--- a/test/specs/TD012-test.js
+++ b/test/specs/TD012-test.js
@@ -66,7 +66,7 @@ describe(`${testID} - endpoint passes multiple SSLInfo check`, function () {
 
 describe(`${testID} - endpoint does not pass multiple SSLInfo check`, () => {
   const sourceDir = path.join(rootDir, "fail");
-
+  const expectedErrorMessages = require(path.join(sourceDir, "messages.js"));
   const testOne = (shortFileName) => {
     it(`check ${shortFileName} throws error`, () => {
       const policy = loadEndpoint(sourceDir, shortFileName);
@@ -75,7 +75,26 @@ describe(`${testID} - endpoint does not pass multiple SSLInfo check`, () => {
         assert.equal(true, foundIssues, "should be issues");
         const messages = policy.getReport().messages;
         assert.ok(messages, "messages for issues should exist");
+        let expected = expectedErrorMessages[shortFileName];
+        assert.ok(
+          expected,
+          "test configuration failure: did not find configuration in messages.js",
+        );
+        if (!Array.isArray(expected)) {
+          expected = [expected];
+        }
         debug(util.format(messages));
+        assert.equal(
+          expected.length,
+          messages.length,
+          "mismatch in number of messages",
+        );
+        expected.forEach((msg) =>
+          assert.ok(
+            messages.find((m) => m.message == msg),
+            `Did not find expected(${msg}) in actual(${messages.map((i) => i.message).toString()})`,
+          ),
+        );
       });
     });
   };


### PR DESCRIPTION
change TD012 warning message, when a LoadBalancer is in use, to 
```
 "TargetEndpoint HTTPTargetConnection is missing SSLInfo configuration"
```