### PR TITLE
fix: add one module to depcheck ignores

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "badge": "mocha --reporter mocha-badge-generator",
     "build-condition-parser": "npx mkdirp build && npx peggy -o build/ConditionParser.js lib/peggy/Apigee-Condition.pegjs",
     "coverage": "npx nyc --reporter=text mocha",
-    "depcheck": "npx depcheck . --ignores=depcheck,mocha-lcov-reporter",
+    "depcheck": "npx depcheck . --ignores=depcheck,mocha-lcov-reporter,apigee-jsc-debug",
     "test": "mocha"
   },
   "repository": {


### PR DESCRIPTION
just a small tweak for release hygiene.  No functional  change.
