### PR TITLE
fix: correct output file writing, described in issue622

### DIFF
--- a/lib/package/bundleLinter.js
+++ b/lib/package/bundleLinter.js
@@ -49,12 +49,13 @@ function exportReport(providedPath, stringifiedReport) {
     fs.existsSync(providedPath) && fs.lstatSync(providedPath).isDirectory()
       ? path.join(providedPath, "apigeelint.out")
       : providedPath;
-  fs.writeFile(constructedPath, stringifiedReport, "utf8", function (err) {
-    if (err) {
-      return console.log(err);
-    }
+  try {
+    fs.writeFileSync(constructedPath, stringifiedReport, { encoding: "utf8" });
     return null;
-  });
+  } catch (exc1) {
+    console.error(exc1.message);
+    return exc1;
+  }
 }
 
 const internalPluginIdRe = new RegExp("^[A-Z]{2}[0-9]{3}$");

--- a/test/fixtures/resources/issue622/apiproxy/i622.xml
+++ b/test/fixtures/resources/issue622/apiproxy/i622.xml
@@ -1,0 +1,4 @@
+<APIProxy revision="1" name="i622">
+  <ConfigurationVersion minorVersion="0" majorVersion="4"/>
+  <DisplayName>i622</DisplayName>
+</APIProxy>

--- a/test/fixtures/resources/issue622/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/issue622/apiproxy/proxies/endpoint1.xml
@@ -1,0 +1,16 @@
+<ProxyEndpoint name="endpoint1">
+  <Description>Test</Description>
+  <HTTPProxyConnection>
+    <BasePath>/test</BasePath>
+  </HTTPProxyConnection>
+  <PreFlow name="PreFlow">
+    <Request>
+    </Request>
+    <Response>
+    </Response>
+  </PreFlow>
+  <Flows />>
+  <RouteRule name="default">
+    <URL>https://example.com</URL>
+  </RouteRule>
+</ProxyEndpoint>

--- a/test/fixtures/resources/issue622/package.json
+++ b/test/fixtures/resources/issue622/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "apigeelint-cli-bug622-test",
+  "version": "1.0.0",
+  "description": "test that apigeelint --write option writes a file",
+  "devDependencies": {
+    "apigeelint": "^2.80.1",
+    "debug": "4.3.5"
+  },
+  "private": true,
+  "engines": {
+    "node": ">=22",
+    "npm": ">=10.5"
+  },
+  "overrides": {}
+}

--- a/test/specs/testWriteOption.js
+++ b/test/specs/testWriteOption.js
@@ -1,0 +1,152 @@
+﻿/*
+Copyright © 2026 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+/* global describe, it */
+
+const assert = require("node:assert"),
+  debug = require("debug")(`apigeelint:issue622-test`),
+  tmp = require("tmp"),
+  path = require("node:path"),
+  fs = require("node:fs"),
+  child_process = require("node:child_process");
+
+describe("issue622 write file handling", function () {
+  this.slow(61000);
+  this.timeout(8000);
+  const issue622Dir = path.resolve(__dirname, "../fixtures/resources/issue622"),
+    tmpdir = tmp.dirSync({
+      prefix: `apigeelint-cli-test`,
+      keep: false,
+      unsafeCleanup: true, // this does not seem to work in apigeelint
+    });
+
+  // make sure to cleanup when the process exits
+  process.on("exit", function () {
+    tmpdir.removeCallback();
+  });
+
+  const spawnOpts = {
+    cwd: tmpdir.name,
+    encoding: "utf8",
+    env: { ...process.env, DEBUG: "apigeelint:cli" },
+  };
+
+  const runOne = (cliOpts, checkCb) => {
+    fs.cpSync(
+      path.resolve(issue622Dir, "package.json"),
+      path.resolve(tmpdir.name, "package.json"),
+      { force: true },
+    );
+
+    // npm install can take a very long time, sometimes.
+    // NB: multiple tests result in re-install of apigeelint in the same directory.
+    child_process.exec("npm install", spawnOpts, (e, stdout, stderr) => {
+      assert.equal(e, null);
+      debug(stdout);
+      // get the bundleLinter.js, to allow testing of it.
+      const srcBl = path.resolve(
+          __dirname,
+          "../../lib/package/bundleLinter.js",
+        ),
+        destBl = path.resolve(
+          tmpdir.name,
+          "node_modules/apigeelint/lib/package/bundleLinter.js",
+        );
+      fs.cpSync(srcBl, destBl, { force: true });
+      try {
+        const proc = child_process.spawn(
+          "node",
+          [
+            path.resolve(tmpdir.name, "node_modules/apigeelint/cli.js"),
+            ...cliOpts,
+          ],
+          { ...spawnOpts, timeout: 20000 },
+        );
+        let stdoutBlobs = [],
+          stderrBlobs = [];
+        proc.stdout.on("data", (data) => {
+          stdoutBlobs.push(data);
+          debug(`stdout: ${data}`);
+        });
+        proc.stderr.on("data", (data) => {
+          stderrBlobs.push(data);
+          debug(`stderr: ${data}`);
+        });
+        proc.on("exit", (exitCode) => debug(`exit: ${exitCode}`));
+        proc.on("error", (error) => console.error(`process error: ${error}`));
+        proc.on("close", (code) => {
+          let aggregatedStdout = stdoutBlobs.join("\n");
+          let aggregatedStderr = stderrBlobs.join("");
+          debug(`child process exited with code ${code}`);
+
+          if (code != 0) {
+            // Could examine this - with DEBUG=apigeelint:rc, you will see
+            // messages indicating parsing of the .apigeelintrc file.
+            debug(`agg stderr: ${aggregatedStderr}`);
+          }
+          debug(`agg stdout: ${aggregatedStdout}`);
+          // we should be able to parse stdout as json
+          let items = [];
+          try {
+            items = JSON.parse(aggregatedStdout);
+          } catch (eparse) {
+            console.log(`while parsing: ${aggregatedStdout}`);
+            console.log(eparse.stack);
+            assert.fail();
+          }
+          checkCb(code, items);
+        });
+      } catch (ex1) {
+        console.log(ex1.stack);
+        assert.fail();
+      }
+    });
+  };
+
+  it("should write the output file", function (done) {
+    this.timeout(158000);
+    if (debug.enabled) {
+      // this may not work on Windows
+      const r = child_process.spawnSync("which", ["node"], spawnOpts);
+      debug(`node: ` + JSON.stringify(r));
+    }
+    runOne(
+      [
+        "-s",
+        path.resolve(issue622Dir, "apiproxy"),
+        "--norc",
+        "--formatter",
+        "codeclimate.js",
+        "--profile",
+        "apigeex",
+        "--write",
+        "findings.out",
+      ],
+      (processExitCode, items) => {
+        assert.equal(processExitCode, 0, "return status code");
+        assert.equal(items.length, 0, "items");
+        const outputContent = fs.readFileSync(
+          path.resolve(tmpdir.name, "findings.out"),
+          {
+            encoding: "utf8",
+          },
+        );
+        assert.equal(outputContent, "[]", "output");
+        done();
+      },
+    );
+  });
+});


### PR DESCRIPTION
This addresses issue 622. 

I am not sure what changed to cause the difference; it could be the update to commander changed the timing of exit, or it could be a newer version of node that causes a timing issue.  

In any case converting to a synchronous file write avoids the timing issue. 

No need to change the README.md; this just corrects a bug in the existing, documented behavior. 