### PR TITLE
fix: validateTemplate adjustment for quoted jsonPath expressions

### DIFF
--- a/lib/package/plugins/PO026-assignVariableUsage.js
+++ b/lib/package/plugins/PO026-assignVariableUsage.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2024 Google LLC
+  Copyright 2019-2025 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ const plugin = {
   fatal: false,
   severity: 2, //error
   nodeType: "AssignMessage",
-  enabled: true
+  enabled: true,
 };
 
 let profile = "apigee";
@@ -55,7 +55,7 @@ const onPolicy = function (policy, cb) {
     const avNodes = xpath.select(xpathExpr, policy.getElement());
     if (avNodes && avNodes.length > 0) {
       debug(
-        `${util.format(policy)} found ${avNodes.length} AssignVariable elements`
+        `${util.format(policy)} found ${avNodes.length} AssignVariable elements`,
       );
       avNodes.forEach((node, ix) => {
         const addNodeMessage = (message) =>
@@ -75,12 +75,12 @@ const onPolicy = function (policy, cb) {
         const childNodes = xpath.select("*", node);
         if (childNodes.length == 0) {
           addNodeMessage(
-            `empty AssignVariable. Should have a Name child, and at least one of {${foundKeysStr}}.`
+            `empty AssignVariable. Should have a Name child, and at least one of {${foundKeysStr}}.`,
           );
         } else {
           childNodes.forEach((child, _ix) => {
             debug(
-              `childNode ${ix}: type(${child.nodeType}) name(${child.nodeName})`
+              `childNode ${ix}: type(${child.nodeType}) name(${child.nodeName})`,
             );
             if (typeof found[child.tagName] !== "undefined") {
               found[child.tagName]++;
@@ -88,7 +88,7 @@ const onPolicy = function (policy, cb) {
               addMessage(
                 child.lineNumber,
                 child.columnNumber,
-                `There is a stray element (${child.tagName})`
+                `There is a stray element (${child.tagName})`,
               );
             }
           });
@@ -108,7 +108,7 @@ const onPolicy = function (policy, cb) {
               addMessage(
                 textnode[0].lineNumber,
                 textnode[0].columnNumber,
-                "The text of the Ref element must be a variable name, should not include curlies"
+                "The text of the Ref element must be a variable name, should not include curlies",
               );
             }
           }
@@ -122,7 +122,7 @@ const onPolicy = function (policy, cb) {
               addMessage(
                 textnode[0].lineNumber,
                 textnode[0].columnNumber,
-                "The text of the PropertySetRef element must not be empty"
+                "The text of the PropertySetRef element must not be empty",
               );
             }
             let r = pluginUtil.validateTemplate(psrText);
@@ -130,7 +130,7 @@ const onPolicy = function (policy, cb) {
               addMessage(
                 textnode[0].lineNumber,
                 textnode[0].columnNumber,
-                `The text of the PropertySetRef element must be a valid message template (${r})`
+                `The text of the PropertySetRef element must be a valid message template (${r})`,
               );
             } else {
               r = pluginUtil.validatePropertySetRef(psrText);
@@ -138,7 +138,7 @@ const onPolicy = function (policy, cb) {
                 addMessage(
                   textnode[0].lineNumber,
                   textnode[0].columnNumber,
-                  `Error in the text of the PropertySetRef element: ${r}`
+                  `Error in the text of the PropertySetRef element: ${r}`,
                 );
               }
             }
@@ -155,7 +155,7 @@ const onPolicy = function (policy, cb) {
                 addMessage(
                   textnode[0].lineNumber,
                   textnode[0].columnNumber,
-                  "error: " + util.format(r)
+                  "invalid template: " + util.format(r),
                 );
               }
             }
@@ -174,7 +174,7 @@ const onPolicy = function (policy, cb) {
           }
           if (foundAny === 0) {
             addNodeMessage(
-              `You should have at least one of: {${foundKeysStr}}`
+              `You should have at least one of: {${foundKeysStr}}`,
             );
           }
         }
@@ -191,5 +191,5 @@ const onPolicy = function (policy, cb) {
 module.exports = {
   plugin,
   onBundle,
-  onPolicy
+  onPolicy,
 };

--- a/lib/package/plugins/_pluginUtil.js
+++ b/lib/package/plugins/_pluginUtil.js
@@ -8,6 +8,7 @@ const STATES = {
   INSIDE_VARREF: 3,
   INSIDE_FNARGS_NO_TEXT: 4,
   INSIDE_FNARGS: 5,
+  INSIDE_FNARGS_OPEN_QUOTE: 6,
 };
 
 const CODES = {
@@ -162,7 +163,9 @@ const validateTemplate = (expr) => {
           if (ch == "{" || ch == "[" || ch == "(" || ch == "}" || ch == "]") {
             return `unexpected character at position ${ix}: ${ch}`;
           }
-          if (ch == ")") {
+          if (ch == "'") {
+            state = STATES.INSIDE_FNARGS_OPEN_QUOTE;
+          } else if (ch == ")") {
             const r = validateFunctionArgs(
               expr,
               fnStart + 1,
@@ -174,6 +177,12 @@ const validateTemplate = (expr) => {
             }
             state = STATES.AWAITING_CLOSE_CURLY;
           } else {
+            state = STATES.INSIDE_FNARGS;
+          }
+          break;
+
+        case STATES.INSIDE_FNARGS_OPEN_QUOTE:
+          if (ch == "'") {
             state = STATES.INSIDE_FNARGS;
           }
           break;
@@ -215,6 +224,9 @@ const validateTemplate = (expr) => {
     return "extraneous close-brace at position ${ix}";
   }
   debug(`final state(${stateToString(state)})`);
+  if (state == STATES.INSIDE_FNARGS_OPEN_QUOTE) {
+    return "unterminated open quote";
+  }
   return state == STATES.OUTSIDE_CURLY ? undefined : "unterminated curly brace";
 };
 

--- a/test/fixtures/resources/PO026-assignVariable/apiproxy/policies/AM-CleanResponseHeaders.xml
+++ b/test/fixtures/resources/PO026-assignVariable/apiproxy/policies/AM-CleanResponseHeaders.xml
@@ -1,5 +1,4 @@
 <AssignMessage name='AM-CleanResponseHeaders'>
-  <AssignTo createNew='false' transport='http' type='response'/>
   <Remove>
     <Headers/>
   </Remove>

--- a/test/fixtures/resources/PO026-assignVariable/apiproxy/policies/AM-JsonPath-1.xml
+++ b/test/fixtures/resources/PO026-assignVariable/apiproxy/policies/AM-JsonPath-1.xml
@@ -1,0 +1,41 @@
+<AssignMessage name="AM-JsonPath-1">
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <AssignVariable>
+    <Name>jsondata</Name>
+    <Value><![CDATA[{
+  "quota": [
+    {
+      "appname": "A",
+      "operation": "ManageOrder",
+      "value": "900",
+      "a": ["1", "2"]
+    },
+    {
+      "appname": "B",
+      "operation": "ManageOrder",
+      "value": "1000",
+      "a": ["3", "4"]
+    },
+    {
+      "appname": "B",
+      "operation": "SubmitOrder",
+      "value": "800",
+      "a": ["5", "3"]
+    }
+  ]
+}
+]]></Value>
+  </AssignVariable>
+
+  <AssignVariable>
+    <Name>selected_value</Name>
+    <!-- quoted jsonpath -->
+    <Template>{jsonPath('$.quota.[*].appname',jsondata)}</Template>
+  </AssignVariable>
+
+  <AssignVariable>
+    <Name>expected_value</Name>
+    <Value>A</Value>
+  </AssignVariable>
+
+</AssignMessage>

--- a/test/fixtures/resources/PO026-assignVariable/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/PO026-assignVariable/apiproxy/proxies/endpoint1.xml
@@ -46,6 +46,9 @@
 
     <Flow name="flow1">
       <Request>
+        <Step>
+          <Name>AM-JsonPath-1</Name>
+        </Step>
       </Request>
       <Response>
         <Step>

--- a/test/specs/PO026-assignVariableHygiene.js
+++ b/test/specs/PO026-assignVariableHygiene.js
@@ -17,22 +17,25 @@
 /* global describe, it */
 
 const assert = require("assert"),
-      path = require("path"),
-      bl = require("../../lib/package/bundleLinter.js");
+  path = require("path"),
+  bl = require("../../lib/package/bundleLinter.js");
 
 describe(`PO026 - AssignVariableHygiene`, () => {
-  it('should generate the expected errors', () => {
+  it("should generate the expected errors", () => {
     const configuration = {
-          debug: true,
-          source: {
-            type: "filesystem",
-            path: path.resolve(__dirname, '../fixtures/resources/PO026-assignVariable/apiproxy'),
-            bundleType: "apiproxy"
-          },
-          excluded: {},
-          setExitCode: false,
-          output: () => {} // suppress output
-        };
+      debug: true,
+      source: {
+        type: "filesystem",
+        path: path.resolve(
+          __dirname,
+          "../fixtures/resources/PO026-assignVariable/apiproxy",
+        ),
+        bundleType: "apiproxy",
+      },
+      excluded: {},
+      setExitCode: false,
+      output: () => {}, // suppress output
+    };
 
     bl.lint(configuration, (bundle) => {
       const items = bundle.getReport();
@@ -40,85 +43,107 @@ describe(`PO026 - AssignVariableHygiene`, () => {
       assert.ok(items.length);
 
       const expected = {
-            'AM-AssignVariable-MissingNameElement.xml' : [
-              {
-                message: "There is no Name element",
-                line: 3,
-                column: 3
-              }
-            ],
-            'AM-AssignVariable-TooManyNameElements.xml' : [
-              {
-                message: "There is more than one Name element",
-                line: 3,
-                column: 3
-              }
-            ],
-            'AM-AssignVariable-RefWithCurlies.xml' : [
-              {
-                message: "The text of the Ref element must be a variable name, should not include curlies",
-                line: 7,
-                column: 10
-              }
-            ],
-            'AM-AssignVariable-MultipleProblems.xml' : [
-              {
-                message: "There is no Name element",
-                line: 4,
-                column: 3
-              },
-              {
-                message: "You should have at least one of: {Ref,Value,Template}",
-                line: 8,
-                column: 3
-              },
-              {
-                message: "The text of the Ref element must be a variable name, should not include curlies",
-                line: 15,
-                column: 10
-              },
-              {
-                message: "empty AssignVariable. Should have a Name child, and at least one of {Ref,Value,Template}.",
-                line: 18,
-                column: 3
-              },
-              {
-                message: "There is a stray element (StrayElement)",
-                line: 23,
-                column: 5
-              },
-              {
-                message: "There is more than one Name element",
-                line: 26,
-                column: 3
-              },
-              {
-                message: "There is more than one Value element",
-                line: 32,
-                column: 3
-              },
-              {
-                message: "There is more than one Template element",
-                line: 38,
-                column: 3
-              }
-            ]
-          };
+        "AM-AssignVariable-MissingNameElement.xml": [
+          {
+            message: "There is no Name element",
+            line: 3,
+            column: 3,
+          },
+        ],
+        "AM-AssignVariable-TooManyNameElements.xml": [
+          {
+            message: "There is more than one Name element",
+            line: 3,
+            column: 3,
+          },
+        ],
+        "AM-AssignVariable-RefWithCurlies.xml": [
+          {
+            message:
+              "The text of the Ref element must be a variable name, should not include curlies",
+            line: 7,
+            column: 10,
+          },
+        ],
+        "AM-AssignVariable-MultipleProblems.xml": [
+          {
+            message: "There is no Name element",
+            line: 4,
+            column: 3,
+          },
+          {
+            message: "You should have at least one of: {Ref,Value,Template}",
+            line: 8,
+            column: 3,
+          },
+          {
+            message:
+              "The text of the Ref element must be a variable name, should not include curlies",
+            line: 15,
+            column: 10,
+          },
+          {
+            message:
+              "empty AssignVariable. Should have a Name child, and at least one of {Ref,Value,Template}.",
+            line: 18,
+            column: 3,
+          },
+          {
+            message: "There is a stray element (StrayElement)",
+            line: 23,
+            column: 5,
+          },
+          {
+            message: "There is more than one Name element",
+            line: 26,
+            column: 3,
+          },
+          {
+            message: "There is more than one Value element",
+            line: 32,
+            column: 3,
+          },
+          {
+            message: "There is more than one Template element",
+            line: 38,
+            column: 3,
+          },
+        ],
+      };
 
-      Object.keys(expected).forEach( (policyName, px) => {
-        const policyItems = items.filter( m => m.filePath.endsWith(policyName));
+      const policiesReported = items.filter((m) =>
+        m.messages.find((msg) => msg.message),
+      );
+      let expectedPnames = Object.keys(expected);
+      assert.equal(
+        expectedPnames.length,
+        policiesReported.length,
+        `reported but not expected: ${policiesReported.map((r) => path.basename(r.filePath)).filter((x) => !expectedPnames.includes(x))}`,
+      );
+
+      expectedPnames.forEach((policyName, px) => {
+        const policyItems = items.filter((m) =>
+          m.filePath.endsWith(policyName),
+        );
         assert.equal(policyItems.length, 1);
-        const po026Messages = policyItems[0].messages.filter( m => m.ruleId == 'PO026');
-        assert.equal(po026Messages.length, expected[policyName].length);
-
-        expected[policyName].forEach( (item, ix) => {
-          Object.keys(item).forEach( key => {
-            assert.equal(po026Messages[ix][key], item[key], `case(${px},${ix}) key(${key})`);
+        const po026Messages = policyItems[0].messages.filter(
+          (m) => m.ruleId == "PO026",
+        );
+        assert.equal(
+          po026Messages.length,
+          expected[policyName].length,
+          `for policyName:${policyName} expected ${expected[policyName].length} msgs`,
+        );
+        expected[policyName].forEach((item, ix) => {
+          Object.keys(item).forEach((key) => {
+            assert.equal(
+              po026Messages[ix][key],
+              item[key],
+              `case(${px},${ix}) key(${key})`,
+            );
           });
         });
       });
-
     });
   });
-
 });

--- a/test/specs/testTemplateCheck.js
+++ b/test/specs/testTemplateCheck.js
@@ -1,5 +1,5 @@
 /*
-  Copyright 2019-2023 Google LLC
+  Copyright 2019-2023,2025 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -62,6 +62,8 @@ describe("TemplateCheck", function () {
     ["{notARealfunction()}", "unsupported function name (notARealfunction)"],
     ["{createUuid[]}", "unexpected character at position 11: ["],
     ["{ createUuid() }", undefined], // but ineffective
+    ["{jsonPath('$.quota.[*].appname',jsondata)}", undefined],
+    ["{jsonPath('$.quota.[*].appname,jsondata)}", "unterminated open quote"],
   ];
 
   testCases.forEach((item, _ix) => {


### PR DESCRIPTION
AssignMessage with this: 
```
  <AssignVariable>
    <Name>selected_value</Name>
    <!-- quoted jsonpath -->
    <Template>{jsonPath('$.quota.[*].appname',jsondata)}</Template>
  </AssignVariable>

```
...can trigger an unwarranted warning from PO026.  This change corrects that, and adds a few tests.
