### PR TITLE
fix: TruthTable subst NOT only with word boundary

### DIFF
--- a/lib/package/TruthTable.js
+++ b/lib/package/TruthTable.js
@@ -481,7 +481,7 @@ TruthTable.prototype.getTokens = function () {
     expression = encodeQuotedChars(expression, ")");
     expression = encodeQuotedChars(expression, "\t");
     expression = encodeQuotedChars(expression, "\n");
-    expression = expression.replace(new RegExp("^ *NOT", "i"), " ! "); // leading NOT
+    expression = expression.replace(new RegExp("^ *NOT\b", "i"), " ! "); // leading NOT
     expression = replaceAll(expression, " Not ", " ! ");
     expression = replaceAll(
       expression,

--- a/test/specs/testTruthTable.js
+++ b/test/specs/testTruthTable.js
@@ -44,7 +44,9 @@ const assert = require("assert"),
     });
   };
 
-describe("TruthTable", function () {
+describe("TruthTable evaluation", function () {
+  test("notValidJson == true", "valid");
+
   // It is not valid to place strings on LHS of expressions.
   // test('"/x/a/b/feed/" Matches "/*/a/*/feed/"', "valid");
   //test('"/Be/ER" Matches "/*/ER" ', "valid");
@@ -151,10 +153,10 @@ describe("TruthTable", function () {
   );
   test(
     `NOT(request.header.auth-type = "passthrough") AND
-        NOT (request.header.auth-type = "impersonated") AND
-        NOT(request.header.auth-type = "platform") AND
-        NOT
-        (request.header.auth-type = "indirect")`,
+          NOT (request.header.auth-type = "impersonated") AND
+          NOT(request.header.auth-type = "platform") AND
+          NOT
+          (request.header.auth-type = "indirect")`,
     "valid",
   );
 });

--- a/test/specs/testTruthTableAST.js
+++ b/test/specs/testTruthTableAST.js
@@ -16,6 +16,7 @@
 /* global describe, it */
 
 const assert = require("assert"),
+  expect = require("chai").expect,
   jsonpath = require("jsonpath"),
   debug = require("debug")("apigeelint:TruthTableTest"),
   TruthTable = require("../../lib/package/TruthTable.js"),
@@ -127,5 +128,53 @@ describe("TruthTable AST", function () {
     "$.args[1].args[0].args[0].type": "variable",
     "$.args[1].args[0].args[0].value": "error.status.code",
     "$.args[1].args[1].args[0].value": 399,
+  });
+
+  const testAst = function (exp, expected) {
+    it(`${exp} should parse correctly`, function () {
+      try {
+        var tt = new TruthTable(exp),
+          ast = tt.getAST();
+
+        debug(`ast: ${ast}`);
+      } catch (parseExc) {
+        debug(`expected: ${expected}`);
+        assert.notEqual("ERR_ASSERTION", parseExc.code);
+        debug(`parse Exception: ${JSON.stringify(parseExc)}`);
+        debug(`parse Exception: ${parseExc.stack}`);
+        assert.equal("exception", expected);
+        return;
+      }
+
+      expect(expected).to.deep.equal(ast);
+    });
+  };
+
+  testAst("validJson == true", {
+    action: "equivalence",
+    args: [
+      {
+        action: "substitution",
+        args: [{ type: "variable", value: "validJson" }],
+      },
+      {
+        action: "substitution",
+        args: [{ type: "constant", value: true, varName: "validJson" }],
+      },
+    ],
+  });
+
+  testAst("notValidJson == true", {
+    action: "equivalence",
+    args: [
+      {
+        action: "substitution",
+        args: [{ type: "variable", value: "notValidJson" }],
+      },
+      {
+        action: "substitution",
+        args: [{ type: "constant", value: true, varName: "notValidJson" }],
+      },
+    ],
   });
 });


### PR DESCRIPTION
This fixes issue #551 (for real this time)