### PR TITLE
chore: add a .c8rc file to specify coverage report width

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -1,0 +1,8 @@
+{
+  "reporter": ["text"],
+  "reporterOptions": {
+    "text": {
+      "maxCols": 340
+    }
+  }
+}


### PR DESCRIPTION
Adds a config file for c8, the coverage tool, so that when redirecting the output of c8, the report is not truncated to 100 characters wide.  

No change in function of the tool.