### PR TITLE
fix: state machine for templates is less intrusive

### DIFF
--- a/lib/package/plugins/PO026-assignVariableUsage.js
+++ b/lib/package/plugins/PO026-assignVariableUsage.js
@@ -1,4 +1,4 @@
-/*
+﻿/*
   Copyright 2019-2025 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/package/plugins/_pluginUtil.js
+++ b/lib/package/plugins/_pluginUtil.js
@@ -1,14 +1,29 @@
+﻿// Copyright © 2025 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 const debug = require("debug")("apigeelint:template");
 
 const STATES = {
   UNDEFINED: -1,
-  OUTSIDE_CURLY: 0,
-  INSIDE_CURLY_NO_TEXT: 1,
-  INSIDE_CURLY: 2,
-  INSIDE_VARREF: 3,
-  INSIDE_FNARGS_NO_TEXT: 4,
-  INSIDE_FNARGS: 5,
-  INSIDE_FNARGS_OPEN_QUOTE: 6,
+  OUTSIDE_TEMPLATE: 0,
+  OPEN_CURLY_OR_TEMPLATE: 1,
+  READING_SYMBOL: 2,
+  PENDING_CLOSE_CURLY: 3,
+  PENDING_DBL_CLOSE_CURLY: 4,
+  OPEN_FNARGS: 5,
+  INSIDE_FNARGS: 7,
 };
 
 const CODES = {
@@ -63,6 +78,9 @@ const FUNCTION_NAMES = [
   "decodeBase64",
 ];
 
+const whitespaceRe = new RegExp("\\s");
+const isWhitespace = (c) => whitespaceRe.test(c);
+
 const validateFunction = (expr, start, end) => {
   const fn = expr.substring(start, end);
   if (FUNCTION_NAMES.find((f) => fn == f)) {
@@ -93,10 +111,13 @@ const stateToString = (s) =>
  * returns undefined for valid template. Returns an explanatory string if invalid.
  **/
 const validateTemplate = (expr) => {
-  let state = STATES.OUTSIDE_CURLY;
+  let state = STATES.OUTSIDE_TEMPLATE;
+  let fnarg = STATES.UNDEFINED;
   const states = [];
+  const fnpending = [];
   let code,
-    fnStart = -1,
+    pendingCurlies = 0,
+    symStart = -1,
     argsStart = -1;
   let ix = -1;
   try {
@@ -104,110 +125,174 @@ const validateTemplate = (expr) => {
       ix++;
       debug(`state(${stateToString(state)}) ch(${ch})`);
       switch (state) {
-        case STATES.OUTSIDE_CURLY:
-        case STATES.INSIDE_CURLY:
+        case STATES.OUTSIDE_TEMPLATE:
           if (ch == "{") {
             states.push(state);
-            state = STATES.INSIDE_CURLY_NO_TEXT;
-            fnStart = ix;
-          }
-          if (ch == "}") {
-            if (state == STATES.OUTSIDE_CURLY) {
-              return `unexpected close curly at position ${ix}`;
+            state = STATES.OPEN_CURLY_OR_TEMPLATE;
+            symStart = ix;
+          } else if (ch == "}") {
+            if (pendingCurlies > 0) {
+              pendingCurlies--;
+            } else {
+              debug(
+                `unexpected close curly at position ${ix}, but not an error`,
+              );
             }
-            state = states.pop();
+            // state = states.pop();
           }
           break;
 
-        case STATES.INSIDE_CURLY_NO_TEXT:
+        case STATES.OPEN_CURLY_OR_TEMPLATE:
           if (ch == "}") {
-            return `empty function name at position ${ix}`;
-          }
-          if (ch == "{" || ch == "[" || ch == "(") {
-            return `unexpected character at position ${ix}: ${ch}`;
-          }
-          code = ch.charCodeAt(0);
-          // examine first character. A numeric is invalid.
-          if (code >= CODES.ZERO && code <= CODES.NINE) {
-            return `unexpected character at position ${ix}: ${ch}`;
-          }
-          // a non-alphabetic means it's not a variable or function.
-          else if (
-            !(code >= CODES.UPPER_A && code <= CODES.UPPER_Z) &&
-            !(code >= CODES.LOWER_a && code <= CODES.LOWER_z)
-          ) {
-            state = STATES.INSIDE_CURLY;
+            return `empty template reference at position ${ix}`;
+          } else if (ch == "{") {
+            states.push(state);
+            state = STATES.OPEN_DOUBLE_CURLY;
+          } else if (isWhitespace(ch) || ch == '"' || ch == "'") {
+            // not a template, just a curly. This fn does not parse fully inside non-template curlies.
+            pendingCurlies++;
+            state = STATES.OUTSIDE_TEMPLATE;
           } else {
-            state = STATES.INSIDE_VARREF;
+            // expecting symbol start, or another open curly
+            code = ch.charCodeAt(0);
+            if (
+              ch != "_" &&
+              !(code >= CODES.UPPER_A && code <= CODES.UPPER_Z) &&
+              !(code >= CODES.LOWER_a && code <= CODES.LOWER_z)
+            ) {
+              return `unexpected character at position ${ix}: ${ch}`;
+            }
+            states.push(state);
+            state = STATES.READING_SYMBOL;
           }
           break;
 
-        case STATES.INSIDE_VARREF:
-          if (ch == "{" || ch == "[" || ch == ")") {
+        case STATES.OPEN_DOUBLE_CURLY:
+          if (ch == "}") {
+            state = states.pop();
+            if (state == STATES.OPEN_CURLY_OR_TEMPLATE) {
+              // after final inner close, the only valid thing is another close-curly
+              state = STATES.PENDING_DBL_CLOSE_CURLY;
+            }
+          } else if (ch == "{") {
+            states.push(state);
+            state = STATES.OPEN_DOUBLE_CURLY;
+          }
+          break;
+
+        case STATES.PENDING_CLOSE_CURLY:
+        case STATES.PENDING_DBL_CLOSE_CURLY:
+          if (ch != "}") {
+            debug(
+              `state ${state}, unexpected character at position ${ix}: ${ch}`,
+            );
+            return `unexpected character at position ${ix}: ${ch}`;
+          }
+          state = states.pop();
+          break;
+
+        case STATES.READING_SYMBOL:
+          if (ch == "{" || ch == "[" || ch == ")" || ch == "," || ch == "|") {
+            debug(
+              `state(${stateToString(state)}) ch(${ch}) unexpected char as position ${ix}`,
+            );
             return `unexpected character at position ${ix}: ${ch}`;
           }
           if (ch == "(") {
-            const r = validateFunction(expr, fnStart + 1, ix);
+            const r = validateFunction(expr, symStart + 1, ix);
             if (r.error) {
               return `unsupported function name (${r.fn})`;
             }
             argsStart = ix;
-            state = STATES.INSIDE_FNARGS_NO_TEXT;
+            state = STATES.OPEN_FNARGS;
           }
           if (ch == "}") {
             state = states.pop();
+            if (state != STATES.OPEN_CURLY_OR_TEMPLATE) {
+              return `state error (posn ${ix})`;
+            }
+            state = STATES.OUTSIDE_TEMPLATE;
           }
           break;
 
-        case STATES.INSIDE_FNARGS_NO_TEXT:
-          if (ch == "{" || ch == "[" || ch == "(" || ch == "}" || ch == "]") {
-            return `unexpected character at position ${ix}: ${ch}`;
+        case STATES.OPEN_FNARGS:
+          if (
+            ch == "{" ||
+            ch == "[" ||
+            ch == "(" ||
+            ch == "}" ||
+            ch == "]" ||
+            ch == "," ||
+            ch == "|" ||
+            ch == '"'
+          ) {
+            return `state ${state}, unexpected character at position ${ix}: ${ch}`;
           }
-          if (ch == "'") {
-            state = STATES.INSIDE_FNARGS_OPEN_QUOTE;
-          } else if (ch == ")") {
+          if (ch == ")") {
             const r = validateFunctionArgs(
               expr,
-              fnStart + 1,
+              symStart + 1,
               argsStart + 1,
               ix,
             );
             if (r.error) {
               return `${r.error} for function ${r.fn}`;
             }
-            state = STATES.AWAITING_CLOSE_CURLY;
+            state = states.pop(); // ??
+            state = STATES.PENDING_CLOSE_CURLY;
           } else {
-            state = STATES.INSIDE_FNARGS;
-          }
-          break;
-
-        case STATES.INSIDE_FNARGS_OPEN_QUOTE:
-          if (ch == "'") {
+            if (ch == "'") {
+              debug(`state ${state}, open quote`);
+              fnpending.push("'");
+            }
             state = STATES.INSIDE_FNARGS;
           }
           break;
 
         case STATES.INSIDE_FNARGS:
-          if (ch == "{" || ch == "[" || ch == "(") {
-            return `unexpected character at position ${ix}: ${ch}`;
-          }
-          if (ch == ")") {
-            const r = validateFunctionArgs(
-              expr,
-              fnStart + 1,
-              argsStart + 1,
-              ix,
-            );
-            if (r.error) {
-              return `${r.error} for function ${r.fn}`;
+          debug(`state(${state})  fnargs(${fnpending.join("")}) ch<${ch}>`);
+          if (ch == "[" || ch == "{" || ch == "(") {
+            fnpending.push(ch);
+          } else if (ch == "'" || ch == '"') {
+            if (fnpending.at(-1) == ch) {
+              fnpending.pop();
+            } else {
+              fnpending.push(ch);
             }
-            state = STATES.AWAITING_CLOSE_CURLY;
+          } else if (ch == "]" || ch == "}") {
+            if (
+              (ch == "]" && fnpending.at(-1) == "[") ||
+              (ch == "}" && fnpending.at(-1) == "{")
+            ) {
+              fnpending.pop();
+            } else {
+              return `unexpected ${ch} character at position ${ix}`;
+            }
+          } else if (ch == ")") {
+            if (fnpending.at(-1) == "(") {
+              fnpending.pop();
+            } else if (fnpending.length != 0) {
+              // return `state ${state}, unexpected ${ch} character at position ${ix}. unclosed ${fnpending.at(-1)}?`;
+              return `unterminated open ${fnpending.at(-1)} at position ${ix}`;
+            } else {
+              const r = validateFunctionArgs(
+                expr,
+                symStart + 1,
+                argsStart + 1,
+                ix,
+              );
+              if (r.error) {
+                return `${r.error} for function ${r.fn}`;
+              }
+              state = states.pop(); // ??
+              state = STATES.PENDING_CLOSE_CURLY;
+            }
           }
           break;
 
-        case STATES.AWAITING_CLOSE_CURLY:
+        case STATES.PENDING_CLOSE_CURLY:
           if (ch != "}") {
-            return `unexpected character at position ${ix}: ${ch}`;
+            return `state ${state}, unexpected character at position ${ix}: ${ch}`;
           }
           state = states.pop();
           break;
@@ -224,10 +309,20 @@ const validateTemplate = (expr) => {
     return "extraneous close-brace at position ${ix}";
   }
   debug(`final state(${stateToString(state)})`);
-  if (state == STATES.INSIDE_FNARGS_OPEN_QUOTE) {
-    return "unterminated open quote";
+  if (
+    state == STATES.OUTSIDE_TEMPLATE ||
+    state == STATES.OPEN_CURLY_OR_TEMPLATE
+  ) {
+    return undefined;
   }
-  return state == STATES.OUTSIDE_CURLY ? undefined : "unterminated curly brace";
+  if (
+    state == STATES.READING_SYMBOL ||
+    state == STATES.PENDING_DBL_CLOSE_CURLY
+  ) {
+    return "unterminated curly brace";
+  }
+
+  return `mangled template? (${stateToString(state)})`;
 };
 
 const validatePropertySetRef = (expr) => {

--- a/test/specs/PO026-profile.js
+++ b/test/specs/PO026-profile.js
@@ -1,5 +1,5 @@
-/*
-  Copyright 2019-2024 Google LLC
+﻿/*
+  Copyright 2019-2025 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -202,7 +202,9 @@ describe(`PO026 - AssignVariable with PropertySetRef`, () => {
       JSON.stringify(p.getReport().messages),
     );
   });
+});
 
+describe(`PO026 - AssignVariable with Template`, () => {
   po026Test(`Template-1.xml`, "apigeex", (p, foundIssues) => {
     assert.equal(foundIssues, false);
     assert.ok(p.getReport().messages, "messages undefined");

--- a/test/specs/testTemplateCheck.js
+++ b/test/specs/testTemplateCheck.js
@@ -1,4 +1,4 @@
-/*
+﻿/*
   Copyright 2019-2023,2025 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,16 +21,16 @@ const assert = require("assert"),
 
 describe("TemplateCheck", function () {
   const testCases = [
-    ["{}", "empty function name at position 1"],
+    ["{}", "empty template reference at position 1"],
     ["{a}", undefined],
-    ["{{a}", "unexpected character at position 1: {"],
-    ["{{a}}", "unexpected character at position 1: {"],
+    ["{{a}", "unterminated curly brace"],
+    ["{{a}}", undefined], // dbl curly just means ... curly
     ["{[]}", "unexpected character at position 1: ["],
     ["{a[]}", "unexpected character at position 2: ["],
     ["{a", "unterminated curly brace"],
-    ["}a", "unexpected close curly at position 0"],
-    ["{a}}", "unexpected close curly at position 3"],
-    ["}a{", "unexpected close curly at position 0"],
+    ["}a", undefined], // but useless and sloppy
+    ["{a}}", undefined], // but sloppy
+    ["}a{", undefined], // but weird
     ["{a}b", undefined],
     ["{a}{b}", undefined],
     ["{a}.{b}", undefined],
@@ -61,9 +61,12 @@ describe("TemplateCheck", function () {
     ["{timeFormatUTCMs()}", "empty arg string for function timeFormatUTCMs"],
     ["{notARealfunction()}", "unsupported function name (notARealfunction)"],
     ["{createUuid[]}", "unexpected character at position 11: ["],
-    ["{ createUuid() }", undefined], // but ineffective
+    ["{ createUuid() }", undefined], // but ineffective and misleading
     ["{jsonPath('$.quota.[*].appname',jsondata)}", undefined],
-    ["{jsonPath('$.quota.[*].appname,jsondata)}", "unterminated open quote"],
+    [
+      "{jsonPath('$.quota.[*].appname,jsondata)}",
+      "unterminated open ' at position 39",
+    ],
   ];
 
   testCases.forEach((item, _ix) => {


### PR DESCRIPTION
PO026 was a little over-intrusive for some kinds of message templates. For example, it would  incorrectly flag these working templates as faulty :

- `{jsonPath($.results[?(@.name == 'Mae West')][0].address.line1,json_value_1)}`
- `{xeger('[0-9]{12}')}`
- `{replaceFirst(messageid,'[0-9]','X')}`

This change fixes the problem.
