### PR TITLE
chore: improve test coverage for TD005 plugin

### DIFF
--- a/lib/package/plugins/TD005-targetSslReferences.js
+++ b/lib/package/plugins/TD005-targetSslReferences.js
@@ -82,25 +82,27 @@ const onTargetEndpoint = function (endpoint, cb) {
         let keyStoreElt = elts && elts.length == 1 && elts[0];
         if (keyStoreElt) {
           let keyStoreName =
-            trustStoreElt.childNodes &&
-            elts[0].childNodes[0] &&
-            elts[0].childNodes[0].nodeValue;
+            keyStoreElt.childNodes &&
+            keyStoreElt.childNodes[0] &&
+            keyStoreElt.childNodes[0].nodeValue;
           if (keyStoreName && !keyStoreName.startsWith("ref://")) {
             endpoint.addMessage({
               plugin,
-              line: trustStoreElt.lineNumber,
-              column: trustStoreElt.columnNumber,
+              line: keyStoreElt.lineNumber,
+              column: keyStoreElt.columnNumber,
               message: "When using a KeyStore, use a reference",
             });
             flagged = true;
           }
         }
       }
+    /* c8 ignore start */
     } catch (exc1) {
       console.error("exception in TD005: " + exc1);
       debug(`onTargetEndpoint exc(${exc1})`);
       debug(`${exc1.stack}`);
     }
+    /* c8 ignore stop */
   }
 
   if (typeof cb == "function") {

--- a/test/specs/TD005-test.js
+++ b/test/specs/TD005-test.js
@@ -107,6 +107,43 @@ describe(`${testID} - ${plugin.plugin.name}`, function () {
   );
 
   test(
+    30,
+    "Multiple TrustStore elements",
+    `<TargetEndpoint name="default">
+    <HTTPTargetConnection>
+      <SSLInfo>
+        <Enabled>true</Enabled>
+        <TrustStore>ref://truststore1</TrustStore>
+        <TrustStore>ref://truststore2</TrustStore>
+      </SSLInfo>
+      <URL>https://foo.com/apis/{api_name}/maskconfigs</URL>
+      <Properties/>
+    </HTTPTargetConnection>
+  </TargetEndpoint>`,
+    ["Incorrect multiple TrustStore elements"],
+  );
+
+  test(
+    40,
+    "Multiple KeyStore elements",
+    `<TargetEndpoint name="default">
+    <HTTPTargetConnection>
+      <SSLInfo>
+        <Enabled>true</Enabled>
+        <ClientAuthEnabled>true</ClientAuthEnabled>
+        <TrustStore>ref://truststore1</TrustStore>
+        <KeyStore>ref://keystore1</KeyStore>
+        <KeyStore>ref://keystore2</KeyStore>
+        <KeyAlias>key1</KeyAlias>
+      </SSLInfo>
+      <URL>https://foo.com/apis/{api_name}/maskconfigs</URL>
+      <Properties/>
+    </HTTPTargetConnection>
+  </TargetEndpoint>`,
+    ["Incorrect multiple KeyStore elements"],
+  );
+
+  test(
     21,
     "SSLInfo KeyStore ref",
     `<TargetEndpoint name="default">


### PR DESCRIPTION
improve test coverage for TD005 plugin, and correct a logic error (keystore vs truststore).