### PR TITLE
test: add cases for issue594, variables containing dots for ST003/4/5

### DIFF
--- a/test/fixtures/resources/ExtractVariables-Attachment/apiproxy/policies/EV-JSONPayload-6.xml
+++ b/test/fixtures/resources/ExtractVariables-Attachment/apiproxy/policies/EV-JSONPayload-6.xml
@@ -1,0 +1,9 @@
+<ExtractVariables name="EV-JSONPayload-6">
+  <Source>private.tokenexchangeResponse</Source>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+  <JSONPayload>
+    <Variable name="accesstoken">
+      <JSONPath>$.accesstoken</JSONPath>
+    </Variable>
+  </JSONPayload>
+</ExtractVariables>

--- a/test/fixtures/resources/ExtractVariables-Attachment/apiproxy/policies/EV-XMLPayload-private-scResponse.xml
+++ b/test/fixtures/resources/ExtractVariables-Attachment/apiproxy/policies/EV-XMLPayload-private-scResponse.xml
@@ -1,0 +1,12 @@
+<ExtractVariables name="EV-XMLPayload-private-scResponse">
+   <Source>private.scResponse</Source>
+   <XMLPayload>
+     <Namespaces>
+       <Namespace prefix='soap'>http://schemas.xmlsoap.org/soap/envelope/</Namespace>
+     </Namespaces>
+     <Variable name='topLevelResponseElement' type='string'>
+       <XPath>local-name(/soap:Envelope/soap:Body/*[1])</XPath>
+     </Variable>
+   </XMLPayload>
+   <VariablePrefix>soapresponse</VariablePrefix>
+</ExtractVariables>

--- a/test/fixtures/resources/ExtractVariables-Attachment/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/ExtractVariables-Attachment/apiproxy/proxies/endpoint1.xml
@@ -155,6 +155,40 @@
       <Condition>(proxy.pathsuffix MatchesPath "/json-5") and (request.verb = "GET") and (response.content != null)</Condition>
     </Flow>
 
+    <Flow name="flow-json-6">
+      <!-- ST003: no error; a suitable check is present using a variable
+           containing dots (issue 594) -->
+      <!-- ST004: no error, EV does not extract from XMLPayload -->
+      <!-- ST005: no error, EV does not extract from FormParam -->
+      <Response>
+        <Step>
+          <Condition>
+            private.tokenexchangeResponse.content != null
+          </Condition>
+          <Name>EV-JSONPayload-6</Name>
+        </Step>
+      </Response>
+      <Condition>(proxy.pathsuffix MatchesPath "/json-6") and (request.verb = "GET")</Condition>
+    </Flow>
+
+    <Flow name="flow-json-6a">
+      <!-- ST003: ERROR; no suitable check is present using a variable
+           containing dots (issue 594) -->
+      <!-- ST004: no error, EV does not extract from XMLPayload -->
+      <!-- ST005: no error, EV does not extract from FormParam -->
+      <Response>
+        <Step>
+          <!--
+          <Condition>
+            private.tokenexchangeResponse.content != null
+          </Condition>
+          -->
+          <Name>EV-JSONPayload-6</Name>
+        </Step>
+      </Response>
+      <Condition>(proxy.pathsuffix MatchesPath "/json-6a") and (request.verb = "GET")</Condition>
+    </Flow>
+
 
     <Flow name="flow-xml-1">
       <!-- ST003: no error, EV does not extract from JSONPayload -->
@@ -242,7 +276,33 @@
           <Name>EV-XMLPayload-scResponse</Name>
         </Step>
       </Response>
-      <Condition>(proxy.pathsuffix MatchesPath "/xml-6") and (request.verb = "GET")</Condition>
+      <Condition>(proxy.pathsuffix MatchesPath "/xml-7") and (request.verb = "GET")</Condition>
+    </Flow>
+
+    <Flow name="flow-xml-8">
+      <!-- ST003: no error, EV does not extract from JSONPayload -->
+      <!-- ST004: no error, appropriate condition (issue 594) -->
+      <!-- ST005: no error, EV does not extract from FormParam -->
+      <Response>
+        <Step>
+          <Condition>private.scResponse.content != null</Condition>
+          <Name>EV-XMLPayload-private-scResponse</Name>
+        </Step>
+      </Response>
+      <Condition>(proxy.pathsuffix MatchesPath "/xml-8") and (request.verb = "GET")</Condition>
+    </Flow>
+
+    <Flow name="flow-xml-8a">
+      <!-- ST003: no error, EV does not extract from JSONPayload -->
+      <!-- ST004: ERROR, no appropriate condition (issue 594) -->
+      <!-- ST005: no error, EV does not extract from FormParam -->
+      <Response>
+        <Step>
+          <Condition>scResponse.content != null</Condition> <!-- wrong variable -->
+          <Name>EV-XMLPayload-private-scResponse</Name>
+        </Step>
+      </Response>
+      <Condition>(proxy.pathsuffix MatchesPath "/xml-8a") and (request.verb = "GET")</Condition>
     </Flow>
 
 

--- a/test/specs/ST003-ev-json-condition.js
+++ b/test/specs/ST003-ev-json-condition.js
@@ -1,5 +1,5 @@
-/*
-  Copyright 2019-2022 Google LLC
+﻿/*
+Copyright © 2019-2022,2026 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,76 +17,87 @@
 /* global describe, it */
 
 const assert = require("assert"),
-      ruleId = 'ST003',
-      path = require("path"),
-      debug = require("debug")(`apigeelint:${ruleId}`),
-      util = require("util"),
-      bl = require("../../lib/package/bundleLinter.js");
+  ruleId = "ST003",
+  path = require("path"),
+  debug = require("debug")(`apigeelint:${ruleId}`),
+  util = require("util"),
+  bl = require("../../lib/package/bundleLinter.js");
 
-const expectedMessageRe =
-  new RegExp("^For the ExtractVariables step \\([-A-Za-z0-9_]{2,}\\), an appropriate check for a message body was not found\\..*");
+const expectedMessageRe = new RegExp(
+  "^For the ExtractVariables step \\([-A-Za-z0-9_]{2,}\\), an appropriate check for a message body was not found\\..*",
+);
 
 describe(`${ruleId} - ExtractVariables JSONPayload Conditions`, () => {
   function check(suffix, bundleType, expected) {
     let configuration = {
-          debug: true,
-          source: {
-            type: "filesystem",
-            path: path.resolve(__dirname, `../fixtures/resources/ExtractVariables-Attachment/${bundleType}`),
-            bundleType
-          },
-          excluded: {},
-          setExitCode: false,
-          output: () => {} // suppress output
-        };
+      debug: true,
+      source: {
+        type: "filesystem",
+        path: path.resolve(
+          __dirname,
+          `../fixtures/resources/ExtractVariables-Attachment/${bundleType}`,
+        ),
+        bundleType,
+      },
+      excluded: {},
+      setExitCode: false,
+      output: () => {}, // suppress output
+    };
 
     bl.lint(configuration, (bundle) => {
       let items = bundle.getReport();
       assert.ok(items);
       assert.ok(items.length);
       debug(util.format(items));
-      let sfItems = items.filter( m => m.filePath.endsWith(suffix));
+      let sfItems = items.filter((m) => m.filePath.endsWith(suffix));
       debug(util.format(sfItems));
       assert.equal(sfItems.length, 1);
-      sfItems.forEach( item =>
-                       debug(util.format(item.messages)));
-      let st003Messages = sfItems[0].messages.filter( m => m.ruleId == ruleId);
+      sfItems.forEach((item) => debug(util.format(item.messages)));
+      let st003Messages = sfItems[0].messages.filter((m) => m.ruleId == ruleId);
       debug(util.format(st003Messages));
       assert.equal(st003Messages.length, expected.length);
 
-      expected.forEach( (item, ix) => {
+      expected.forEach((item, ix) => {
         assert.equal(st003Messages[ix].line, item.line, `case(${ix}) line`);
-        assert.equal(st003Messages[ix].column, item.column, `case(${ix}) column`);
+        assert.equal(
+          st003Messages[ix].column,
+          item.column,
+          `case(${ix}) column`,
+        );
         assert.equal(st003Messages[ix].severity, 1, `case(${ix}) severity`);
-        assert.ok(st003Messages[ix].message.match(expectedMessageRe), `case(${ix}) message`);
+        assert.ok(
+          st003Messages[ix].message.match(expectedMessageRe),
+          `case(${ix}) message`,
+        );
       });
     });
   }
 
-  it('should find the expected warnings in an apiproxy', () => {
+  it("should find the expected warnings in an apiproxy", () => {
     let expected = [
-          {
-            line: 100,
-            column: 9
-          },
-          {
-            line: 112,
-            column: 9
-          },
-          {
-            line: 125,
-            column: 9
-          }
-        ];
+      {
+        line: 100,
+        column: 9,
+      },
+      {
+        line: 112,
+        column: 9,
+      },
+      {
+        line: 125,
+        column: 9,
+      },
+      {
+        line: 180,
+        column: 9,
+      },
+    ];
 
-    check('endpoint1.xml', 'apiproxy', expected);
+    check("endpoint1.xml", "apiproxy", expected);
   });
 
-  it('should find the expected warnings in a sharedflow', () => {
-    let expected = [
-          { line: 5, column: 3 }
-        ];
-    check('sf-default.xml', 'sharedflowbundle', expected);
+  it("should find the expected warnings in a sharedflow", () => {
+    let expected = [{ line: 5, column: 3 }];
+    check("sf-default.xml", "sharedflowbundle", expected);
   });
-
 });

--- a/test/specs/ST004-ev-xml-condition.js
+++ b/test/specs/ST004-ev-xml-condition.js
@@ -1,5 +1,5 @@
-/*
-  Copyright 2019-2022 Google LLC
+﻿/*
+Copyright © 2019-2022,2026 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,88 +17,107 @@
 /* global describe, it */
 
 const assert = require("assert"),
-      ruleId = 'ST004',
-      path = require("path"),
-      debug = require("debug")(`apigeelint:${ruleId}`),
-      util = require("util"),
-      bl = require("../../lib/package/bundleLinter.js");
+  ruleId = "ST004",
+  path = require("path"),
+  debug = require("debug")(`apigeelint:${ruleId}`),
+  util = require("util"),
+  bl = require("../../lib/package/bundleLinter.js");
 
-const expectedMessageRe =
-  new RegExp("^For the ExtractVariables step \\([-A-Za-z0-9_]{2,}\\), an appropriate check for a message body was not found\\..*");
+const expectedMessageRe = new RegExp(
+  "^For the ExtractVariables step \\([-A-Za-z0-9_]{2,}\\), an appropriate check for a message body was not found\\..*",
+);
 
 describe(`${ruleId} - ExtractVariables XMLPayload Conditions`, () => {
   function check(suffix, bundleType, expected) {
     let configuration = {
-          debug: true,
-          source: {
-            type: "filesystem",
-            path: path.resolve(__dirname, `../fixtures/resources/ExtractVariables-Attachment/${bundleType}`),
-            bundleType
-          },
-          excluded: {},
-          setExitCode: false,
-          output: () => {} // suppress output
-        };
+      debug: true,
+      source: {
+        type: "filesystem",
+        path: path.resolve(
+          __dirname,
+          `../fixtures/resources/ExtractVariables-Attachment/${bundleType}`,
+        ),
+        bundleType,
+      },
+      excluded: {},
+      setExitCode: false,
+      output: () => {}, // suppress output
+    };
 
     bl.lint(configuration, (bundle) => {
       let items = bundle.getReport();
       assert.ok(items);
       assert.ok(items.length);
-      debug('all items: ' + util.format(items));
-      let itemsForFileOfInterest = items.filter( m => m.filePath.endsWith(suffix));
-      debug('items for that filepath: ' + util.format(itemsForFileOfInterest));
+      debug("all items: " + util.format(items));
+      let itemsForFileOfInterest = items.filter((m) =>
+        m.filePath.endsWith(suffix),
+      );
+      debug("items for that filepath: " + util.format(itemsForFileOfInterest));
       assert.equal(itemsForFileOfInterest.length, 1);
       // itemsForFileOfInterest.forEach( item =>
       //                  debug(util.format(item.messages)));
-      let st004Messages = itemsForFileOfInterest[0].messages.filter( m => m.ruleId == ruleId);
+      let st004Messages = itemsForFileOfInterest[0].messages.filter(
+        (m) => m.ruleId == ruleId,
+      );
 
-      debug(`ST004 messages (${st004Messages.length}): ` + util.format(st004Messages));
+      debug(
+        `ST004 messages (${st004Messages.length}): ` +
+          util.format(st004Messages),
+      );
       assert.equal(st004Messages.length, expected.length);
 
-      expected.forEach( (item, ix) => {
+      expected.forEach((item, ix) => {
         assert.equal(st004Messages[ix].line, item.line, `case(${ix}) line`);
-        assert.equal(st004Messages[ix].column, item.column, `case(${ix}) column`);
+        assert.equal(
+          st004Messages[ix].column,
+          item.column,
+          `case(${ix}) column`,
+        );
         assert.equal(st004Messages[ix].severity, 1, `case(${ix}) severity`);
-        assert.ok(st004Messages[ix].message.match(expectedMessageRe), `case(${ix}) message`);
+        assert.ok(
+          st004Messages[ix].message.match(expectedMessageRe),
+          `case(${ix}) message`,
+        );
       });
     });
   }
 
-  it('should generate the expected warnings in an apiproxy', () => {
+  it("should generate the expected warnings in an apiproxy", () => {
     let expected = [
-            {
-              line: 29,
-              column: 7
-            },
-            {
-              line: 38,
-              column: 7
-            },
-            {
-              line: 164,
-              column: 9
-            },
-            {
-              line: 176,
-              column: 9
-            },
-            {
-              line: 189,
-              column: 9
-            },
-            {
-              line: 240,
-              column: 9
-            }
-          ];
-    check('endpoint1.xml', 'apiproxy', expected);
+      {
+        line: 29,
+        column: 7,
+      },
+      {
+        line: 38,
+        column: 7,
+      },
+      {
+        line: 198,
+        column: 9,
+      },
+      {
+        line: 210,
+        column: 9,
+      },
+      {
+        line: 223,
+        column: 9,
+      },
+      {
+        line: 274,
+        column: 9,
+      },
+      {
+        line: 300,
+        column: 9,
+      },
+    ];
+    check("endpoint1.xml", "apiproxy", expected);
   });
 
-  it('should find the expected warnings in a sharedflow', () => {
-    let expected = [
-          { line: 12, column: 3 }
-        ];
-    check('sf-default.xml', 'sharedflowbundle', expected);
+  it("should find the expected warnings in a sharedflow", () => {
+    let expected = [{ line: 12, column: 3 }];
+    check("sf-default.xml", "sharedflowbundle", expected);
   });
-
 });

--- a/test/specs/ST005-ev-form-condition.js
+++ b/test/specs/ST005-ev-form-condition.js
@@ -1,5 +1,5 @@
-/*
-  Copyright 2019-2022 Google LLC
+﻿/*
+Copyright © 2019-2022,2026 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -17,84 +17,101 @@
 /* global describe, it */
 
 const assert = require("assert"),
-      ruleId = 'ST005',
-      path = require("path"),
-      debug = require("debug")(`apigeelint:${ruleId}`),
-      util = require("util"),
-      bl = require("../../lib/package/bundleLinter.js");
+  ruleId = "ST005",
+  path = require("path"),
+  debug = require("debug")(`apigeelint:${ruleId}`),
+  util = require("util"),
+  bl = require("../../lib/package/bundleLinter.js");
 
-const expectedMessageRe =
-  new RegExp("For the ExtractVariables step \\([-A-Za-z0-9_]{2,}\\), an appropriate check for a message body was not found.");
+const expectedMessageRe = new RegExp(
+  "For the ExtractVariables step \\([-A-Za-z0-9_]{2,}\\), an appropriate check for a message body was not found.",
+);
 
 describe(`${ruleId} - ExtractVariables XMLPayload Conditions`, () => {
   function check(suffix, bundleType, expected) {
     let configuration = {
-          debug: true,
-          source: {
-            type: "filesystem",
-            path: path.resolve(__dirname, `../fixtures/resources/ExtractVariables-Attachment/${bundleType}`),
-            bundleType
-          },
-          excluded: {},
-          setExitCode: false,
-          output: () => {} // suppress output
-        };
+      debug: true,
+      source: {
+        type: "filesystem",
+        path: path.resolve(
+          __dirname,
+          `../fixtures/resources/ExtractVariables-Attachment/${bundleType}`,
+        ),
+        bundleType,
+      },
+      excluded: {},
+      setExitCode: false,
+      output: () => {}, // suppress output
+    };
 
     bl.lint(configuration, (bundle) => {
       let items = bundle.getReport();
       assert.ok(items);
       assert.ok(items.length);
-      debug('all items: ' + util.format(items));
-      let itemsForFileOfInterest = items.filter( m => m.filePath.endsWith(suffix));
-      debug('items for that filepath: ' + util.format(itemsForFileOfInterest));
+      debug("all items: " + util.format(items));
+      let itemsForFileOfInterest = items.filter((m) =>
+        m.filePath.endsWith(suffix),
+      );
+      debug("items for that filepath: " + util.format(itemsForFileOfInterest));
       assert.equal(itemsForFileOfInterest.length, 1);
 
-      itemsForFileOfInterest.forEach( (item, ix) =>
-                                      debug(`item ${ix}: ` + util.format(item.messages)));
+      itemsForFileOfInterest.forEach((item, ix) =>
+        debug(`item ${ix}: ` + util.format(item.messages)),
+      );
 
-      let st005Messages = itemsForFileOfInterest[0].messages.filter( m => m.ruleId == ruleId);
-      debug(`ST005 messages (${st005Messages.length}): ` + util.format(st005Messages));
+      let st005Messages = itemsForFileOfInterest[0].messages.filter(
+        (m) => m.ruleId == ruleId,
+      );
+      debug(
+        `ST005 messages (${st005Messages.length}): ` +
+          util.format(st005Messages),
+      );
       assert.equal(st005Messages.length, expected.length);
-      expected.forEach( (item, ix) => {
+      expected.forEach((item, ix) => {
         assert.equal(st005Messages[ix].line, item.line, `case(${ix}) line`);
-        assert.equal(st005Messages[ix].column, item.column, `case(${ix}) column`);
+        assert.equal(
+          st005Messages[ix].column,
+          item.column,
+          `case(${ix}) column`,
+        );
         assert.equal(st005Messages[ix].severity, 1, `case(${ix}) severity`);
-        assert.ok(st005Messages[ix].message.match(expectedMessageRe), `case(${ix}) message`);
+        assert.ok(
+          st005Messages[ix].message.match(expectedMessageRe),
+          `case(${ix}) message`,
+        );
       });
-
     });
   }
 
-  it('should generate the expected warnings in an apiproxy', () => {
-      let expected = [
-            {
-              line: 48,
-              column: 7
-            },
-            {
-              line: 54,
-              column: 7
-            },
-            {
-              line: 72,
-              column: 7
-            },
-            {
-              line: 254,
-              column: 9
-            }
-          ];
-    check('endpoint1.xml', "apiproxy", expected);
+  it("should generate the expected warnings in an apiproxy", () => {
+    let expected = [
+      {
+        line: 48,
+        column: 7,
+      },
+      {
+        line: 54,
+        column: 7,
+      },
+      {
+        line: 72,
+        column: 7,
+      },
+      {
+        line: 314,
+        column: 9,
+      },
+    ];
+    check("endpoint1.xml", "apiproxy", expected);
   });
 
-  it('should generate the expected warnings in a sharedflow', () => {
-      let expected = [
-            {
-              line: 36,
-              column: 3
-            }
-          ];
-    check('sf-default.xml', "sharedflowbundle", expected);
+  it("should generate the expected warnings in a sharedflow", () => {
+    let expected = [
+      {
+        line: 36,
+        column: 3,
+      },
+    ];
+    check("sf-default.xml", "sharedflowbundle", expected);
   });
-
 });


### PR DESCRIPTION
This is a test-only change; it introduces new test cases for ST004 and ST004 to check the cases in which the name of the variable referenced in the ExtractVariables policy contains a dot.  Eg, `private.tokenexchangeResponse` . 

The rules for ST003, ST004, and ST005 (for JS, XML, and FORM payloads) require that when an ExtractVariables policy operates on a payload, there must be a check in the flow for the existence of the `.content` property of the message referenced in the policy. 

Issue #594 asserts that the existing check, because it relies on the `\b` word boundary regex sequence, does not handle variable names containing dots.  In the tests added as part of this PR, I do not see that behavior. 
