### PR TITLE
fix: remove program.exitOverride() call in cli.js

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -150,7 +150,6 @@ const findBundle = (p) => {
        apigeelint -f table.js --download org:my-org,api:my-proxy\n`,
   );
 
-  program.exitOverride();
   program.parse(process.argv);
   const options = program.opts();
 


### PR DESCRIPTION
addresses issue 619