### PR TITLE
fix: handle NotBefore in GenerateJwt

### DIFF
--- a/lib/package/plugins/PO044-jwt-hygiene.js
+++ b/lib/package/plugins/PO044-jwt-hygiene.js
@@ -39,6 +39,7 @@ const allowedChildren = {
   Subject: [],
   Issuer: [],
   Id: [],
+  NotBefore: [],
   Audience: [],
   ExpiresIn: [],
   AdditionalClaims: ["Claim"],

--- a/test/fixtures/resources/PO044/pass/GenerateJWT-with-NotBefore.xml
+++ b/test/fixtures/resources/PO044/pass/GenerateJWT-with-NotBefore.xml
@@ -1,0 +1,14 @@
+<GenerateJWT name='GenerateJWT-with-NotBefore'>
+  <Algorithm>HS256</Algorithm>
+  <IgnoreUnresolvedVariables>false</IgnoreUnresolvedVariables>
+  <SecretKey>
+    <Value ref='private.secretkey'/>
+    <Id ref='key-id'/>
+  </SecretKey>
+  <Subject ref='my-subject'/>
+  <Issuer ref='variable-with-name-of-issuer'/>
+  <Audience>audience-here</Audience>
+  <ExpiresIn>30m</ExpiresIn>
+  <NotBefore>20m</NotBefore>
+  <OutputVariable>output_variable_name</OutputVariable>
+</GenerateJWT>


### PR DESCRIPTION
Missed a supported child element - NotBefore. This fixes #683  