### PR TITLE
feat: CC008 unique names & conditions on Flows/RouteRules/FaultRules

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,6 +513,7 @@ This is the current list:
 | &nbsp; |:white_check_mark:| CC005 | unterminated strings in Condition |  Strings within a Condition element must be properly wrapped by double quotes. |
 | &nbsp; |:white_check_mark:| CC006 | Detect logical absurdities |  Conditions should not have internal logic conflicts - warn when these are detected. |
 | &nbsp; |:white_check_mark:| CC007 | Check validity of expression syntax | Condition expressions should use valid syntax. No single quotes, no extraneous or unmatched parens, etc. |
+| &nbsp; |:white_check_mark:| CC008 | Condition Uniqueness | The conditions on Conditional flows, FaultRules, and RouteRules must be unique. |
 | Endpoints | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| EP001 | CORS Policy attachment | Check for multiple CORS policies, or attachment to Target Endpoint. |
 | &nbsp; |:white_check_mark:| EP002 | Misplaced Elements | Check for commonly misplaced configuration elements in Proxy and Target Endpoints. |

--- a/lib/package/RouteRule.js
+++ b/lib/package/RouteRule.js
@@ -1,4 +1,4 @@
-/*
+﻿/*
   Copyright 2019, 2025 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@ class RouteRule extends ConfigElement {
 
   getName() {
     if (!this.name) {
-      let attr = xpath.select("//@name", this.element);
+      let attr = xpath.select("@name", this.element);
       this.name = (attr[0] && attr[0].value) || "";
     }
     return this.name;

--- a/lib/package/plugins/CC008-conditional-flows-unique-conditions.js
+++ b/lib/package/plugins/CC008-conditional-flows-unique-conditions.js
@@ -1,0 +1,158 @@
+﻿/*
+  Copyright © 2019-2026 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const ruleId = require("../lintUtil.js").getRuleId();
+
+const plugin = {
+  ruleId,
+  name: "Uniqueness of conditions in Flows, FaultRules, and RouteRules",
+  message: "Each condition must be unique.  Error if duplicates.",
+  fatal: true,
+  severity: 2, //2= error
+  nodeType: "Endpoint",
+  enabled: true,
+};
+const parser = require("../../../build/ConditionParser.js");
+const conditionComparison = require("./_conditionComparison.js");
+const debug = require("debug")(`apigeelint:${ruleId}`);
+const util = require("node:util");
+
+const checkDuplicateConditions = function (
+  flag,
+  endpoint,
+  flowsOrRules,
+  label,
+) {
+  debug(`endpoint (${endpoint.getName()})  ${flowsOrRules.length} ${label}`);
+  const withConditions = flowsOrRules.filter(
+    (f) => f.getCondition() && f.getCondition().getExpression() !== "",
+  );
+
+  const shortLabel = (() => {
+    let parts = label.split(" ");
+    return parts[parts.length - 1];
+  })();
+
+  if (withConditions.length > 0) {
+    let seen = {};
+    debug(
+      `endpoint (${endpoint.getName()})  ${withConditions.length} ${label} with Condition`,
+    );
+
+    withConditions.forEach((flow) => {
+      debug(
+        `name(${flow.getName()}) expr(${flow.getCondition().getExpression()})`,
+      );
+
+      if (seen[flow.getName()]) {
+        flag(
+          flow,
+          `Duplicate name on ${label}: ${flow.getName()} (see previous on line ${seen[flow.getName()].sourceLine}).`,
+        );
+      } else {
+        debug(`name(${flow.getName()}) unique name`);
+        const expr = flow.condition.getExpression().trim();
+        try {
+          const current = parser.parse(expr);
+          const canonicalCurrent = conditionComparison.canonicalize(current);
+          // record that this has been seen
+          seen[flow.getName()] = {
+            parsedExpr: current,
+            sourceLine: flow.getElement().lineNumber,
+          };
+          // check whether this expression is equivalent to any existing expression.
+          debug(`parsed: ${util.format(current)}`);
+          const repeat = Object.keys(seen).find((key) => {
+            const previous = seen[key];
+            return (
+              previous.c14n &&
+              canonicalCurrent.signature == previous.c14n.signature
+            );
+          });
+          if (repeat) {
+            flag(
+              flow,
+              `Logically equivalent conditions, ${shortLabel} ${flow.getName()} and ${repeat} (starting on line ${seen[repeat].sourceLine}).`,
+            );
+          } else {
+            debug(`name(${flow.getName()}) not a repeat `);
+            seen[flow.getName()].c14n = canonicalCurrent;
+          }
+        } catch (e) {
+          // Nothing to do here.
+          // Bad expression syntax is caught by a different lint plugin.
+          debug(`ERROR while parsing condition expression: ` + util.format(e));
+        }
+      }
+    });
+  }
+};
+
+const searchConditionalFlowsInEndpoint = function (endpoint) {
+  let flagged = false;
+  const flag = (flow, message) => {
+    flagged = true;
+    endpoint.addMessage({
+      source: flow.getSource(),
+      line: flow.getElement().lineNumber,
+      column: flow.getElement().columnNumber,
+      plugin,
+      message,
+    });
+  };
+  checkDuplicateConditions(
+    flag,
+    endpoint,
+    endpoint.getFlows(),
+    "Conditional Flows",
+  );
+  checkDuplicateConditions(
+    flag,
+    endpoint,
+    endpoint.getFaultRules(),
+    "FaultRules",
+  );
+
+  // RouteRules apply only in ProxyEndpoints
+  const routeRules = endpoint.getRouteRules();
+  if (routeRules) {
+    checkDuplicateConditions(flag, endpoint, routeRules, "RouteRules");
+  }
+
+  return flagged;
+};
+
+const onProxyEndpoint = function (endpoint, cb) {
+  const flagged = searchConditionalFlowsInEndpoint(endpoint);
+  if (typeof cb == "function") {
+    cb(null, flagged);
+  }
+  return flagged;
+};
+
+const onTargetEndpoint = function (endpoint, cb) {
+  const flagged = searchConditionalFlowsInEndpoint(endpoint);
+  if (typeof cb == "function") {
+    cb(null, flagged);
+  }
+  return flagged;
+};
+
+module.exports = {
+  plugin,
+  onProxyEndpoint,
+  onTargetEndpoint,
+};

--- a/lib/package/plugins/_conditionComparison.js
+++ b/lib/package/plugins/_conditionComparison.js
@@ -1,0 +1,148 @@
+﻿// Copyright © 2026 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+const debug = require("debug")("apigeelint:condition");
+
+const headerVarRe = new RegExp(
+  "^([a-zA-z0-9_][-a-zA-z0-9_]*)\\.header\\.([a-zA-z0-9_][-a-zA-z0-9_]*)$",
+);
+
+/*
+ * Transform to Negation Normal Format.  This logic
+ * normalizes "NOT (A OR B) into "NOT(A) and NOT(B)".
+ **/
+function toNNF(node) {
+  // Base case: Literals/Strings
+  if (typeof node === "string") return node;
+
+  const { operator, operands } = node;
+
+  // Handle Negations
+  if (operator === "NOT") {
+    const child = operands[0];
+
+    // Double Negation: NOT(NOT(A)) => A
+    if (child.operator === "NOT") {
+      return toNNF(child.operands[0]);
+    }
+
+    // De Morgan: NOT(A AND B) => (NOT A) OR (NOT B)
+    if (child.operator === "AND") {
+      return toNNF({
+        operator: "OR",
+        operands: child.operands.map((op) => ({
+          operator: "NOT",
+          operands: [op],
+        })),
+      });
+    }
+
+    // De Morgan: NOT(A OR B) => (NOT A) AND (NOT B)
+    if (child.operator === "OR") {
+      return toNNF({
+        operator: "AND",
+        operands: child.operands.map((op) => ({
+          operator: "NOT",
+          operands: [op],
+        })),
+      });
+    }
+
+    // If it's a leaf we can't simplify further
+    return { operator, operands: [toNNF(child)] };
+  }
+
+  // String comparisons may take variables referring to headers.
+  // In that case, normalize header names to uppercase.
+  if (
+    [
+      "EqualsCaseInsensitive",
+      "Equals",
+      "NotEquals",
+      "StartsWith",
+      "Matches",
+      "MatchesPath",
+      "JavaRegex",
+    ].includes(operator)
+  ) {
+    let m = headerVarRe.exec(operands[0]); // left operand
+    if (m) {
+      operands[0] = `${m[1]}.header.${m[2].toUpperCase()}`;
+    }
+  }
+
+  // normalize NotEquals to Not(Equals):  (A != B) => NOT(A = B)
+  if (operator === "NotEquals") {
+    return {
+      operator: "NOT",
+      operands: [
+        {
+          operator: "Equals",
+          operands,
+        },
+      ],
+    };
+  }
+
+  // Standard AND/OR (Just recurse)
+  return {
+    operator,
+    operands: operands.map(toNNF),
+  };
+}
+
+function canonicalize(node) {
+  // Convert to NNF first to handle De Morgan's and NOTs
+  const nnfNode = toNNF(node);
+
+  function process(n) {
+    if (typeof n === "string") {
+      return { node: n, signature: n };
+    }
+
+    let ops = n.operands.map(process);
+
+    // Flattening (Associativity)
+    if (n.operator === "AND" || n.operator === "OR") {
+      ops = ops.flatMap((child) =>
+        child.node.operator === n.operator
+          ? child.node.operands.map(process)
+          : [child],
+      );
+
+      // commutativity
+      ops.sort((a, b) => a.signature.localeCompare(b.signature));
+    }
+
+    const finalOperands = ops.map((o) => o.node);
+    const finalSig = `${n.operator}(${ops.map((o) => o.signature).join(",")})`;
+
+    return {
+      node: { operator: n.operator, operands: finalOperands },
+      signature: finalSig,
+    };
+  }
+
+  return process(nnfNode);
+}
+
+function equivalent(expr1, expr2) {
+  return canonicalize(expr1).signature === canonicalize(expr2).signature;
+}
+
+module.exports = {
+  equivalent,
+  canonicalize,
+};

--- a/test/fixtures/resources/CC008/apiproxy/CC008.xml
+++ b/test/fixtures/resources/CC008/apiproxy/CC008.xml
@@ -1,0 +1,6 @@
+<APIProxy revision="2" name="CC008">
+    <DisplayName></DisplayName>
+    <Description></Description>
+    <CreatedAt>1621009025657</CreatedAt>
+    <LastModifiedAt>1621009262854</LastModifiedAt>
+</APIProxy>

--- a/test/fixtures/resources/CC008/apiproxy/policies/AM-Inject-Proxy-Version-Header.xml
+++ b/test/fixtures/resources/CC008/apiproxy/policies/AM-Inject-Proxy-Version-Header.xml
@@ -1,0 +1,7 @@
+<AssignMessage name="AM-Inject-Proxy-Version-Header">
+  <Set>
+    <Headers>
+      <Header name="APIProxy">{apiproxy.name} r{apiproxy.revision}</Header>
+    </Headers>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/CC008/apiproxy/policies/AM-Override-Message-1.xml
+++ b/test/fixtures/resources/CC008/apiproxy/policies/AM-Override-Message-1.xml
@@ -1,0 +1,7 @@
+<AssignMessage name="AM-Override-Message-1">
+  <Set>
+    <Payload contentType="text/plain">
+Overridden message 1
+</Payload>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/CC008/apiproxy/policies/AM-Override-Message-2.xml
+++ b/test/fixtures/resources/CC008/apiproxy/policies/AM-Override-Message-2.xml
@@ -1,0 +1,7 @@
+<AssignMessage name="AM-Override-Message-2">
+  <Set>
+    <Payload contentType="text/plain">
+Overridden message 2
+</Payload>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/CC008/apiproxy/policies/AM-Response-1.xml
+++ b/test/fixtures/resources/CC008/apiproxy/policies/AM-Response-1.xml
@@ -1,0 +1,9 @@
+<AssignMessage name="AM-Response-1">
+  <Set>
+    <Payload contentType="text/plain">
+response 1
+</Payload>
+    <StatusCode>200</StatusCode>
+    <ReasonPhrase>OK</ReasonPhrase>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/CC008/apiproxy/policies/AM-Response-2.xml
+++ b/test/fixtures/resources/CC008/apiproxy/policies/AM-Response-2.xml
@@ -1,0 +1,9 @@
+<AssignMessage name="AM-Response-2">
+  <Set>
+    <Payload contentType="text/plain">
+response 2
+</Payload>
+    <StatusCode>200</StatusCode>
+    <ReasonPhrase>OK</ReasonPhrase>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/CC008/apiproxy/policies/AM-Response-3.xml
+++ b/test/fixtures/resources/CC008/apiproxy/policies/AM-Response-3.xml
@@ -1,0 +1,9 @@
+<AssignMessage name="AM-Response-3">
+  <Set>
+    <Payload contentType="text/plain">
+response 3
+</Payload>
+    <StatusCode>200</StatusCode>
+    <ReasonPhrase>OK</ReasonPhrase>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/CC008/apiproxy/policies/AM-Response-4.xml
+++ b/test/fixtures/resources/CC008/apiproxy/policies/AM-Response-4.xml
@@ -1,0 +1,9 @@
+<AssignMessage name="AM-Response-4">
+  <Set>
+    <Payload contentType="text/plain">
+response 4
+</Payload>
+    <StatusCode>200</StatusCode>
+    <ReasonPhrase>OK</ReasonPhrase>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/CC008/apiproxy/policies/AM-Response-5.xml
+++ b/test/fixtures/resources/CC008/apiproxy/policies/AM-Response-5.xml
@@ -1,0 +1,9 @@
+<AssignMessage name="AM-Response-5">
+  <Set>
+    <Payload contentType="text/plain">
+response 5
+</Payload>
+    <StatusCode>200</StatusCode>
+    <ReasonPhrase>OK</ReasonPhrase>
+  </Set>
+</AssignMessage>

--- a/test/fixtures/resources/CC008/apiproxy/policies/RF-Unknown-Request.xml
+++ b/test/fixtures/resources/CC008/apiproxy/policies/RF-Unknown-Request.xml
@@ -1,0 +1,10 @@
+<RaiseFault name="RF-Unknown-Request">
+  <FaultResponse>
+    <Set>
+      <Payload contentType="text/plain">Not Found</Payload>
+      <StatusCode>404</StatusCode>
+      <ReasonPhrase>Not Found</ReasonPhrase>
+    </Set>
+  </FaultResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</RaiseFault>

--- a/test/fixtures/resources/CC008/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/CC008/apiproxy/proxies/endpoint1.xml
@@ -1,0 +1,110 @@
+<ProxyEndpoint name="endpoint1">
+  <HTTPProxyConnection>
+    <BasePath>/CC008/endpoint1</BasePath>
+  </HTTPProxyConnection>
+
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Version-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <Flows>
+
+    <Flow name="f1">
+      <Response>
+        <Step>
+          <Name>AM-Response-1</Name>
+        </Step>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/r1"</Condition>
+    </Flow>
+
+    <Flow name="f2">
+      <Response>
+        <Step>
+          <Name>AM-Response-2</Name>
+        </Step>
+      </Response>
+      <!-- exact same condition string as above; will never be reached. CC008 violation -->
+      <Condition>proxy.pathsuffix MatchesPath "/r1"</Condition>
+    </Flow>
+
+    <Flow name="f3">
+      <Response>
+        <Step>
+          <Name>AM-Response-3</Name>
+        </Step>
+      </Response>
+      <!-- equivalent condition as above; CC008 violation -->
+      <Condition>proxy.pathsuffix ~/ "/r1"</Condition>
+    </Flow>
+
+
+
+    <Flow name="f4">
+      <Response>
+        <Step>
+          <Name>AM-Response-4</Name>
+        </Step>
+      </Response>
+      <Condition>proxy.pathsuffix ~/ "/r2" and request.verb = "GET"</Condition>
+    </Flow>
+
+    <Flow name="f5">
+      <Response>
+        <Step>
+          <Name>AM-Response-5</Name>
+        </Step>
+      </Response>
+      <!-- CC008 - differs only in ordering, casing, parens, and spacing from the above  -->
+      <Condition>
+        (request.verb = "GET") AND (proxy.pathsuffix ~/ "/r2")
+      </Condition>
+    </Flow>
+
+
+    <Flow name="f6">
+      <Response>
+        <Step>
+          <Name>AM-Response-4</Name>
+        </Step>
+      </Response>
+      <Condition>proxy.pathsuffix ~/ "/r3" and request.verb = "GET"
+      and request.header.foo = "Bar"</Condition>
+    </Flow>
+
+    <Flow name="f7">
+      <Response>
+        <Step>
+          <Name>AM-Response-5</Name>
+        </Step>
+      </Response>
+      <!-- CC008 - differs only in ordering, casing, parens, and spacing from the above -->
+      <Condition>
+        (request.header.Foo = "Bar") AND
+        (request.verb = "GET") AND (proxy.pathsuffix ~/ "/r3")
+      </Condition>
+    </Flow>
+
+
+    <Flow name="default">
+      <!-- all other requests -->
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response/>
+    </Flow>
+  </Flows>
+
+  <RouteRule name="http-1">
+    <Condition>proxy.pathsuffix MatchesPath "/t1"</Condition>
+    <TargetEndpoint>http-1</TargetEndpoint>
+  </RouteRule>
+
+  <RouteRule name="noroute"/>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/CC008/apiproxy/proxies/endpoint2.xml
+++ b/test/fixtures/resources/CC008/apiproxy/proxies/endpoint2.xml
@@ -1,0 +1,53 @@
+<ProxyEndpoint name="endpoint3">
+  <HTTPProxyConnection>
+    <BasePath>/CC008/endpoint3</BasePath>
+  </HTTPProxyConnection>
+
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Version-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <Flows>
+
+    <Flow name="f1">
+      <Response>
+        <Step>
+          <Name>AM-Response-1</Name>
+        </Step>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/r1"</Condition>
+    </Flow>
+
+    <!-- duplicate flow name. CC008 violation -->
+    <Flow name="f1">
+      <Response>
+        <Step>
+          <Name>AM-Response-2</Name>
+        </Step>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/r2"</Condition>
+    </Flow>
+
+
+    <Flow name="default">
+      <!-- all other requests -->
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response/>
+    </Flow>
+  </Flows>
+
+  <RouteRule name="http-1">
+    <Condition>proxy.pathsuffix MatchesPath "/t1"</Condition>
+    <TargetEndpoint>http-1</TargetEndpoint>
+  </RouteRule>
+
+  <RouteRule name="noroute"/>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/CC008/apiproxy/proxies/endpoint3.xml
+++ b/test/fixtures/resources/CC008/apiproxy/proxies/endpoint3.xml
@@ -1,0 +1,69 @@
+<ProxyEndpoint name="endpoint2">
+  <HTTPProxyConnection>
+    <BasePath>/CC008/endpoint2</BasePath>
+  </HTTPProxyConnection>
+
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Version-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <FaultRules>
+    <FaultRule name='rule1'>
+      <Step>
+        <Name>AM-Override-Message-1</Name>
+      </Step>
+      <Condition>fault.name = "foobar"</Condition>
+    </FaultRule>
+
+    <!-- same condition as above. will not be reached. CC008 violation -->
+    <FaultRule name='rule2'>
+      <Step>
+        <Name>AM-Override-Message-2</Name>
+      </Step>
+      <Condition>fault.name = "foobar"</Condition>
+    </FaultRule>
+
+  </FaultRules>
+
+  <Flows>
+    <Flow name="f1">
+      <Response>
+        <Step>
+          <Name>AM-Response-1</Name>
+        </Step>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/r1"</Condition>
+    </Flow>
+
+    <Flow name="f2">
+      <Response>
+        <Step>
+          <Name>AM-Response-2</Name>
+        </Step>
+      </Response>
+      <!-- different condition from above -->
+      <Condition>proxy.pathsuffix MatchesPath "/r2"</Condition>
+    </Flow>
+
+    <Flow name="default">
+      <!-- all other requests -->
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response/>
+    </Flow>
+  </Flows>
+
+  <RouteRule name="http-1">
+    <Condition>proxy.pathsuffix MatchesPath "/t1"</Condition>
+    <TargetEndpoint>http-1</TargetEndpoint>
+  </RouteRule>
+
+  <RouteRule name="noroute"/>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/CC008/apiproxy/proxies/endpoint4.xml
+++ b/test/fixtures/resources/CC008/apiproxy/proxies/endpoint4.xml
@@ -1,0 +1,69 @@
+<ProxyEndpoint name="endpoint4">
+  <HTTPProxyConnection>
+    <BasePath>/CC008/endpoint4</BasePath>
+  </HTTPProxyConnection>
+
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Version-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <FaultRules>
+    <FaultRule name='rule1'>
+      <Step>
+        <Name>AM-Override-Message-1</Name>
+      </Step>
+      <Condition>fault.name = "foobar"</Condition>
+    </FaultRule>
+
+    <!-- same rule name as above. CC008 violation -->
+    <FaultRule name='rule1'>
+      <Step>
+        <Name>AM-Override-Message-2</Name>
+      </Step>
+      <Condition>fault.name = "something-else"</Condition>
+    </FaultRule>
+
+  </FaultRules>
+
+  <Flows>
+    <Flow name="f1">
+      <Response>
+        <Step>
+          <Name>AM-Response-1</Name>
+        </Step>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/r1"</Condition>
+    </Flow>
+
+    <Flow name="f2">
+      <Response>
+        <Step>
+          <Name>AM-Response-2</Name>
+        </Step>
+      </Response>
+      <!-- different condition from above -->
+      <Condition>proxy.pathsuffix MatchesPath "/r2"</Condition>
+    </Flow>
+
+    <Flow name="default">
+      <!-- all other requests -->
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response/>
+    </Flow>
+  </Flows>
+
+  <RouteRule name="http-1">
+    <Condition>proxy.pathsuffix MatchesPath "/t1"</Condition>
+    <TargetEndpoint>http-1</TargetEndpoint>
+  </RouteRule>
+
+  <RouteRule name="noroute"/>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/CC008/apiproxy/proxies/endpoint5.xml
+++ b/test/fixtures/resources/CC008/apiproxy/proxies/endpoint5.xml
@@ -1,0 +1,57 @@
+<ProxyEndpoint name="endpoint5">
+  <HTTPProxyConnection>
+    <BasePath>/CC008/endpoint5</BasePath>
+  </HTTPProxyConnection>
+
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Version-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <Flows>
+    <Flow name="f1">
+      <Response>
+        <Step>
+          <Name>AM-Response-1</Name>
+        </Step>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/r1"</Condition>
+    </Flow>
+
+    <Flow name="f2">
+      <Response>
+        <Step>
+          <Name>AM-Response-2</Name>
+        </Step>
+      </Response>
+      <!-- different condition from above -->
+      <Condition>proxy.pathsuffix MatchesPath "/r2"</Condition>
+    </Flow>
+
+    <Flow name="default">
+      <!-- all other requests -->
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response/>
+    </Flow>
+  </Flows>
+
+  <RouteRule name="http-1">
+    <Condition>proxy.pathsuffix MatchesPath "/t1"</Condition>
+    <TargetEndpoint>http-1</TargetEndpoint>
+  </RouteRule>
+
+  <RouteRule name="http-2">
+    <!-- CC008 - duplicate condition -->
+    <Condition>proxy.pathsuffix MatchesPath "/t1"</Condition>
+    <TargetEndpoint>http-2</TargetEndpoint>
+  </RouteRule>
+
+  <RouteRule name="noroute"/>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/CC008/apiproxy/proxies/endpoint6.xml
+++ b/test/fixtures/resources/CC008/apiproxy/proxies/endpoint6.xml
@@ -1,0 +1,57 @@
+<ProxyEndpoint name="endpoint6">
+  <HTTPProxyConnection>
+    <BasePath>/CC008/endpoint6</BasePath>
+  </HTTPProxyConnection>
+
+  <DefaultFaultRule name="default-fault-rule">
+    <Step>
+      <Name>AM-Inject-Proxy-Version-Header</Name>
+    </Step>
+    <AlwaysEnforce>true</AlwaysEnforce>
+  </DefaultFaultRule>
+
+  <Flows>
+    <Flow name="f1">
+      <Response>
+        <Step>
+          <Name>AM-Response-1</Name>
+        </Step>
+      </Response>
+      <Condition>proxy.pathsuffix MatchesPath "/r1"</Condition>
+    </Flow>
+
+    <Flow name="f2">
+      <Response>
+        <Step>
+          <Name>AM-Response-2</Name>
+        </Step>
+      </Response>
+      <!-- different condition from above -->
+      <Condition>proxy.pathsuffix MatchesPath "/r2"</Condition>
+    </Flow>
+
+    <Flow name="default">
+      <!-- all other requests -->
+      <Request>
+        <Step>
+          <Name>RF-Unknown-Request</Name>
+        </Step>
+      </Request>
+      <Response/>
+    </Flow>
+  </Flows>
+
+  <RouteRule name="http-1">
+    <Condition>proxy.pathsuffix MatchesPath "/t1"</Condition>
+    <TargetEndpoint>http-1</TargetEndpoint>
+  </RouteRule>
+
+  <!-- CC008 - duplicate name -->
+  <RouteRule name="http-1">
+    <Condition>proxy.pathsuffix MatchesPath "/t2"</Condition>
+    <TargetEndpoint>http-2</TargetEndpoint>
+  </RouteRule>
+
+  <RouteRule name="noroute"/>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/CC008/apiproxy/targets/http-1.xml
+++ b/test/fixtures/resources/CC008/apiproxy/targets/http-1.xml
@@ -1,0 +1,21 @@
+<TargetEndpoint name="http-1">
+  <PreFlow name="PreFlow">
+    <Request>
+    </Request>
+    <Response/>
+  </PreFlow>
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response/>
+  </PostFlow>
+  <Flows/>
+
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <Enforce>true</Enforce>
+    </SSLInfo>
+    <URL>https://foo.bar/test</URL>
+  </HTTPTargetConnection>
+
+</TargetEndpoint>

--- a/test/fixtures/resources/CC008/apiproxy/targets/http-2.xml
+++ b/test/fixtures/resources/CC008/apiproxy/targets/http-2.xml
@@ -1,0 +1,21 @@
+<TargetEndpoint name="http-2">
+  <PreFlow name="PreFlow">
+    <Request>
+    </Request>
+    <Response/>
+  </PreFlow>
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response/>
+  </PostFlow>
+  <Flows/>
+
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <Enforce>true</Enforce>
+    </SSLInfo>
+    <URL>https://foo.bar.bam/test</URL>
+  </HTTPTargetConnection>
+
+</TargetEndpoint>

--- a/test/specs/CC008-test.js
+++ b/test/specs/CC008-test.js
@@ -1,0 +1,159 @@
+﻿/*
+Copyright © 2019-2024,2026 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const ruleId = "CC008",
+  assert = require("assert"),
+  path = require("path"),
+  util = require("util"),
+  debug = require("debug")(`apigeelint:${ruleId}`),
+  bl = require("../../lib/package/bundleLinter.js");
+
+describe(`${ruleId} - bundle with conditional flows`, () => {
+  function check(endpointName, expected) {
+    const configuration = {
+      debug: true,
+      source: {
+        type: "filesystem",
+        path: path.resolve(__dirname, "../fixtures/resources/CC008/apiproxy"),
+        bundleType: "apiproxy",
+      },
+      profile: "apigeex",
+      excluded: {},
+      setExitCode: false,
+      output: () => {}, // suppress output
+    };
+
+    bl.lint(configuration, (bundle) => {
+      const items = bundle.getReport();
+      assert.ok(items);
+      assert.ok(items.length);
+      const actualErrors = items.filter(
+        (item) => item.messages && item.messages.length,
+      );
+      assert.ok(actualErrors.length);
+      debug(util.format(actualErrors));
+
+      const ep = actualErrors.find((e) => e.filePath.endsWith(endpointName));
+      assert.ok(ep);
+      let cc008Messages = ep.messages.filter((m) => m.ruleId == ruleId);
+      assert.equal(cc008Messages.length, expected.length);
+
+      expected.forEach((item, ix) => {
+        assert.equal(cc008Messages[ix].line, item.line, `case(${ix}) line`);
+        assert.equal(
+          cc008Messages[ix].column,
+          item.column,
+          `case(${ix}) column`,
+        );
+        assert.equal(cc008Messages[ix].severity, 2, `case(${ix}) severity`);
+        assert.ok(
+          cc008Messages[ix].message.match(item.msgRe),
+          `case(${ix}) message`,
+        );
+      });
+    });
+  }
+
+  const re1 = new RegExp(
+      "Logically equivalent conditions, (Flows|FaultRules|RouteRules) ([a-zA-Z][-a-zA-Z0-9]*) and ([a-zA-Z][-a-zA-Z0-9]*)",
+    ),
+    re2 = new RegExp(
+      "Duplicate name on (Conditional Flows|FaultRules|RouteRules): ([a-zA-Z][-a-zA-Z0-9]*) \\(see previous.+\\)\\.",
+    );
+
+  it("should find equivalent conditions in a proxy endpoint", () => {
+    let expected = [
+      {
+        line: 24,
+        column: 5,
+        msgRe: re1,
+      },
+      {
+        line: 34,
+        column: 5,
+        msgRe: re1,
+      },
+      {
+        line: 55,
+        column: 5,
+        msgRe: re1,
+      },
+      {
+        line: 78,
+        column: 5,
+        msgRe: re1,
+      },
+    ];
+    check("endpoint1.xml", expected);
+  });
+
+  it("should find duplicate names on flows", () => {
+    let expected = [
+      {
+        line: 25,
+        column: 5,
+        msgRe: re2,
+      },
+    ];
+    check("endpoint2.xml", expected);
+  });
+
+  it("should find equivalent conditions in faultrules", () => {
+    let expected = [
+      {
+        line: 22,
+        column: 5,
+        msgRe: re1,
+      },
+    ];
+    check("endpoint3.xml", expected);
+  });
+
+  it("should find duplicate names on FaultRules", () => {
+    let expected = [
+      {
+        line: 22,
+        column: 5,
+        msgRe: re2,
+      },
+    ];
+    check("endpoint4.xml", expected);
+  });
+
+  it("should find equivalent conditions on RouteRules", () => {
+    let expected = [
+      {
+        line: 49,
+        column: 3,
+        msgRe: re1,
+      },
+    ];
+    check("endpoint5.xml", expected);
+  });
+
+  it("should find duplicate names on RouteRules", () => {
+    let expected = [
+      {
+        line: 50,
+        column: 3,
+        msgRe: re2,
+      },
+    ];
+    check("endpoint6.xml", expected);
+  });
+});

--- a/test/specs/ConditionComparisonTest.js
+++ b/test/specs/ConditionComparisonTest.js
@@ -1,0 +1,107 @@
+﻿/*
+  Copyright © 2019-2026 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const parser = require("../../build/ConditionParser.js");
+const conditionComparison = require("../../lib/package/plugins/_conditionComparison.js");
+const expect = require("chai").expect;
+
+describe("ConditionComparison", function () {
+
+  describe("Canonicalization", function () {
+    const testcases = [
+      [`request.verb="GET"`, `Equals(request.verb,'GET')`],
+      [`(request.header.foo = "Bar")`, `Equals(request.header.FOO,'Bar')`],
+      [
+        `NOT(request.header.foo = "Bar")`,
+        `NOT(Equals(request.header.FOO,'Bar'))`,
+      ],
+      [
+        `(request.header.foo = "Foo") or (request.header.foo = "Bar")`,
+        `OR(Equals(request.header.FOO,'Bar'),Equals(request.header.FOO,'Foo'))`,
+      ],
+      [
+        `NOT(variable1 = "Foo" or variable2 = "Bar")`,
+        `AND(NOT(Equals(variable1,'Foo')),NOT(Equals(variable2,'Bar')))`,
+      ],
+      [
+        `proxy.pathsuffix ~/ "/r3" and request.verb = "GET" and request.header.foo = "Bar"`,
+
+        `AND(Equals(request.header.FOO,'Bar'),Equals(request.verb,'GET'),MatchesPath(proxy.pathsuffix,'/r3'))`,
+      ],
+      [
+        `proxy.pathsuffix ~/ "/r3" and request.header.foo = "Bar" and request.verb = "GET" `,
+
+        `AND(Equals(request.header.FOO,'Bar'),Equals(request.verb,'GET'),MatchesPath(proxy.pathsuffix,'/r3'))`,
+      ],
+
+      [`request.header.foo = "bar"`, "Equals(request.header.FOO,'bar')"],
+      [`response.header.via ~~ "bar"`, "JavaRegex(response.header.VIA,'bar')"],
+      [
+        `request.header.x-apikey StartsWith "bar"`,
+        "StartsWith(request.header.X-APIKEY,'bar')",
+      ],
+    ];
+
+    testcases.forEach((testcase, ix) => {
+      it(`canonicalizes [${testcase[0]}] to [${testcase[1]}]`, function () {
+        const expr = parser.parse(testcase[0].trim());
+        const canonical = conditionComparison.canonicalize(expr);
+        expect(canonical.signature).to.equal(testcase[1], `case ${ix}`);
+      });
+    });
+  });
+
+  describe("Comparison", function () {
+    const testcases = [
+      [`request.verb="GET"`, `request.verb = "GET"`, true],
+      [`request.verb="GET"`, `request.verb = "POST"`, false],
+      [
+        `proxy.pathsuffix ~/ "/r2" and request.verb = "GET"`,
+        `(request.verb = "GET") AND (proxy.pathsuffix ~/ "/r2")`,
+        true,
+      ],
+      [
+        `proxy.pathsuffix ~/ "/r3" and request.verb = "GET" and request.header.foo = "Bar"`,
+        `(request.header.foo = "Bar") AND (request.verb = "GET") AND (proxy.pathsuffix ~/ "/r3")`,
+        true,
+      ],
+
+      [
+        `NOT(request.header.FOO = "Foo" or request.header.Foo = "Bar")`,
+        `NOT(request.header.foo = "Bar" or request.header.foo = "Foo")`,
+        true,
+      ],
+
+      [
+        `NOT(request.header.foo = "Foo" or request.header.bar = "Bar")`,
+        `NOT(request.header.foo = "Bar" or request.header.bar = "Foo")`,
+        false,
+      ],
+      [`request.header.foo="bar"`, `request.header.FOO = "bar"`, true],
+    ];
+
+    testcases.forEach((testcase) => {
+      it(`treats [${testcase[0]}] and [${testcase[1]}] expressions as ${testcase[2] ? "" : "NOT "}equivalent`, function () {
+        const expr1 = parser.parse(testcase[0]);
+        const expr2 = parser.parse(testcase[1]);
+        const expected = testcase[2];
+        expect(conditionComparison.equivalent(expr1, expr2)).to.equal(expected);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a new plugin that checks for logical equivalence of Conditions on Conditional Flows, FaultRules, and RouteRules. 

Without this plugin it is possible to have two flows with identical Conditions, like so: 
```xml
  <Flows>

    <Flow name="f1">
      <Response>
        <Step>
          <Name>AM-Response-1</Name>
        </Step>
      </Response>
      <Condition>proxy.pathsuffix MatchesPath "/r1"</Condition>
    </Flow>

    <Flow name="f2">
      <Response>
        <Step>
          <Name>AM-Response-2</Name>
        </Step>
      </Response>
      <!-- exact same condition string as above; will never be reached. -->
      <Condition>proxy.pathsuffix MatchesPath "/r1"</Condition>
    </Flow>
```

This plugin finds those conditions and flags them.  It applies a similar check to conditions on FaultRules and on RouteRules. 

This plugin normalizes conditions to evaluate logical equivalence.  It handles ordering and case-insensitivity of header names. For example, the following conditions are treated as equivalent and will be flagged if they both appear on distinct Conditional Flows: 
```
        proxy.pathsuffix ~/ "/r3" and request.verb = "GET" and request.header.Foo= "Bar"

        (request.header.foo = "Bar") AND (request.verb = "GET") AND (proxy.pathsuffix ~/ "/r3")

```

Likewise these Conditions are detected as equivalent:

```
  variable1 != "foo"

  NOT (variable1 = "foo") 
```

