### PR TITLE
fix: invoke onStep for steps found in PostClientFlow

### DIFF
--- a/lib/package/Endpoint.js
+++ b/lib/package/Endpoint.js
@@ -310,6 +310,13 @@ class Endpoint extends ConfigElement {
         } else {
           debug("onSteps: no postflow");
         }
+        if (endpoint.getPostClientFlow()) {
+          endpoint
+            .getPostClientFlow()
+            .onSteps(pluginFunction, getcb("onSteps postClientFlow"));
+        } else {
+          debug("onSteps: no postClientFlow");
+        }
       }
       if (endpoint.getDefaultFaultRule()) {
         debug("onSteps: defaultFaultRule");

--- a/test/fixtures/resources/BN010-missing-policy/apiproxy/proxies/endpoint1.xml
+++ b/test/fixtures/resources/BN010-missing-policy/apiproxy/proxies/endpoint1.xml
@@ -36,9 +36,15 @@
     </Response>
   </PostFlow>
   <PostClientFlow name="PostClientFlow">
+    <!-- Request is not supported here.  Should be flagged by other plugin. Not
+         part of this test. -->
     <Request>
     </Request>
     <Response>
+      <Step>
+          <!-- This policy is missing; will be flagged by BN010. -->
+        <Name>AM-Missing-Policy-2</Name>
+      </Step>
     </Response>
   </PostClientFlow>
 
@@ -53,7 +59,7 @@
       </Request>
       <Response>
         <Step>
-          <!-- This policy is missing; expected to be flagged by BN010. -->
+          <!-- This policy is missing; will be flagged by BN010. -->
           <Name>AM-Response-1</Name>
         </Step>
       </Response>

--- a/test/specs/BN010-1.js
+++ b/test/specs/BN010-1.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2022,2025 Google LLC
+Copyright © 2019-2022,2025-2026 Google LLC
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -55,13 +55,12 @@ describe(`${testID} - bundle with reference to missing policy`, () => {
         (m) => m.ruleId == testID,
       );
 
-      assert.equal(bn010Messages.length, 1, diags);
+      assert.equal(bn010Messages.length, 2, diags);
       assert.ok(bn010Messages[0].message, diags);
-      assert.equal(
-        bn010Messages[0].message,
-        'Missing policy "AM-Response-1"',
-        bn010Messages[0].message,
-      );
+      ["AM-Response-1", "AM-Missing-Policy-2"].forEach((pname) => {
+        const expectedMsg = `Missing policy "${pname}"`;
+        assert.ok(bn010Messages.find((item) => item.message == expectedMsg));
+      });
     });
   });
 });


### PR DESCRIPTION
This corrects issue #621 .

The Endpoint.js was invoking `onStep` for all steps in FaultRules, DefaultFaultRule, PreFlow, PostFlow, and Conditional flows, but not for steps appearing in PostClientFlow.  This fixes that problem. 

This is a bug fix; no new documentation required. 