### PR TITLE
fix: correct license field in package.json (Apache-2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/apigee/apigeelint"
   },
   "keywords": ["API", "bundle", "lint", "linter", "Apigee", "Edge"],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/apigee/apigeelint/issues"
   },


### PR DESCRIPTION
This changes only the license field in the package.json file.  Not sure how, but it seems it was wrong for a long time. 