### PR TITLE
chore: add line number and file path to testcase element in junit

### DIFF
--- a/lib/package/third_party/formatters/junit.js
+++ b/lib/package/third_party/formatters/junit.js
@@ -46,7 +46,17 @@ module.exports = function(results) {
         messages.forEach(message => {
             const type = message.fatal ? "error" : "failure";
 
-            output += `<testcase time="0" name="org.eslint.${message.ruleId || "unknown"}">`;
+            // The start of the <testcase> element
+            output += `<testcase time="0" name="org.eslint.${message.ruleId || "unknown"}"`;
+
+            output += ` file="${result.filePath}"`;
+
+            // Add a line number
+            output += ` line="${message.line || 0}"`;
+
+            // The end of the <testcase> element
+            output += `>`;
+
             output += `<${type} message="${xmlEscape(message.message || "")}">`;
             output += "<![CDATA[";
             output += `line ${message.line || 0}, col `;


### PR DESCRIPTION
Reasoning: While junit doesn't have an explicit schema, attributes like file and line are generally recognized for the testcase, and these attributes are useful for CI pipelines

This pull request extends the JUnit formatter output in `junit.js` by adding more detailed information to each `<testcase>` element. The main enhancement is the inclusion of the file path and line number for each reported issue, making it easier to trace problems directly from the test report.

JUnit formatter enhancements:

* Added the `file` attribute to each `<testcase>` element, specifying the originating file path for the issue.
* Added the `line` attribute to each `<testcase>` element, indicating the line number where the issue occurred.