### PR TITLE
fix: correct check in TD004 to allow for variable in URL

### DIFF
--- a/lib/package/plugins/TD004-targetSslInfo-enabled-and-enforce.js
+++ b/lib/package/plugins/TD004-targetSslInfo-enabled-and-enforce.js
@@ -100,21 +100,28 @@ const onTargetEndpoint = function (endpoint, cb) {
                   }
                 }
               } else {
-                if (enabled) {
-                  messages.push(
-                    "SSLInfo configuration must not use the Enabled=true with insecure URL",
-                  );
-                }
-                if (enforce) {
-                  if (bundleProfile == "apigeex") {
+                const isHttp = endpointUrl.startsWith("http://");
+                if (isHttp) {
+                  if (enabled) {
                     messages.push(
-                      "SSLInfo configuration must not use the Enforce=true with insecure URL",
-                    );
-                  } else {
-                    messages.push(
-                      "SSLInfo configuration should never use Enforce in profile=apigee, and also should not use Enforce=true with insecure URL",
+                      "SSLInfo configuration must not use the Enabled=true with insecure URL",
                     );
                   }
+                  if (enforce) {
+                    if (bundleProfile == "apigeex") {
+                      messages.push(
+                        "SSLInfo configuration must not use the Enforce=true with insecure URL",
+                      );
+                    } else {
+                      messages.push(
+                        "SSLInfo configuration should never use Enforce in profile=apigee, and also should not use Enforce=true with insecure URL",
+                      );
+                    }
+                  }
+                } else {
+                  debug(
+                    `HTTPTargetConnection/URL is neither https nor http. Probably variable (${endpointUrl})`,
+                  );
                 }
               }
             }

--- a/test/specs/TD004-test-sslInfo.js
+++ b/test/specs/TD004-test-sslInfo.js
@@ -138,6 +138,20 @@ describe(`${testID} - ${plugin.plugin.name}`, function () {
     ["SSLInfo configuration must not use the Enabled=true with insecure URL"],
   );
 
+  test(
+    81,
+    "SSLInfo/Enabled=true, scheme=variable, profile=apigee",
+    `<TargetEndpoint name="default">
+    <HTTPTargetConnection>
+      <SSLInfo>
+        <Enabled>true</Enabled>
+      </SSLInfo>
+      <URL>{variable-goes-here}</URL>
+    </HTTPTargetConnection>
+  </TargetEndpoint>`,
+    null,
+  );
+
   testApigeeX(
     90,
     "SSLInfo/Enforce = true, scheme=https, profile=apigeex",


### PR DESCRIPTION
This small fix tweaks the TD004 plugin to allow a variable/template in the URL for HTTPTargetConnection .