### PR TITLE
chore: be explicit about using node builtins in the test tree

### DIFF
--- a/test/specs/BN001-BundleStructure.js
+++ b/test/specs/BN001-BundleStructure.js
@@ -15,7 +15,7 @@
 */
 /* global describe, it, configuration */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "BN001",
   debug = require("debug")("apigeelint:" + testID),
   Bundle = require("../../lib/package/Bundle.js"),

--- a/test/specs/BN001-incorrectResourceTest.js
+++ b/test/specs/BN001-incorrectResourceTest.js
@@ -17,8 +17,8 @@
 /* jshint esversion:9, node:true, strict:implied */
 /* global describe, it */
 
-const assert = require("assert"),
-  path = require("path"),
+const assert = require("node:assert"),
+  path = require("node:path"),
   debug = require("debug")("apigeelint:BN001"),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/BN001-integrationEndpoint.js
+++ b/test/specs/BN001-integrationEndpoint.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const ruleId = 'BN001',
-      assert = require("assert"),
-      path = require("path"),
-      util = require("util"),
+      assert = require("node:assert"),
+      path = require("node:path"),
+      util = require("node:util"),
       debug = require("debug")(`apigeelint:${ruleId}`),
       bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/BN001-propertySetTest.js
+++ b/test/specs/BN001-propertySetTest.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const ruleId = 'BN001',
-      assert = require("assert"),
-      path = require("path"),
-      util = require("util"),
+      assert = require("node:assert"),
+      path = require("node:path"),
+      util = require("node:util"),
       debug = require("debug")(`apigeelint:${ruleId}`),
       bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/BN001-xsdResourceTest.js
+++ b/test/specs/BN001-xsdResourceTest.js
@@ -17,8 +17,8 @@
 /* jshint esversion:9, node:true, strict:implied */
 /* global describe, it */
 
-const assert = require("assert"),
-  path = require("path"),
+const assert = require("node:assert"),
+  path = require("node:path"),
   debug = require("debug")("apigeelint:BN001"),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/BN005-UnattachedPolicies.js
+++ b/test/specs/BN005-UnattachedPolicies.js
@@ -14,7 +14,7 @@
   limitations under the License.
 */
 /* global configuration, describe, it */
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "BN005",
   debug = require("debug")("apigeelint:" + testID),
   Bundle = require("../../lib/package/Bundle.js"),

--- a/test/specs/BN009-MultipleStatsCollectors.js
+++ b/test/specs/BN009-MultipleStatsCollectors.js
@@ -16,9 +16,9 @@
 
 /* global describe, it, configuration */
 
-const assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+const assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   testID = "BN009",
   debug = require("debug")(`apigeelint:${testID}-test`),
   Bundle = require("../../lib/package/Bundle.js"),

--- a/test/specs/BN010-1.js
+++ b/test/specs/BN010-1.js
@@ -15,8 +15,8 @@ Copyright 2019-2022,2025 Google LLC
 */
 /* global describe, it */
 
-const assert = require("assert"),
-  path = require("path"),
+const assert = require("node:assert"),
+  path = require("node:path"),
   testID = "BN010",
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/BN011-wellFormedXmlTest.js
+++ b/test/specs/BN011-wellFormedXmlTest.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const ruleId = "BN011",
-  assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+  assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   debug = require("debug")(`apigeelint:${ruleId}`),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/BN012-unreferenced-targets.js
+++ b/test/specs/BN012-unreferenced-targets.js
@@ -14,9 +14,9 @@
   limitations under the License.
 */
 /* global configuration, describe, it */
-const assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+const assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   testID = "BN012",
   debug = require("debug")("apigeelint:" + testID),
   //Bundle = require("../../lib/package/Bundle.js"),

--- a/test/specs/BN013-test.js
+++ b/test/specs/BN013-test.js
@@ -14,9 +14,9 @@
   limitations under the License.
 */
 /* global configuration, describe, it */
-const assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+const assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   testID = "BN013",
   debug = require("debug")("apigeelint:${testID}-test"),
   //Bundle = require("../../lib/package/Bundle.js"),

--- a/test/specs/BN014-test.js
+++ b/test/specs/BN014-test.js
@@ -16,9 +16,9 @@
 
 /* global describe, it, __dirname */
 
-const assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+const assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   ruleId = "BN014",
   debug = require("debug")("apigeelint:" + ruleId),
   bl = require("../../lib/package/bundleLinter.js");

--- a/test/specs/CC001-CheckConditionForLiterals.js
+++ b/test/specs/CC001-CheckConditionForLiterals.js
@@ -15,7 +15,7 @@
 */
 /* global it, describe */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "CC001",
   debug = require("debug")("apigeelint:" + testID),
   bl = require("../../lib/package/bundleLinter.js"),

--- a/test/specs/CC003-ConditionLength.js
+++ b/test/specs/CC003-ConditionLength.js
@@ -15,7 +15,7 @@
 */
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
       testID = "CC003",
       bl = require("../../lib/package/bundleLinter.js"),
       plugin = require(bl.resolvePlugin(testID)),

--- a/test/specs/CC004-ConditionComplexity.js
+++ b/test/specs/CC004-ConditionComplexity.js
@@ -15,7 +15,7 @@
 */
 /* global it, describe */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "CC004",
   debug = require("debug")("apigeelint:" + testID),
   Condition = require("../../lib/package/Condition.js"),

--- a/test/specs/CC005-test.js
+++ b/test/specs/CC005-test.js
@@ -17,8 +17,8 @@ Copyright © 2019-2021,2025,2026 Google LLC
 /* global describe, it */
 
 const testID = "CC005",
-  assert = require("assert"),
-  path = require("path"),
+  assert = require("node:assert"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   debug = require("debug")(`apigeelint:${testID}-test`);
 

--- a/test/specs/CC006-checkConditionTruth.js
+++ b/test/specs/CC006-checkConditionTruth.js
@@ -15,7 +15,7 @@
 */
 /* global describe, it, configuration */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "CC006",
   Bundle = require("../../lib/package/Bundle.js"),
   bl = require("../../lib/package/bundleLinter.js"),

--- a/test/specs/CC007-Condition-Syntax-Test.js
+++ b/test/specs/CC007-Condition-Syntax-Test.js
@@ -16,7 +16,7 @@
 /* global describe, it */
 
 const testID = "CC007",
-  assert = require("assert"),
+  assert = require("node:assert"),
   xpath = require("xpath"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),

--- a/test/specs/CC008-test.js
+++ b/test/specs/CC008-test.js
@@ -17,9 +17,9 @@ Copyright © 2019-2024,2026 Google LLC
 /* global describe, it */
 
 const ruleId = "CC008",
-  assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+  assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   debug = require("debug")(`apigeelint:${ruleId}`),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/DC001-DeprecationConcurrentRatePolicy.js
+++ b/test/specs/DC001-DeprecationConcurrentRatePolicy.js
@@ -14,9 +14,9 @@
   limitations under the License.
 */
 /* global describe, it */
-const assert = require("assert"),
-      path = require("path"),
-      util = require("util"),
+const assert = require("node:assert"),
+      path = require("node:path"),
+      util = require("node:util"),
       bl = require("../../lib/package/bundleLinter.js");
 
 describe(`DC001 - ConcurrentRateLimit Policy is deprecated`, () => {

--- a/test/specs/DC002-DeprecationOAuthv1.js
+++ b/test/specs/DC002-DeprecationOAuthv1.js
@@ -16,8 +16,8 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
-      path = require("path"),
+const assert = require("node:assert"),
+      path = require("node:path"),
       bl = require("../../lib/package/bundleLinter.js");
 
 describe(`DC002 - OAuth V1 policies are deprecated`, () => {

--- a/test/specs/EP001-corsAttachment.js
+++ b/test/specs/EP001-corsAttachment.js
@@ -16,8 +16,8 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
-      path = require("path"),
+const assert = require("node:assert"),
+      path = require("node:path"),
       bl = require("../../lib/package/bundleLinter.js");
 
 describe(`EP001 - bundle with properties resource`, () => {

--- a/test/specs/EP002-test.js
+++ b/test/specs/EP002-test.js
@@ -16,9 +16,9 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+const assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   debug = require("debug")("apigeelint:EP002-test"),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/FE001-Authentication-element.js
+++ b/test/specs/FE001-Authentication-element.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const ruleId = "FE001",
-  assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+  assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   debug = require("debug")(`apigeelint:${ruleId}`),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/FL001-unconditional-flows-and-routes.js
+++ b/test/specs/FL001-unconditional-flows-and-routes.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const ruleId = "FL001",
-  assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+  assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   debug = require("debug")(`apigeelint:${ruleId}`),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/PD001-1.js
+++ b/test/specs/PD001-1.js
@@ -15,8 +15,8 @@
 */
 /* global describe, it */
 
-const assert = require("assert"),
-      path = require("path"),
+const assert = require("node:assert"),
+      path = require("node:path"),
       testID = "PD001",
       bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/PD002-at-least-one-unconditional-RouteRule.js
+++ b/test/specs/PD002-at-least-one-unconditional-RouteRule.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const ruleId = "PD002",
-  assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+  assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   debug = require("debug")(`apigeelint:${ruleId}`),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/PD003-conditions-on-RouteRules.js
+++ b/test/specs/PD003-conditions-on-RouteRules.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const ruleId = "PD003",
-  assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+  assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   debug = require("debug")(`apigeelint:${ruleId}`),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/PD004-proxyendpoint-name.js
+++ b/test/specs/PD004-proxyendpoint-name.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const ruleId = "PD004",
-  assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+  assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   debug = require("debug")(`apigeelint:${ruleId}`),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/PD005-unnecessary-VirtualHost.js
+++ b/test/specs/PD005-unnecessary-VirtualHost.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const ruleId = 'PD005',
-      assert = require("assert"),
-      path = require("path"),
-      util = require("util"),
+      assert = require("node:assert"),
+      path = require("node:path"),
+      util = require("node:util"),
       debug = require("debug")(`apigeelint:${ruleId}`),
       bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/PD006-test.js
+++ b/test/specs/PD006-test.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const ruleId = "PD006",
-  assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+  assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   debug = require("debug")(`apigeelint:${ruleId}-test`),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/PO007-PolicyNameConventions.js
+++ b/test/specs/PO007-PolicyNameConventions.js
@@ -17,7 +17,7 @@
 /* global describe, it */
 
 const testID = "PO007",
-      assert = require("assert"),
+      assert = require("node:assert"),
       bl = require("../../lib/package/bundleLinter.js"),
       plugin = require(bl.resolvePlugin(testID)),
       Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO007-corsPolicyName.js
+++ b/test/specs/PO007-corsPolicyName.js
@@ -15,9 +15,9 @@
 */
 
 const testID = "PO007",
-  assert = require("assert"),
-  fs = require("fs"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO007-quotaPrefix.js
+++ b/test/specs/PO007-quotaPrefix.js
@@ -17,7 +17,7 @@
 /* global describe, it */
 
 const testID = "PO007",
-  assert = require("assert"),
+  assert = require("node:assert"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO012-assignToHygiene.js
+++ b/test/specs/PO012-assignToHygiene.js
@@ -16,9 +16,9 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+const assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   ruleId = "PO012",
   debug = require("debug")("apigeelint:" + ruleId),
   bl = require("../../lib/package/bundleLinter.js");

--- a/test/specs/PO013-JSHint.js
+++ b/test/specs/PO013-JSHint.js
@@ -15,7 +15,7 @@
 */
 /* global describe, it, configuration */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "PO013",
   debug = require("debug")("apigeelint:" + testID),
   Bundle = require("../../lib/package/Bundle.js"),

--- a/test/specs/PO018-checkRegexLookAround.js
+++ b/test/specs/PO018-checkRegexLookAround.js
@@ -15,7 +15,7 @@
 */
 /* global it, describe */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "PO018",
   debug = require("debug")("apigeelint:" + testID),
   Bundle = require("../../lib/package/Bundle.js"),

--- a/test/specs/PO022-distributedQuotaCheck.js
+++ b/test/specs/PO022-distributedQuotaCheck.js
@@ -15,7 +15,7 @@
 */
 /* global it, describe */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "PO022",
   debug = require("debug")("apigeelint:" + testID),
   Bundle = require("../../lib/package/Bundle.js"),

--- a/test/specs/PO023-test.js
+++ b/test/specs/PO023-test.js
@@ -16,9 +16,9 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+const assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   ruleId = "PO023",
   debug = require("debug")("apigeelint:" + ruleId),
   bl = require("../../lib/package/bundleLinter.js");

--- a/test/specs/PO024-ResponseCacheErrorResponseCheck.js
+++ b/test/specs/PO024-ResponseCacheErrorResponseCheck.js
@@ -15,7 +15,7 @@
 */
 /* global it, describe */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "PO024",
   debug = require("debug")("apigeelint:" + testID),
   Bundle = require("../../lib/package/Bundle.js"),

--- a/test/specs/PO025-esLint.js
+++ b/test/specs/PO025-esLint.js
@@ -16,7 +16,7 @@
 
 /* global describe, it, configuration */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "PO025",
   debug = require("debug")("apigeelint:" + testID),
   Bundle = require("../../lib/package/Bundle.js"),

--- a/test/specs/PO026-assignVariableHygiene.js
+++ b/test/specs/PO026-assignVariableHygiene.js
@@ -16,8 +16,8 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
-  path = require("path"),
+const assert = require("node:assert"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js");
 
 describe(`PO026 - AssignVariableHygiene`, () => {

--- a/test/specs/PO026-assignVariableHygieneInRaiseFault.js
+++ b/test/specs/PO026-assignVariableHygieneInRaiseFault.js
@@ -18,9 +18,9 @@
 /* global describe, it */
 
 const testID = "PO026",
-  assert = require("assert"),
-  fs = require("fs"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO026-profile.js
+++ b/test/specs/PO026-profile.js
@@ -15,8 +15,8 @@
 */
 /* global describe, it */
 
-const assert = require("assert"),
-  path = require("path"),
+const assert = require("node:assert"),
+  path = require("node:path"),
   debug = require("debug")("apigeelint:PO026-test"),
   bl = require("../../lib/package/bundleLinter.js");
 
@@ -67,7 +67,7 @@ describe(`PO026 - PropertySetRef with various profiles`, () => {
 const testID = "PO026",
   Policy = require("../../lib/package/Policy.js"),
   Dom = require("@xmldom/xmldom").DOMParser,
-  fs = require("fs"),
+  fs = require("node:fs"),
   plugin = require(bl.resolvePlugin(testID));
 
 const po026Test = (filename, profile, cb) => {

--- a/test/specs/PO027-hmacHygiene.js
+++ b/test/specs/PO027-hmacHygiene.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const testID = "PO027",
-      assert = require("assert"),
-      fs = require("fs"),
-      path = require("path"),
+      assert = require("node:assert"),
+      fs = require("node:fs"),
+      path = require("node:path"),
       bl = require("../../lib/package/bundleLinter.js"),
       plugin = require(bl.resolvePlugin(testID)),
       Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO028-policy-in-profile.js
+++ b/test/specs/PO028-policy-in-profile.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "PO028",
-  assert = require("assert"),
-  fs = require("fs"),
-  path = require("path"),
-  util = require("util"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  path = require("node:path"),
+  util = require("node:util"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO029-policyTypes.js
+++ b/test/specs/PO029-policyTypes.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const testID = "PO029",
-  assert = require("assert"),
-  fs = require("fs"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO030-ExpirySettings.js
+++ b/test/specs/PO030-ExpirySettings.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "PO030",
-  assert = require("assert"),
-  fs = require("fs"),
-  path = require("path"),
-  util = require("util"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  path = require("node:path"),
+  util = require("node:util"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO031-AssignMessage-Payload-ContentType.js
+++ b/test/specs/PO031-AssignMessage-Payload-ContentType.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const testID = "PO031",
-  assert = require("assert"),
-  fs = require("fs"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  path = require("node:path"),
   //util = require('util'),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),

--- a/test/specs/PO032-CORS-hygiene-test.js
+++ b/test/specs/PO032-CORS-hygiene-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "PO032",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO033-extractVariables-JSON-Variable-type.js
+++ b/test/specs/PO033-extractVariables-JSON-Variable-type.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "PO033",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO034-am-hygiene-test.js
+++ b/test/specs/PO034-am-hygiene-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "PO034",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO035-test-bundles.js
+++ b/test/specs/PO035-test-bundles.js
@@ -16,9 +16,9 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+const assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   ruleId = "PO035",
   debug = require("debug")("apigeelint:" + ruleId),
   bl = require("../../lib/package/bundleLinter.js");

--- a/test/specs/PO035-test-policies.js
+++ b/test/specs/PO035-test-policies.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "PO035",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO036-service-callout-response-element-syntax.js
+++ b/test/specs/PO036-service-callout-response-element-syntax.js
@@ -18,9 +18,9 @@
 /* global describe, it */
 
 const testID = "PO036",
-  assert = require("assert"),
-  fs = require("fs"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   debug = require("debug")("apigeelint:" + testID),

--- a/test/specs/PO037-DataCapture-hygiene.js
+++ b/test/specs/PO037-DataCapture-hygiene.js
@@ -16,9 +16,9 @@
 
 /* global describe, it, __dirname */
 
-const assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+const assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   ruleId = "PO037",
   debug = require("debug")("apigeelint:" + ruleId),
   bl = require("../../lib/package/bundleLinter.js");

--- a/test/specs/PO038-test.js
+++ b/test/specs/PO038-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "PO038",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO039-test.js
+++ b/test/specs/PO039-test.js
@@ -15,9 +15,9 @@
 */
 
 const testID = "PO039",
-  assert = require("assert"),
-  fs = require("fs"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   debug = require("debug")("apigeelint:" + testID),

--- a/test/specs/PO040-test.js
+++ b/test/specs/PO040-test.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const testID = "PO040",
-  assert = require("assert"),
-  fs = require("fs"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO041-test.js
+++ b/test/specs/PO041-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "PO041",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO042-test-policies.js
+++ b/test/specs/PO042-test-policies.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "PO042",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO043-test.js
+++ b/test/specs/PO043-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "PO043",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/PO044-test.js
+++ b/test/specs/PO044-test.js
@@ -17,10 +17,10 @@ Copyright © 2019-2024,2026 Google LLC
 /* global describe, it */
 
 const testID = "PO044",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Policy = require("../../lib/package/Policy.js"),

--- a/test/specs/ST001-test.js
+++ b/test/specs/ST001-test.js
@@ -16,7 +16,7 @@
 /* global it, describe */
 
 const testID = "ST001",
-  assert = require("assert"),
+  assert = require("node:assert"),
   path = require("node:path"),
   util = require("node:util"),
   debug = require("debug")("apigeelint:" + testID),

--- a/test/specs/ST002-test.js
+++ b/test/specs/ST002-test.js
@@ -16,10 +16,10 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
-  path = require("path"),
+const assert = require("node:assert"),
+  path = require("node:path"),
   debug = require("debug")("apigeelint:ST002"),
-  util = require("util"),
+  util = require("node:util"),
   bl = require("../../lib/package/bundleLinter.js");
 
 describe(`ST002 - StepHygiene - apiproxy`, () => {

--- a/test/specs/ST003-ev-json-condition.js
+++ b/test/specs/ST003-ev-json-condition.js
@@ -16,11 +16,11 @@ Copyright © 2019-2022,2026 Google LLC
 
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   ruleId = "ST003",
-  path = require("path"),
+  path = require("node:path"),
   debug = require("debug")(`apigeelint:${ruleId}`),
-  util = require("util"),
+  util = require("node:util"),
   bl = require("../../lib/package/bundleLinter.js");
 
 const expectedMessageRe = new RegExp(

--- a/test/specs/ST004-ev-xml-condition.js
+++ b/test/specs/ST004-ev-xml-condition.js
@@ -16,11 +16,11 @@ Copyright © 2019-2022,2026 Google LLC
 
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   ruleId = "ST004",
-  path = require("path"),
+  path = require("node:path"),
   debug = require("debug")(`apigeelint:${ruleId}`),
-  util = require("util"),
+  util = require("node:util"),
   bl = require("../../lib/package/bundleLinter.js");
 
 const expectedMessageRe = new RegExp(

--- a/test/specs/ST005-ev-form-condition.js
+++ b/test/specs/ST005-ev-form-condition.js
@@ -16,11 +16,11 @@ Copyright © 2019-2022,2026 Google LLC
 
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   ruleId = "ST005",
-  path = require("path"),
+  path = require("node:path"),
   debug = require("debug")(`apigeelint:${ruleId}`),
-  util = require("util"),
+  util = require("node:util"),
   bl = require("../../lib/package/bundleLinter.js");
 
 const expectedMessageRe = new RegExp(

--- a/test/specs/ST006-jtp-condition.js
+++ b/test/specs/ST006-jtp-condition.js
@@ -16,11 +16,11 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
       ruleId = 'ST006',
-      path = require("path"),
+      path = require("node:path"),
       debug = require("debug")(`apigeelint:${ruleId}`),
-      util = require("util"),
+      util = require("node:util"),
       bl = require("../../lib/package/bundleLinter.js");
 
 const expectedMessageRe =

--- a/test/specs/ST007-xtp-condition.js
+++ b/test/specs/ST007-xtp-condition.js
@@ -16,11 +16,11 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
       ruleId = 'ST007',
-      path = require("path"),
+      path = require("node:path"),
       debug = require("debug")(`apigeelint:${ruleId}`),
-      util = require("util"),
+      util = require("node:util"),
       bl = require("../../lib/package/bundleLinter.js");
 
 const expectedMessageRe =

--- a/test/specs/ST008-test.js
+++ b/test/specs/ST008-test.js
@@ -16,11 +16,11 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
       ruleId = 'ST008',
-      path = require("path"),
+      path = require("node:path"),
       debug = require("debug")(`apigeelint:${ruleId}-test`),
-      util = require("util"),
+      util = require("node:util"),
       bl = require("../../lib/package/bundleLinter.js");
 
 const expectedMessageRe =

--- a/test/specs/TD001-MgmtServerTargetEndpoint.js
+++ b/test/specs/TD001-MgmtServerTargetEndpoint.js
@@ -15,7 +15,7 @@
 */
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "TD001",
   debug = require("debug")("apigeelint:" + testID),
   Bundle = require("../../lib/package/Bundle.js"),

--- a/test/specs/TD002-edgemicro.js
+++ b/test/specs/TD002-edgemicro.js
@@ -16,8 +16,8 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
-      path = require("path"),
+const assert = require("node:assert"),
+      path = require("node:path"),
       bl = require("../../lib/package/bundleLinter.js");
 
 describe(`TD002 - Edgemicro`, () => {

--- a/test/specs/TD003-targetendpoint-name.js
+++ b/test/specs/TD003-targetendpoint-name.js
@@ -17,9 +17,9 @@
 /* global describe, it */
 
 const ruleId = "TD003",
-  assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+  assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   debug = require("debug")(`apigeelint:${ruleId}`),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/TD004-test-sslInfo.js
+++ b/test/specs/TD004-test-sslInfo.js
@@ -15,9 +15,9 @@
 */
 /* global describe, it, configuration */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "TD004",
-  util = require("util"),
+  util = require("node:util"),
   debug = require("debug")(`apigeelint:${testID}-test`),
   Bundle = require("../../lib/package/Bundle.js"),
   bl = require("../../lib/package/bundleLinter.js"),

--- a/test/specs/TD005-sslInfo-references.js
+++ b/test/specs/TD005-sslInfo-references.js
@@ -15,9 +15,9 @@
 */
 /* global describe, it, configuration */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "TD005",
-  util = require("util"),
+  util = require("node:util"),
   debug = require("debug")("apigeelint:" + testID),
   Bundle = require("../../lib/package/Bundle.js"),
   bl = require("../../lib/package/bundleLinter.js"),

--- a/test/specs/TD006-test.js
+++ b/test/specs/TD006-test.js
@@ -15,9 +15,9 @@
 */
 /* global describe, it, configuration */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "TD006",
-  util = require("util"),
+  util = require("node:util"),
   debug = require("debug")("apigeelint:" + testID),
   Bundle = require("../../lib/package/Bundle.js"),
   bl = require("../../lib/package/bundleLinter.js"),

--- a/test/specs/TD007-target-sslInfo-truststore.js
+++ b/test/specs/TD007-target-sslInfo-truststore.js
@@ -15,9 +15,9 @@
 */
 /* global describe, it, configuration */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "TD007",
-  util = require("util"),
+  util = require("node:util"),
   debug = require("debug")("apigeelint:" + testID),
   Bundle = require("../../lib/package/Bundle.js"),
   bl = require("../../lib/package/bundleLinter.js"),

--- a/test/specs/TD008-test.js
+++ b/test/specs/TD008-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "TD008",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Endpoint = require("../../lib/package/Endpoint.js"),

--- a/test/specs/TD009-test.js
+++ b/test/specs/TD009-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "TD009",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Endpoint = require("../../lib/package/Endpoint.js"),

--- a/test/specs/TD010-test.js
+++ b/test/specs/TD010-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "TD010",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Endpoint = require("../../lib/package/Endpoint.js"),

--- a/test/specs/TD011-test.js
+++ b/test/specs/TD011-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "TD011",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Endpoint = require("../../lib/package/Endpoint.js"),

--- a/test/specs/TD012-test.js
+++ b/test/specs/TD012-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "TD012",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Endpoint = require("../../lib/package/Endpoint.js"),

--- a/test/specs/TD013-test.js
+++ b/test/specs/TD013-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "TD013",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Endpoint = require("../../lib/package/Endpoint.js"),

--- a/test/specs/TD014-test.js
+++ b/test/specs/TD014-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "TD014",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Endpoint = require("../../lib/package/Endpoint.js"),

--- a/test/specs/TD015-test.js
+++ b/test/specs/TD015-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "TD015",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Endpoint = require("../../lib/package/Endpoint.js"),

--- a/test/specs/TD016-test.js
+++ b/test/specs/TD016-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "TD016",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Endpoint = require("../../lib/package/Endpoint.js"),

--- a/test/specs/TD017-test.js
+++ b/test/specs/TD017-test.js
@@ -17,10 +17,10 @@
 /* global describe, it */
 
 const testID = "TD017",
-  assert = require("assert"),
-  fs = require("fs"),
-  util = require("util"),
-  path = require("path"),
+  assert = require("node:assert"),
+  fs = require("node:fs"),
+  util = require("node:util"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js"),
   plugin = require(bl.resolvePlugin(testID)),
   Endpoint = require("../../lib/package/Endpoint.js"),

--- a/test/specs/disable-directives.js
+++ b/test/specs/disable-directives.js
@@ -14,9 +14,9 @@
   limitations under the License.
 */
 /* global configuration, describe, it */
-const assert = require("assert"),
-  path = require("path"),
-  util = require("util"),
+const assert = require("node:assert"),
+  path = require("node:path"),
+  util = require("node:util"),
   debug = require("debug")("apigeelint:directives"),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/issue546-test.js
+++ b/test/specs/issue546-test.js
@@ -16,8 +16,8 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
-  path = require("path"),
+const assert = require("node:assert"),
+  path = require("node:path"),
   debug = require("debug")(`apigeelint:issue546`),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/issue567-test.js
+++ b/test/specs/issue567-test.js
@@ -16,8 +16,8 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
-  path = require("path"),
+const assert = require("node:assert"),
+  path = require("node:path"),
   bl = require("../../lib/package/bundleLinter.js");
 
 describe(`issue567 - HTTPTargetConnection check`, () => {

--- a/test/specs/testAllPlugins.js
+++ b/test/specs/testAllPlugins.js
@@ -15,9 +15,9 @@
 */
 /* global describe, it */
 
-const assert = require("assert"),
-      path = require("path"),
-      fs = require("fs"),
+const assert = require("node:assert"),
+      path = require("node:path"),
+      fs = require("node:fs"),
       //debug = require("debug")("apigeelint:allplugins"),
       Bundle = require("../../lib/package/Bundle.js"),
       Validator = require("jsonschema").Validator,

--- a/test/specs/testAllPluginsMultipleBundlesReportSchema.js
+++ b/test/specs/testAllPluginsMultipleBundlesReportSchema.js
@@ -14,9 +14,9 @@
   limitations under the License.
 */
 
-const assert = require("assert"),
-      fs = require("fs"),
-      path = require("path"),
+const assert = require("node:assert"),
+      fs = require("node:fs"),
+      path = require("node:path"),
       schema = require("./../fixtures/reportSchema.js"),
       Validator = require("jsonschema").Validator,
       findFolders = require(path.join(__dirname, "../../lib/package/findFolders.js")),

--- a/test/specs/testCacheCoherence.js
+++ b/test/specs/testCacheCoherence.js
@@ -15,7 +15,7 @@
 */
 /* global describe, it, configuration */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   testID = "BN003",
   debug = require("debug")("apigeelint:" + testID),
   Bundle = require("../../lib/package/Bundle.js"),

--- a/test/specs/testFaultRules.js
+++ b/test/specs/testFaultRules.js
@@ -16,10 +16,10 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
       debug = require("debug")("apigeelint:faultrules"),
       Bundle = require("../../lib/package/Bundle.js"),
-      util = require("util");
+      util = require("node:util");
 
 const configuration = {
   debug: false,

--- a/test/specs/testFlowConditions.js
+++ b/test/specs/testFlowConditions.js
@@ -15,7 +15,7 @@ Copyright © 2019-2021,2026 Google LLC
 */
 /* global it, describe */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   debug = require("debug")("apigeelint:flowConditions"),
   Endpoint = require("../../lib/package/Endpoint.js"),
   Dom = require("@xmldom/xmldom").DOMParser,

--- a/test/specs/testFlowNames.js
+++ b/test/specs/testFlowNames.js
@@ -15,7 +15,7 @@
 */
 /* global it, describe */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
       //debug = require("debug")("apigeelint:flowNames"),
       Endpoint = require("../../lib/package/Endpoint.js"),
       Dom = require("@xmldom/xmldom").DOMParser,

--- a/test/specs/testFormatters.js
+++ b/test/specs/testFormatters.js
@@ -16,7 +16,7 @@ Copyright © 2019-2021,2024,2026 Google LLC
 /* global describe, it, configuration */
 /* jslint esversion:9 */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   debug = require("debug")("apigeelint:Formatters"),
   bl = require("../../lib/package/bundleLinter.js");
 

--- a/test/specs/testPolicyName.js
+++ b/test/specs/testPolicyName.js
@@ -16,7 +16,7 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
       Policy = require("../../lib/package/Policy.js"),
       Dom = require("@xmldom/xmldom").DOMParser;
 

--- a/test/specs/testReportCorrectness.js
+++ b/test/specs/testReportCorrectness.js
@@ -122,7 +122,7 @@ var example = [
   }
 ];
 
-var assert = require("assert");
+var assert = require("node:assert");
 
 describe("report correctness", function() {
 

--- a/test/specs/testTemplateCheck.js
+++ b/test/specs/testTemplateCheck.js
@@ -16,7 +16,7 @@
 /* global describe, it, configuration */
 /* jslint esversion:9 */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   pu = require("../../lib/package/plugins/_pluginUtil.js");
 
 describe("TemplateCheck", function () {

--- a/test/specs/testTruthTable.js
+++ b/test/specs/testTruthTable.js
@@ -14,7 +14,7 @@ Copyright © 2019-2020,2025,2026 Google LLC
   limitations under the License.
 */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   debug = require("debug")("apigeelint:TruthTableTest"),
   TruthTable = require("../../lib/package/TruthTable.js"),
   test = function (exp, expected) {

--- a/test/specs/testTruthTableAST.js
+++ b/test/specs/testTruthTableAST.js
@@ -15,7 +15,7 @@
 */
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   expect = require("chai").expect,
   jsonpath = require("jsonpath"),
   debug = require("debug")("apigeelint:TruthTableTest"),

--- a/test/specs/testTruthTableMatchesPath.js
+++ b/test/specs/testTruthTableMatchesPath.js
@@ -15,7 +15,7 @@
 */
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   TruthTable = require("../../lib/package/TruthTable.js"),
   test = function (exp, assertion) {
     it(`${exp} should be ${assertion}`, function () {

--- a/test/specs/testTruthTableStartsWith.js
+++ b/test/specs/testTruthTableStartsWith.js
@@ -16,7 +16,7 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
       TruthTable = require("../../lib/package/TruthTable.js"),
       test = function(exp, assertion) {
         it(`${exp} should be ${assertion}`, function() {

--- a/test/specs/testTruthTableVarComps.js
+++ b/test/specs/testTruthTableVarComps.js
@@ -16,7 +16,7 @@
 
 /* global describe, it */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   TruthTable = require("../../lib/package/TruthTable.js"),
   test = function (exp, assertion) {
     it(`${exp} should be ${assertion}`, function () {

--- a/test/specs/testUnexpectedExternalPlugins.js
+++ b/test/specs/testUnexpectedExternalPlugins.js
@@ -16,10 +16,8 @@
 
 /* global require, describe, before, after, it, __dirname */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   Dom = require("@xmldom/xmldom").DOMParser,
-  lintUtil = require("../../lib/package/lintUtil.js"),
-  util = require("node:util"),
   child_process = require("node:child_process"),
   debug = require("debug")("apigeelint:issue515");
 

--- a/test/specs/testXmlNodeLabels.js
+++ b/test/specs/testXmlNodeLabels.js
@@ -16,7 +16,7 @@
 
 /* global require, describe, before, after, it, __dirname */
 
-const assert = require("assert"),
+const assert = require("node:assert"),
   Dom = require("@xmldom/xmldom").DOMParser,
   lintUtil = require("../../lib/package/lintUtil.js"),
   util = require("node:util"),


### PR DESCRIPTION
No functional change here, and no changes in test logic. Therefore, there is no need to cut a release with this change.

This formalizes the `require()` statements _only in the test tree_ (for now) to specify the `node:` prefix for node built-ins like util, path, fs, and assert.  

Before:
```
   const assert = require("assert");
```

After:
```
   const assert = require("node:assert");
```


In a future PR, I'll make a similar change for the lib tree. 