### PR TITLE
feat: plugin PO041 checks deprecated ExclusiveCache in KVM policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ This is the current list:
 | &nbsp; |:white_check_mark:| PO038 | KeyValueMapOperations policy hygiene | Checks that MapName or mapIdentifier is specified, and not both.|
 | &nbsp; |:white_check_mark:| PO039 | MessageLogging policy hygiene | Checks that ResourceType is not used, or is "api".|
 | &nbsp; |:white_check_mark:| PO040 | Check JSONPath within ExtractVariables policy | Checks that JSONPath compiles and is valid. |
+| &nbsp; |:white_check_mark:| PO041 | KeyValueMapOperations policy and ExclusiveCache | Checks that KeyValueMapOperations policy does not use deprecated ExclusiveCache. |
 | FaultRules | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| FR001 | No Condition on FaultRule | Use Condition elements on FaultRules, unless it is the fallback rule. |
 | &nbsp; |:white_check_mark:| FR002 | DefaultFaultRule Structure | DefaultFaultRule should have only supported child elements, at most one AlwaysEnforce element, and at most one Condition element. |

--- a/lib/package/plugins/PO041-kvm-exclusive-cache.js
+++ b/lib/package/plugins/PO041-kvm-exclusive-cache.js
@@ -1,0 +1,94 @@
+/*
+  Copyright 2019-2023,2025 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const lintUtil = require("../lintUtil.js"),
+  xpath = require("xpath"),
+  jsonpath = require("jsonpath"),
+  ruleId = lintUtil.getRuleId(),
+  debug = require("debug")("apigeelint:" + ruleId);
+
+const plugin = {
+  ruleId,
+  name: "Check KeyValueMapOperations ExclusiveCache usage",
+  fatal: false,
+  severity: 1, //1= warning, 2=error
+  nodeType: "Policy",
+  enabled: true,
+};
+
+let bundleProfile = "apigee";
+const onBundle = function (bundle, cb) {
+  if (bundle.profile) {
+    bundleProfile = bundle.profile;
+  }
+  if (typeof cb == "function") {
+    cb(null, false);
+  }
+};
+
+const onPolicy = function (policy, cb) {
+  let flagged = false;
+
+  const addMessage = (line, column, message) => {
+    policy.addMessage({ plugin, message, line, column });
+    flagged = true;
+  };
+  try {
+    if (policy.getType() === "KeyValueMapOperations") {
+      let selection = policy.select(`/KeyValueMapOperations/ExclusiveCache`);
+      if (selection && selection[0]) {
+        selection.forEach((node) =>
+          addMessage(
+            node.lineNumber,
+            node.columnNumber,
+            "ExclusiveCache is deprecated in the KeyValueMapOperations policy",
+          ),
+        );
+      }
+      selection = policy.select(`/KeyValueMapOperations/Scope`);
+      if (!selection || !selection[0]) {
+        addMessage(
+          1,
+          1,
+          "Scope element is missing in the KeyValueMapOperations policy",
+        );
+      } else if (selection || selection.length > 1) {
+        selection
+          .slice(1)
+          .forEach((node) =>
+            addMessage(
+              node.lineNumber,
+              node.columnNumber,
+              "use at most one Scope element in the KeyValueMapOperations policy",
+            ),
+          );
+      }
+    }
+  } catch (e) {
+    debug(util.format(e));
+  }
+
+  if (typeof cb == "function") {
+    cb(null, flagged);
+  }
+  return flagged;
+};
+
+module.exports = {
+  plugin,
+  onPolicy,
+  onBundle,
+};

--- a/test/fixtures/resources/PO041/fail/KVM-ExclusiveCache-apigee.xml
+++ b/test/fixtures/resources/PO041/fail/KVM-ExclusiveCache-apigee.xml
@@ -1,0 +1,9 @@
+<KeyValueMapOperations name="KVM-ExclusiveCache-apigee" mapIdentifier='foobar'>
+  <ExpiryTimeInSecs>300</ExpiryTimeInSecs>
+  <Get assignTo="JwkURI">
+    <Key>
+      <Parameter>jwk_uri</Parameter>
+    </Key>
+  </Get>
+  <ExclusiveCache>true</ExclusiveCache>
+</KeyValueMapOperations>

--- a/test/fixtures/resources/PO041/fail/KVM-ExclusiveCache-apigeex.xml
+++ b/test/fixtures/resources/PO041/fail/KVM-ExclusiveCache-apigeex.xml
@@ -1,0 +1,16 @@
+<KeyValueMapOperations name="KVM-ExclusiveCache-apigeex">
+
+  <MapName ref="OrganizationMapName"/>
+
+  <ExpiryTimeInSecs>300</ExpiryTimeInSecs>
+  <Get assignTo="JwkURI">
+    <Key>
+      <Parameter>jwk_uri</Parameter>
+    </Key>
+  </Get>
+  <ExclusiveCache>true</ExclusiveCache>
+
+<!--
+  <Scope>organization</Scope>
+-->
+</KeyValueMapOperations>

--- a/test/fixtures/resources/PO041/fail/KVM-both-Scope-and-ExclusiveCache-apigee.xml
+++ b/test/fixtures/resources/PO041/fail/KVM-both-Scope-and-ExclusiveCache-apigee.xml
@@ -1,0 +1,10 @@
+<KeyValueMapOperations name="KVM-both-Scope-and-ExclusiveCache-apigee" mapIdentifier='foobar'>
+  <ExpiryTimeInSecs>300</ExpiryTimeInSecs>
+  <Get assignTo="JwkURI">
+    <Key>
+      <Parameter>jwk_uri</Parameter>
+    </Key>
+  </Get>
+  <Scope>organization</Scope>
+  <ExclusiveCache>true</ExclusiveCache>
+</KeyValueMapOperations>

--- a/test/fixtures/resources/PO041/fail/KVM-missing-Scope-apigeex.xml
+++ b/test/fixtures/resources/PO041/fail/KVM-missing-Scope-apigeex.xml
@@ -1,0 +1,14 @@
+<KeyValueMapOperations name="KVM-missing-Scope-apigeex">
+
+  <MapName ref="OrganizationMapName"/>
+
+  <ExpiryTimeInSecs>300</ExpiryTimeInSecs>
+  <Get assignTo="JwkURI">
+    <Key>
+      <Parameter>jwk_uri</Parameter>
+    </Key>
+  </Get>
+<!--
+  <Scope>organization</Scope>
+-->
+</KeyValueMapOperations>

--- a/test/fixtures/resources/PO041/fail/messages.js
+++ b/test/fixtures/resources/PO041/fail/messages.js
@@ -1,0 +1,19 @@
+// These are the error messages only for the failed policies.
+module.exports = {
+  "KVM-ExclusiveCache-apigeex.xml": [
+    "ExclusiveCache is deprecated in the KeyValueMapOperations policy",
+    "Scope element is missing in the KeyValueMapOperations policy",
+  ],
+
+  "KVM-missing-Scope-apigeex.xml": [
+    "Scope element is missing in the KeyValueMapOperations policy",
+  ],
+
+  "KVM-both-Scope-and-ExclusiveCache-apigee.xml":
+    "ExclusiveCache is deprecated in the KeyValueMapOperations policy",
+
+  "KVM-ExclusiveCache-apigee.xml": [
+    "ExclusiveCache is deprecated in the KeyValueMapOperations policy",
+    "Scope element is missing in the KeyValueMapOperations policy",
+  ],
+};

--- a/test/fixtures/resources/PO041/pass/KVM-Scope-apigee.xml
+++ b/test/fixtures/resources/PO041/pass/KVM-Scope-apigee.xml
@@ -1,0 +1,9 @@
+<KeyValueMapOperations name="KVM-Scope-apigee" mapIdentifier='foobar'>
+  <ExpiryTimeInSecs>300</ExpiryTimeInSecs>
+  <Get assignTo="JwkURI">
+    <Key>
+      <Parameter>jwk_uri</Parameter>
+    </Key>
+  </Get>
+  <Scope>organization</Scope>
+</KeyValueMapOperations>

--- a/test/fixtures/resources/PO041/pass/KVM-Scope-apigeex.xml
+++ b/test/fixtures/resources/PO041/pass/KVM-Scope-apigeex.xml
@@ -1,0 +1,10 @@
+<KeyValueMapOperations name="KVM-Scope-apigeex">
+  <MapName ref="OrganizationMapName"/>
+  <ExpiryTimeInSecs>300</ExpiryTimeInSecs>
+  <Get assignTo="JwkURI">
+    <Key>
+      <Parameter>jwk_uri</Parameter>
+    </Key>
+  </Get>
+  <Scope>organization</Scope>
+</KeyValueMapOperations>

--- a/test/specs/PO041-test.js
+++ b/test/specs/PO041-test.js
@@ -1,0 +1,118 @@
+/*
+  Copyright 2019-2025 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const testID = "PO041",
+  assert = require("assert"),
+  fs = require("fs"),
+  util = require("util"),
+  path = require("path"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Policy = require("../../lib/package/Policy.js"),
+  Dom = require("@xmldom/xmldom").DOMParser,
+  rootDir = path.resolve(__dirname, "../fixtures/resources/PO041"),
+  debug = require("debug")(`apigeelint:${testID}-test`);
+
+const loadPolicy = (sourceDir, shortFileName) => {
+  const fqPath = path.join(sourceDir, shortFileName),
+    policyXml = fs.readFileSync(fqPath).toString("utf-8"),
+    doc = new Dom().parseFromString(policyXml),
+    p = new Policy(rootDir, shortFileName, this, doc);
+  p.getElement = () => doc.documentElement;
+  p.fileName = shortFileName;
+  return p;
+};
+
+describe(`${testID} - policy passes KVM hygiene check`, function () {
+  const sourceDir = path.join(rootDir, "pass");
+  const testOne = (shortFileName) => {
+    const policy = loadPolicy(sourceDir, shortFileName);
+    const profile = shortFileName.split(".")[0].split("-").slice(-1)[0];
+    const policyType = policy.getType();
+    it(`check ${shortFileName} passes`, () => {
+      assert.notEqual(policyType, undefined, `${policyType} should be defined`);
+      plugin.onBundle({ profile });
+      plugin.onPolicy(policy);
+      const report = policy.getReport();
+      const foundIssues = report.errorCount != 0 || report.warningCount != 0;
+      const messages = report.messages;
+      debug(`pass ${shortFileName} issues: ${foundIssues}`);
+      debug(`pass ${shortFileName} messages: ${util.format(messages)}`);
+      assert.equal(foundIssues, false, "should be no issues");
+      assert.ok(messages, "messages should exist");
+      assert.equal(messages.length, 0, "unexpected number of messages");
+    });
+  };
+
+  fs.readdirSync(sourceDir)
+    .filter((shortFileName) => shortFileName.endsWith(".xml"))
+    .forEach(testOne);
+});
+
+describe(`${testID} - policy does not pass KVM hygiene check`, () => {
+  const sourceDir = path.join(rootDir, "fail");
+  const expectedErrorMessages = require(path.join(sourceDir, "messages.js"));
+  const testOne = (shortFileName) => {
+    const policy = loadPolicy(sourceDir, shortFileName);
+    const profile = shortFileName.split(".")[0].split("-").slice(-1)[0];
+    const policyType = policy.getType();
+    it(`check ${shortFileName} throws error`, () => {
+      assert.notEqual(policyType, undefined, `${policyType} should be defined`);
+      plugin.onBundle({ profile });
+      plugin.onPolicy(policy);
+      const report = policy.getReport();
+      const foundIssues = report.errorCount != 0 || report.warningCount != 0;
+      debug(`onPolicy: ${policy.getName()}`);
+      assert.equal(true, foundIssues, "should be issues");
+      const messages = report.messages;
+      assert.ok(messages, "messages should exist");
+      debug(util.format(messages));
+      let expectedList = expectedErrorMessages[policy.fileName];
+      assert.ok(
+        expectedList,
+        "test configuration failure: did not find an expected message",
+      );
+      if (typeof expectedList == "string") {
+        expectedList = [expectedList];
+      }
+      assert.equal(
+        messages.length,
+        expectedList.length,
+        "unexpected number of messages",
+      );
+
+      expectedList.forEach((expected, ix) => {
+        debug(`expected: ${expected}`);
+        debug(`actual: ${messages[ix].message}`);
+        assert.ok(messages[ix]);
+        assert.ok(messages[ix].message);
+        assert.equal(typeof messages[ix].message, "string");
+        assert.equal(typeof expected, "string");
+        assert.equal(
+          expected,
+          messages[ix].message,
+          "did not find expected message",
+        );
+      });
+    });
+  };
+
+  fs.readdirSync(sourceDir)
+    .filter((shortFileName) => shortFileName.endsWith(".xml"))
+    .forEach(testOne);
+});


### PR DESCRIPTION
The ExclusiveCache element in the KeyValueMapOperations policy is deprecated. 

This new plugin flags the use of that element as a warning. 