### PR TITLE
feat: support .cjs files for external plugins

### DIFF
--- a/lib/package/bundleLinter.js
+++ b/lib/package/bundleLinter.js
@@ -60,8 +60,10 @@ function exportReport(providedPath, stringifiedReport) {
 const internalPluginIdRe = new RegExp("^[A-Z]{2}[0-9]{3}$");
 const internalPluginFileRe = new RegExp("^[A-Z]{2}[0-9]{3}-.+\\.js$");
 const externalPluginIdRe = new RegExp("^EX-[A-Z]{2}[0-9]{3}$");
-const externalPluginFileRe = new RegExp("^EX-[A-Z]{2}[0-9]{3}-.+\\.js$");
+const externalPluginFileRe = new RegExp("^EX-[A-Z]{2}[0-9]{3}-.+\\.(js|cjs)$");
 const nonlibrarySourceRe = new RegExp("^_.+\\.js$");
+
+const endsWithJsOrCjs = (s) => s.endsWith(".js") || s.endsWith(".cjs");
 
 /* exposed for testing */
 const getPluginResolver = (d, isInternal) => (idOrFilename) => {
@@ -102,9 +104,9 @@ const listPlugins = () =>
 const listExternalPlugins = (d) =>
   fs.readdirSync(d).filter((fname) => {
     const isNameMatch = externalPluginFileRe.test(fname);
-    if (fname.endsWith(".js") && !isNameMatch && !fname.startsWith("_")) {
+    if (endsWithJsOrCjs(fname) && !isNameMatch && !fname.startsWith("_")) {
       console.warn(
-        `Unexpected .js file in external plugins directory: ${fname}`,
+        `Unexpected .js/.cjs file in external plugins directory: ${fname}`,
       );
     }
     return isNameMatch;

--- a/test/specs/testUnexpectedExternalPlugins.js
+++ b/test/specs/testUnexpectedExternalPlugins.js
@@ -109,7 +109,7 @@ describe("cli external plugin warning verification", function () {
           assert.equal(code, 0, "return status code");
           assert.ok(
             aggregatedErrorOutput.startsWith(
-              "Unexpected .js file in external plugins directory:",
+              "Unexpected .js/.cjs file in external plugins directory:",
             ),
             "error messages",
           );


### PR DESCRIPTION
At the moment, external plugins for Apigeelint must be `.js` files. It would be convenient to allow them to be `.cjs` files so that ESM codebases that use Apigeelint as a dependency require no extra configuration to write external plugins (for instance, if you want to write a Typescript ESM repository with some apigeelint external plugins).