### PR TITLE
feat: PO043 and EP002 detect misplaced elements beneath SSLInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ This is the current list:
 | &nbsp; |:white_check_mark:| PO040 | Check JSONPath within ExtractVariables policy | Checks that JSONPath compiles and is valid. |
 | &nbsp; |:white_check_mark:| PO041 | KeyValueMapOperations policy and ExclusiveCache | Checks that KeyValueMapOperations policy does not use deprecated ExclusiveCache. |
 | &nbsp; |:white_check_mark:| PO042 | SpikeArrest policy hygiene | In a SpikeArrest policy, check element placement and other hygiene. |
+| &nbsp; |:white_check_mark:| PO043 | ServiceCallout SSLInfo | Check for misplaced or invalid elements beneath SSLInfo. |
 | FaultRules | &nbsp; | &nbsp; | &nbsp; | &nbsp; |
 | &nbsp; |:white_check_mark:| FR001 | No Condition on FaultRule | Use Condition elements on FaultRules, unless it is the fallback rule. |
 | &nbsp; |:white_check_mark:| FR002 | DefaultFaultRule Structure | DefaultFaultRule should have only supported child elements, at most one AlwaysEnforce element, and at most one Condition element. |

--- a/lib/package/plugins/EP002-misplacedElements.js
+++ b/lib/package/plugins/EP002-misplacedElements.js
@@ -1,5 +1,5 @@
-/*
-Copyright 2019-2023,2025 Google LLC
+﻿/*
+Copyright © 2019-2023,2025-2026 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -16,7 +16,8 @@ Copyright 2019-2023,2025 Google LLC
 
 const ruleId = require("../lintUtil.js").getRuleId(),
   debug = require("debug")("apigeelint:" + ruleId),
-  xpath = require("xpath");
+  xpath = require("xpath"),
+  sslInfoCheck = require("./_sslInfoCheck.js");
 
 const plugin = {
   ruleId,
@@ -254,39 +255,29 @@ class EndpointChecker {
 
       // in apigeex, exactly one of LocalTarget and HTTPTarget is required
       if (ep == "TargetEndpoint") {
-        let condition = [];
-        if (bundleProfile != "apigee")
-          condition = ["LocalTargetConnection", "HTTPTargetConnection"]
-            .map((n) => `self::${n}`)
-            .join(" or ");
-        else
-          condition = [
-            "LocalTargetConnection",
-            "HTTPTargetConnection",
-            "HostedTarget",
-          ]
-            .map((n) => `self::${n}`)
-            .join(" or "); //Apigee Edge can have <HostedTarget> without HTTPTargetConnection or LocalTargetConnection
+        let supportedTargetTypes = [
+          "LocalTargetConnection",
+          "HTTPTargetConnection",
+        ];
+        if (bundleProfile == "apigee") {
+          supportedTargetTypes.push("HostedTarget");
+        }
+        let condition = supportedTargetTypes
+          .map((n) => `self::${n}`)
+          .join(" or ");
+
         let targetChildren = xpath.select(
           `*[${condition}]`,
           self.endpoint.element,
         );
         if (targetChildren.length == 0) {
           self.flagged = true;
-          if (bundleProfile != "apigee")
-            _markEndpoint(
-              self.endpoint,
-              `Missing a required *TargetConnection`,
-              1,
-              2,
-            );
-          else
-            _markEndpoint(
-              self.endpoint,
-              `Missing a required *TargetConnection or HostedTarget`,
-              1,
-              2,
-            );
+          _markEndpoint(
+            self.endpoint,
+            `Missing one of [${supportedTargetTypes.join(",")}]`,
+            1,
+            2,
+          );
         } else if (targetChildren.length != 1) {
           self.flagged = true;
           targetChildren
@@ -300,10 +291,26 @@ class EndpointChecker {
               ),
             );
         }
-      }
 
-      // in HealthMonitor, exactly one of HTTPMonitor or TCPMonitor is required
-      if (ep == "TargetEndpoint") {
+        // check SSLInfo if it exists
+        const htc = xpath.select(`HTTPTargetConnection`, self.endpoint.element);
+        if (htc.length > 0) {
+          const sslinfo = xpath.select(`SSLInfo`, htc[0]);
+          if (sslinfo.length > 0) {
+            const flag = (message, child) => {
+              self.flagged = true;
+              _markEndpoint(
+                self.endpoint,
+                message,
+                child.lineNumber,
+                child.columnNumber,
+              );
+            };
+            sslInfoCheck.check(sslinfo[0], flag);
+          }
+        }
+
+        // in HealthMonitor, exactly one of HTTPMonitor or TCPMonitor is required
         const healthMonitors = xpath.select(
           `HTTPTargetConnection/HealthMonitor`,
           self.endpoint.element,

--- a/lib/package/plugins/PO043-serviceCallout-sslinfo.js
+++ b/lib/package/plugins/PO043-serviceCallout-sslinfo.js
@@ -1,0 +1,64 @@
+﻿/*
+  Copyright © 2026 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const lintUtil = require("../lintUtil.js"),
+  xpath = require("xpath"),
+  ruleId = lintUtil.getRuleId(),
+  debug = require("debug")("apigeelint:" + ruleId);
+
+const plugin = {
+  ruleId,
+  name: "Check ServiceCallout SSLInfo usage",
+  message: "There should be only valid child elements of SSLInfo",
+  fatal: false,
+  severity: 2, //2=error
+  nodeType: "Policy",
+  enabled: true,
+};
+
+const sslInfoCheck = require("./_sslInfoCheck.js");
+
+const onPolicy = function (policy, cb) {
+  let flagged = false;
+  if (policy.getType() === "ServiceCallout") {
+    debug(`found policy ${policy.getName()}`);
+    const sslinfo = xpath.select(
+      "/ServiceCallout/HTTPTargetConnection/SSLInfo",
+      policy.getElement(),
+    );
+
+    if (sslinfo.length > 0) {
+      const flag = (message, child) => {
+        flagged = true;
+        policy.addMessage({
+          plugin,
+          message,
+          line: child.lineNumber,
+          column: child.columnNumber,
+        });
+      };
+      sslInfoCheck.check(sslinfo[0], flag);
+    }
+  }
+  if (typeof cb == "function") {
+    cb(null, flagged);
+  }
+};
+
+module.exports = {
+  plugin,
+  onPolicy,
+};

--- a/lib/package/plugins/_sslInfoCheck.js
+++ b/lib/package/plugins/_sslInfoCheck.js
@@ -1,0 +1,43 @@
+﻿/*
+Copyright © 2026 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+const xpath = require("xpath");
+const allowedSslInfoChildElements = [
+  "Enabled",
+  "Enforce",
+  "TrustStore",
+  "KeyStore",
+  "ClientAuthEnabled",
+  "KeyAlias",
+  "IgnoreValidationErrors",
+  "Protocols",
+  "Ciphers",
+];
+
+// in lieu of a schema validation
+const check = (sslinfo, flagFn) => {
+  const children = xpath.select(`*`, sslinfo);
+  children.forEach((child) => {
+    if (allowedSslInfoChildElements.indexOf(child.tagName) < 0) {
+      flagFn(`Invalid ${child.tagName} element`, child);
+    }
+  });
+};
+
+module.exports = {
+  check,
+  allowedSslInfoChildElements,
+};

--- a/test/fixtures/resources/EP002-issue-437/apiproxy/issue-437.xml
+++ b/test/fixtures/resources/EP002-issue-437/apiproxy/issue-437.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<APIProxy revision="1" name="issue-437">
+    <ConfigurationVersion majorVersion="4" minorVersion="0"/>
+    <CreatedBy>DChiesa@google.com</CreatedBy>
+    <DisplayName>issue-437</DisplayName>
+</APIProxy>

--- a/test/fixtures/resources/EP002-issue-437/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/EP002-issue-437/apiproxy/proxies/endpoint1.xml
@@ -1,0 +1,24 @@
+<ProxyEndpoint name="endpoint1">
+  <HTTPProxyConnection>
+    <BasePath>/issue-437</BasePath>
+  </HTTPProxyConnection>
+
+  <PreFlow name="PreFlow">
+    <Request />
+    <Response />
+  </PreFlow>
+  <PostFlow name="PostFlow">
+    <Request />
+    <Response />
+  </PostFlow>
+
+  <RouteRule name='rule1'>
+    <TargetEndpoint>target1</TargetEndpoint>
+    <Condition>request.verb = "HEAD"</Condition>
+  </RouteRule>
+
+  <RouteRule name='rule2'>
+    <TargetEndpoint>target2</TargetEndpoint>
+  </RouteRule>
+
+</ProxyEndpoint>

--- a/test/fixtures/resources/EP002-issue-437/apiproxy/targets/target1.xml
+++ b/test/fixtures/resources/EP002-issue-437/apiproxy/targets/target1.xml
@@ -1,0 +1,26 @@
+<TargetEndpoint name="target1">
+  <!-- The following is not valid. See issue 437. -->
+  <IgnoreValidationError>true</IgnoreValidationError>
+
+  <Description/>
+  <FaultRules/>
+  <PreFlow name="PreFlow">
+    <Request/>
+    <Response/>
+  </PreFlow>
+  <PostFlow name="PostFlow">
+    <Request/>
+    <Response/>
+  </PostFlow>
+  <Flows/>
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <Enforce>true</Enforce>
+      <TrustStore>ref://myTrustStoreRef</TrustStore>
+      <!-- The following is not valid. See issue 437. -->
+      <IgnoreValidationError>true</IgnoreValidationError>
+    </SSLInfo>
+    <URL>https://echo.dchiesa.demo.altostrat.com</URL>
+  </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/EP002-issue-437/apiproxy/targets/target2.xml
+++ b/test/fixtures/resources/EP002-issue-437/apiproxy/targets/target2.xml
@@ -1,0 +1,5 @@
+<TargetEndpoint name="target2">
+  <HTTPTargetConnection>
+    <URL>http://echo.dchiesa.demo.altostrat.com</URL>
+  </HTTPTargetConnection>
+</TargetEndpoint>

--- a/test/fixtures/resources/PO043/fail/SC-SSLInfo-invalid.xml
+++ b/test/fixtures/resources/PO043/fail/SC-SSLInfo-invalid.xml
@@ -1,0 +1,19 @@
+<ServiceCallout name='SC-SSLInfo-invalid'>
+  <Request variable='simpleGetRequest'>
+    <Set>
+      <Verb>GET</Verb>
+    </Set>
+  </Request>
+  <Response>jwksResponse</Response>
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <!-- PO043 will flag this -->
+      <IgnoreValidationError>false</IgnoreValidationError>
+    </SSLInfo>
+    <Properties>
+      <Property name='success.codes'>2xx</Property>
+    </Properties>
+    <URL>https://www.googleapis.com/oauth2/v3/certs</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/test/fixtures/resources/PO043/fail/messages.js
+++ b/test/fixtures/resources/PO043/fail/messages.js
@@ -1,0 +1,4 @@
+﻿// These are the error messages only for the failed policies.
+module.exports = {
+  "SC-SSLInfo-invalid.xml": ["Invalid IgnoreValidationError element"],
+};

--- a/test/fixtures/resources/PO043/pass/SC-SSLInfo-valid.xml
+++ b/test/fixtures/resources/PO043/pass/SC-SSLInfo-valid.xml
@@ -1,0 +1,18 @@
+<ServiceCallout name='SC-SSLInfo-valid'>
+  <Request variable='simpleGetRequest'>
+    <Set>
+      <Verb>GET</Verb>
+    </Set>
+  </Request>
+  <Response>jwksResponse</Response>
+  <HTTPTargetConnection>
+    <SSLInfo>
+      <Enabled>true</Enabled>
+      <IgnoreValidationErrors>false</IgnoreValidationErrors>
+    </SSLInfo>
+    <Properties>
+      <Property name='success.codes'>2xx</Property>
+    </Properties>
+    <URL>https://www.googleapis.com/oauth2/v3/certs</URL>
+  </HTTPTargetConnection>
+</ServiceCallout>

--- a/test/specs/PO043-test.js
+++ b/test/specs/PO043-test.js
@@ -1,0 +1,118 @@
+﻿/*
+  Copyright © 2026 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const testID = "PO043",
+  assert = require("assert"),
+  fs = require("fs"),
+  util = require("util"),
+  path = require("path"),
+  bl = require("../../lib/package/bundleLinter.js"),
+  plugin = require(bl.resolvePlugin(testID)),
+  Policy = require("../../lib/package/Policy.js"),
+  Dom = require("@xmldom/xmldom").DOMParser,
+  rootDir = path.resolve(__dirname, "../fixtures/resources/PO043"),
+  debug = require("debug")(`apigeelint:${testID}-test`);
+
+const loadPolicy = (sourceDir, shortFileName) => {
+  const fqPath = path.join(sourceDir, shortFileName),
+    policyXml = fs.readFileSync(fqPath).toString("utf-8"),
+    doc = new Dom().parseFromString(policyXml),
+    p = new Policy(rootDir, shortFileName, this, doc);
+  p.getElement = () => doc.documentElement;
+  p.fileName = shortFileName;
+  return p;
+};
+
+describe(`${testID} - policy passes ServiceCallout SSLInfo check`, function () {
+  const sourceDir = path.join(rootDir, "pass");
+  const testOne = (shortFileName) => {
+    const policy = loadPolicy(sourceDir, shortFileName);
+    const profile = shortFileName.split(".")[0].split("-").slice(-1)[0];
+    const policyType = policy.getType();
+    it(`check ${shortFileName} passes`, () => {
+      assert.notEqual(policyType, undefined, `${policyType} should be defined`);
+      // plugin.onBundle({ profile });
+      plugin.onPolicy(policy);
+      const report = policy.getReport();
+      const foundIssues = report.errorCount != 0 || report.warningCount != 0;
+      const messages = report.messages;
+      debug(`pass ${shortFileName} issues: ${foundIssues}`);
+      debug(`pass ${shortFileName} messages: ${util.format(messages)}`);
+      assert.equal(foundIssues, false, "should be no issues");
+      assert.ok(messages, "messages should exist");
+      assert.equal(messages.length, 0, "unexpected number of messages");
+    });
+  };
+
+  fs.readdirSync(sourceDir)
+    .filter((shortFileName) => shortFileName.endsWith(".xml"))
+    .forEach(testOne);
+});
+
+describe(`${testID} - policy does not pass KVM hygiene check`, () => {
+  const sourceDir = path.join(rootDir, "fail");
+  const expectedErrorMessages = require(path.join(sourceDir, "messages.js"));
+  const testOne = (shortFileName) => {
+    const policy = loadPolicy(sourceDir, shortFileName);
+    const profile = shortFileName.split(".")[0].split("-").slice(-1)[0];
+    const policyType = policy.getType();
+    it(`check ${shortFileName} throws error`, () => {
+      assert.notEqual(policyType, undefined, `${policyType} should be defined`);
+      // plugin.onBundle({ profile });
+      plugin.onPolicy(policy);
+      const report = policy.getReport();
+      const foundIssues = report.errorCount != 0 || report.warningCount != 0;
+      debug(`onPolicy: ${policy.getName()}`);
+      assert.equal(true, foundIssues, "should be issues");
+      const messages = report.messages;
+      assert.ok(messages, "messages should exist");
+      debug(util.format(messages));
+      let expectedList = expectedErrorMessages[policy.fileName];
+      assert.ok(
+        expectedList,
+        "test configuration failure: did not find an expected message",
+      );
+      if (typeof expectedList == "string") {
+        expectedList = [expectedList];
+      }
+      assert.equal(
+        messages.length,
+        expectedList.length,
+        "unexpected number of messages",
+      );
+
+      expectedList.forEach((expected, ix) => {
+        debug(`expected: ${expected}`);
+        debug(`actual: ${messages[ix].message}`);
+        assert.ok(messages[ix]);
+        assert.ok(messages[ix].message);
+        assert.equal(typeof messages[ix].message, "string");
+        assert.equal(typeof expected, "string");
+        assert.equal(
+          expected,
+          messages[ix].message,
+          "did not find expected message",
+        );
+      });
+    });
+  };
+
+  fs.readdirSync(sourceDir)
+    .filter((shortFileName) => shortFileName.endsWith(".xml"))
+    .forEach(testOne);
+});

--- a/test/specs/testFormatters.js
+++ b/test/specs/testFormatters.js
@@ -1,5 +1,5 @@
-/*
-  Copyright 2019-2021,2024 Google LLC
+﻿/*
+Copyright © 2019-2021,2024,2026 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ const formatters = [
   "tap.js",
   "unix.js",
   "visualstudio.js",
-  "pdf.js"
+  "pdf.js",
 ];
 
 function randomString(L) {
@@ -46,6 +46,7 @@ function randomString(L) {
 }
 
 describe("Formatters", function () {
+  this.slow(8000); // on older machines this can be slow
   let capturedOutput = null;
   configuration.source.path =
     "./test/fixtures/resources/sample-proxy-with-issues/response-shaping/apiproxy";
@@ -81,7 +82,7 @@ describe("Formatters", function () {
       assert.ok(e);
       assert.equal(
         e.message,
-        `There was a problem loading formatter: ./third_party/formatters/${nonExistingFormatterName}`
+        `There was a problem loading formatter: ./third_party/formatters/${nonExistingFormatterName}`,
       );
     }
   });

--- a/test/specs/testXmlNodeLabels.js
+++ b/test/specs/testXmlNodeLabels.js
@@ -1,5 +1,5 @@
 ﻿/*
-  Copyright © 2024-2025 Google LLC
+  Copyright © 2024-2026 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ const assert = require("assert"),
   debug = require("debug")("apigeelint:xmldom-test");
 
 describe("xmldom path resolution verification", function () {
-  this.slow(11000);
+  this.slow(18000);
   const path = require("node:path"),
     fs = require("node:fs"),
     proxyDir = path.resolve(__dirname, "../fixtures/resources/issue481"),


### PR DESCRIPTION
This addresses the specific case in issue #437. 

With this change, this configuration: 
```xml
<TargetEndpoint name="target1">
     ...
  <HTTPTargetConnection>
    <SSLInfo>
      <Enabled>true</Enabled>
      <TrustStore>ref://myTrustStoreRef</TrustStore>
      <!-- The following will be flagged as invalid. -->
      <IgnoreValidationError>true</IgnoreValidationError>
    </SSLInfo>
    <URL>https://whatever.com</URL>
     ...

```

...is flagged as invalid by EP002.   

Also, a similar configuration in ServiceCallout will be flagged as invalid by the new plugin, PO043. 

