### PR TITLE
fix: extend a few test timeouts to allow success on slower machines

### DIFF
--- a/test/specs/testUnexpectedExternalPlugins.js
+++ b/test/specs/testUnexpectedExternalPlugins.js
@@ -51,7 +51,7 @@ describe("cli external plugin warning verification", function () {
   });
 
   it("should log a warning for stray files in the external plugins dir", function (done) {
-    this.timeout(38000);
+    this.timeout(58000);
     const opts = {
       cwd: proxyDir,
       encoding: "utf8",

--- a/test/specs/testXmlNodeLabels.js
+++ b/test/specs/testXmlNodeLabels.js
@@ -1,5 +1,5 @@
-/*
-  Copyright 2024 Google LLC
+﻿/*
+  Copyright © 2024-2025 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ describe("xmldom path resolution verification", function () {
   });
 
   it("should find xmldom", function (done) {
-    this.timeout(38000);
+    this.timeout(58000);
     const opts = {
       cwd: proxyDir,
       encoding: "utf8",


### PR DESCRIPTION
Just a few changes in the test code.  No functional difference.